### PR TITLE
Add finished and worker queue for job queue

### DIFF
--- a/scoring_engine/finished_queue.py
+++ b/scoring_engine/finished_queue.py
@@ -1,0 +1,7 @@
+from job_queue import JobQueue
+
+
+class FinishedQueue(JobQueue):
+    def __init__(self):
+        super(FinishedQueue, self).__init__()
+        self.queue_name = "finished"

--- a/scoring_engine/job_queue.py
+++ b/scoring_engine/job_queue.py
@@ -1,0 +1,39 @@
+import redis
+import json
+
+from config import Config
+from job import Job
+from malformed_job import MalformedJob
+
+
+class JobQueue(object):
+    def __init__(self):
+        config = Config()
+        self.queue_name = config.redis_queue_name
+        self.conn = redis.Redis(host=config.redis_host, port=config.redis_port, password=config.redis_password)
+        self.namespace = config.redis_namespace
+        # This is meant to get overwritten by children
+        self.queue_name = "jobs"
+
+    @property
+    def queue_key(self):
+        return self.namespace + ':' + self.queue_name
+
+    def size(self):
+        return int(self.conn.llen(self.queue_key))
+
+    def clear(self):
+        while self.size() > 0:
+            self.get_job()
+
+    def add_job(self, job):
+        if not isinstance(job, Job):
+            raise MalformedJob()
+        return self.conn.rpush(self.queue_key, json.dumps(job.to_dict()))
+
+    def get_job(self):
+        binary_job = self.conn.lpop(self.queue_key)
+        if binary_job is None:
+            return None
+        encoded_job = binary_job.decode("utf-8")
+        return Job.from_dict(json.loads(encoded_job))

--- a/scoring_engine/malformed_job.py
+++ b/scoring_engine/malformed_job.py
@@ -1,0 +1,4 @@
+class MalformedJob(Exception):
+    def __str__(self):
+        return "Job must be of instance of Job class"
+

--- a/scoring_engine/worker_queue.py
+++ b/scoring_engine/worker_queue.py
@@ -1,42 +1,7 @@
-import redis
-import json
-
-from config import Config
-from job import Job
+from job_queue import JobQueue
 
 
-class MalformedJob(Exception):
-    def __str__(self):
-        return "Job must be of instance of Job class"
-
-
-class WorkerQueue(object):
-
+class WorkerQueue(JobQueue):
     def __init__(self):
-        config = Config()
-        self.queue_name = config.redis_queue_name
-        self.conn = redis.Redis(host=config.redis_host, port=config.redis_port, password=config.redis_password)
-        self.namespace = config.redis_namespace
-
-    @property
-    def queue_key(self):
-        return self.namespace + ':' + self.queue_name
-
-    def size(self):
-        return int(self.conn.llen(self.queue_key))
-
-    def clear(self):
-        while self.size() > 0:
-            self.get_job()
-
-    def add_job(self, job):
-        if not isinstance(job, Job):
-            raise MalformedJob()
-        return self.conn.rpush(self.queue_key, json.dumps(job.to_dict()))
-
-    def get_job(self):
-        binary_job = self.conn.lpop(self.queue_key)
-        if binary_job is None:
-            return None
-        encoded_job = binary_job.decode("utf-8")
-        return Job.from_dict(json.loads(encoded_job))
+        super(WorkerQueue, self).__init__()
+        self.queue_name = "queued"

--- a/tests/scoring_engine/test_finished_queue.py
+++ b/tests/scoring_engine/test_finished_queue.py
@@ -2,14 +2,14 @@ import sys
 import os
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../scoring_engine'))
 
-from worker_queue import WorkerQueue
+from finished_queue import FinishedQueue
 from job_queue import JobQueue
 
 
-class TestWorkerQueue(object):
+class TestFinishedQueue(object):
 
     def test_init(self):
-        queue = WorkerQueue()
+        queue = FinishedQueue()
         assert isinstance(queue, JobQueue) is True
-        assert queue.queue_name == "queued"
-        assert queue.queue_key == "scoring_engine:queued"
+        assert queue.queue_name == "finished"
+        assert queue.queue_key == "scoring_engine:finished"

--- a/tests/scoring_engine/test_job_queue.py
+++ b/tests/scoring_engine/test_job_queue.py
@@ -1,0 +1,69 @@
+import pytest
+
+from redis import Redis
+
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../scoring_engine'))
+
+from job_queue import JobQueue
+from malformed_job import MalformedJob
+from job import Job
+
+
+class TestJobQueue(object):
+
+    def compare_jobs(self, src_job, dst_job):
+        assert isinstance(src_job, Job)
+        assert isinstance(dst_job, Job)
+        assert src_job.service_id == dst_job.service_id
+        assert src_job.command == dst_job.command
+        assert src_job.output == dst_job.output
+
+    def setup(self):
+        self.queue = JobQueue()
+        self.queue.clear()
+
+    def test_init(self):
+        assert isinstance(self.queue.conn, Redis) is True
+        assert self.queue.queue_name == "jobs"
+        assert self.queue.namespace == "scoring_engine"
+        assert self.queue.queue_key == "scoring_engine:jobs"
+        assert self.queue.size() == 0
+
+    def test_clear(self):
+        job = Job(service_id="102938", command="ls -l")
+        self.queue.add_job(job)
+        assert self.queue.size() == 1
+        self.queue.clear()
+        assert self.queue.size() == 0
+
+    def test_get_job_without_jobs(self):
+        found_job = self.queue.get_job()
+        assert found_job is None
+
+    def test_add_job_not_job_class(self):
+        with pytest.raises(MalformedJob):
+            malformed_job = {"exkey": "exvalue"}
+            self.queue.add_job(malformed_job)
+
+    def test_add_job(self):
+        job = Job(service_id="12345", command="ls -l")
+        self.queue.add_job(job)
+        assert self.queue.size() == 1
+        found_job = self.queue.get_job()
+        self.compare_jobs(found_job, job)
+        assert self.queue.size() == 0
+
+    def test_adding_multiple_jobs(self):
+        job_1 = Job(service_id="12345", command="ping -c 127.0.0.1")
+        job_2 = Job(service_id="54321", command="ping -c 127.0.0.1")
+        self.queue.add_job(job_1)
+        self.queue.add_job(job_2)
+        assert self.queue.size() == 2
+        found_job_1 = self.queue.get_job()
+        assert self.queue.size() == 1
+        found_job_2 = self.queue.get_job()
+        self.compare_jobs(found_job_1, job_1)
+        self.compare_jobs(found_job_2, job_2)
+        assert self.queue.size() == 0


### PR DESCRIPTION
The idea here is that we will have a queue for unfinished jobs (WorkerQueue), where we store jobs that we need a worker to pluck and run with, in addition to a FinishedQueue, where we store jobs that are completed and are awaiting the engine from consuming.
Signed-off-by: Brandon Myers bmyers@mozilla.com
