### PR TITLE
Explicitly define network in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     restart: on-failure
     volumes:
       - redis:/data
+    networks:
+      - default
     # ports:
     #   - 6379:6379
   mysql:
@@ -23,6 +25,8 @@ services:
     restart: on-failure
     volumes:
       - mysql:/var/lib/mysql
+    networks:
+      - default
     # ports:
     #   - 3306:3306
   nginx:
@@ -32,13 +36,15 @@ services:
     depends_on:
       - flask
     ports:
-      - "80:80"
+      - 80:80
     healthcheck:
       test: ["CMD", "curl", "-f", "localhost"]
       interval: 30s
       timeout: 3s
       retries: 10
     restart: on-failure
+    networks:
+      - default
   base:
     build:
       context: .
@@ -54,6 +60,8 @@ services:
     healthcheck:
       test: ["CMD", "exit", "1"]
     restart: on-failure
+    networks:
+      - default
     environment:
       - EXAMPLE
       - OVERWRITE_DB
@@ -66,6 +74,8 @@ services:
       - redis
       - bootstrap
     restart: on-failure
+    networks:
+      - default
     environment:
       - EXAMPLE
   worker:
@@ -76,6 +86,8 @@ services:
       - base
       - redis
     restart: on-failure
+    networks:
+      - default
     environment:
       - EXAMPLE
   flask:
@@ -91,7 +103,12 @@ services:
       timeout: 3s
       retries: 10
     restart: on-failure
+    networks:
+      - default
 
 volumes:
   redis:
   mysql:
+
+networks:
+  default:

--- a/docker/testbed/docker-compose.yml
+++ b/docker/testbed/docker-compose.yml
@@ -5,10 +5,14 @@ services:
     build:
       context: .
       dockerfile: ./docker/testbed/icmp/Dockerfile
+    networks:
+      - default
   testbed_web:
     build:
       context: .
       dockerfile: ./docker/testbed/web/Dockerfile
+    networks:
+      - default
     # ports:
     #   - 80:80
     #   - 443:443
@@ -16,6 +20,8 @@ services:
     build:
       context: .
       dockerfile: ./docker/testbed/ssh/Dockerfile
+    networks:
+      - default
     # ports:
     #   - 22:22
   testbed_mysql:
@@ -25,6 +31,8 @@ services:
       - MYSQL_DATABASE=randomdb
       - MYSQL_USER=user1
       - MYSQL_PASSWORD=CHANGEME
+    networks:
+      - default
     # ports:
     #   - 3306:3306
   testbed_mssql:
@@ -32,24 +40,32 @@ services:
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=yourStrong(!)Password
+    networks:
+      - default
     # ports:
     #   - 1433:1433
   testbed_ftp:
     build:
       context: .
       dockerfile: ./docker/testbed/ftp/Dockerfile
+    networks:
+      - default
     # ports:
     #   - 21:21
   testbed_elasticsearch:
     build:
       context: .
       dockerfile: ./docker/testbed/elasticsearch/Dockerfile
+    networks:
+      - default
     # ports:
     #   - 9200:9200
   testbed_smb:
     build:
       context: .
       dockerfile: ./docker/testbed/smb/Dockerfile
+    networks:
+      - default
     # ports:
       # - 139:139
       # - 445:445
@@ -57,6 +73,11 @@ services:
     build:
       context: .
       dockerfile: ./docker/testbed/dns/Dockerfile
+    networks:
+      - default
     # ports:
       # - 53:53/udp
       # - 53:53
+
+networks:
+  default:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3'
 services:
   redis:
     image: "redis:latest"
+    networks:
+      - default
   base:
     build:
       context: ../
@@ -14,3 +16,8 @@ services:
       dockerfile: ./docker/tester/Dockerfile
     depends_on:
       - base
+    networks:
+      - default
+
+networks:
+  default:

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - redis
       - bootstrap
     restart: "no"
+    networks:
+      - default
     environment:
       - ENGINE_NUM_ROUNDS=10
   base:
@@ -27,3 +29,8 @@ services:
       dockerfile: ./docker/tester/Dockerfile
     depends_on:
       - base
+    networks:
+      - default
+
+networks:
+  default:


### PR DESCRIPTION
This makes it possible to extend/override, and to add other containers to the same network.