### PR TITLE
Update travisci file to not submit code coverage with forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,15 @@ script:
   - ./tests/integration/run.sh
 after_script:
   # Push results to code climate
-  - docker run -it
-      -v artifacts:/app/artifacts
-      -e GIT_BRANCH=$TRAVIS_BRANCH
-      -e GIT_COMMIT_SHA=$TRAVIS_COMMIT
-      -e GIT_COMMITTED_AT=$(git log -1 --pretty=tformat:%ct $TRAVIS_COMMIT)
-      -e CC_TEST_REPORTER_ID=$CC_TEST_REPORTER_ID
-      scoringengine_tester bash -c
-    "cp artifacts/coverage.xml ./ && /usr/bin/cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
+  # only if a non PR and branch is master
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+      docker run -it
+        -v artifacts:/app/artifacts
+        -e GIT_BRANCH=$TRAVIS_BRANCH
+        -e GIT_COMMIT_SHA=$TRAVIS_COMMIT
+        -e GIT_COMMITTED_AT=$(git log -1 --pretty=tformat:%ct $TRAVIS_COMMIT)
+        -e CC_TEST_REPORTER_ID=$CC_TEST_REPORTER_ID
+        scoringengine_tester bash -c
+      "cp artifacts/coverage.xml ./ && /usr/bin/cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
+    fi


### PR DESCRIPTION
When a PR is submitted originating from a fork, the last code coverage command fails because the environment variables aren't set for the fork repo in travis. This restricts that command to run only if it's not a PR, and the branch is master.