### PR TITLE
Memoize example

### DIFF
--- a/scoring_engine/models/account.py
+++ b/scoring_engine/models/account.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, ForeignKey, Text, String
 from sqlalchemy.orm import relationship
 
-from scoring_engine.models.base import Base
+from scoring_engine.models.base import Base, Group
 
 
 class Account(Base):
@@ -11,3 +11,8 @@ class Account(Base):
     password = Column(Text, nullable=False)
     service_id = Column(Integer, ForeignKey('services.id'))
     service = relationship("Service")
+
+    @cache.memoize(50)
+    def get_id(self, account_id):
+        return Group.query.filter_by(user=self, id=account_id)
+

--- a/scoring_engine/web/views/api.py
+++ b/scoring_engine/web/views/api.py
@@ -32,7 +32,7 @@ mod = Blueprint('api', __name__)
 def update_service_account_info():
     if current_user.is_white_team or current_user.is_blue_team:
         if 'name' in request.form and 'value' in request.form and 'pk' in request.form:
-            account = session.query(Account).get(int(request.form['pk']))
+            account = session.query(Account).get_id(int(request.form['pk']))
             if current_user.team == account.service.team or current_user.is_white_team:
                 if account:
                     if request.form['name'] == 'username':


### PR DESCRIPTION
This is what I mean - you want to cache your models within the DB. The ID of the account isn't changing, so you add the functionality to the model to be able to query the specific input you want. It's kind of a pain, but it looks nicer and is easier to extend than having your SQLALchemy queries embedded in your views. 

Memoize works by caching a function that's called with the same arguments - so if you're consistently calling a function on the same account id - it'll cache that. 