### PR TITLE
Add worker queue config

### DIFF
--- a/bin/worker
+++ b/bin/worker
@@ -25,5 +25,7 @@ celery_args = [
 if config.worker_num_concurrent_tasks != -1:
     celery_args.append('--concurrency={0}'.format(config.worker_num_concurrent_tasks))
 
-logger.info("Starting Worker v.{0}".format(version))
+celery_args.append('--queues={0}'.format(config.worker_queue))
+
+logger.info("Starting Worker v.{0} monitoring '{1}' queue".format(version, config.worker_queue))
 celery_app.start(argv=celery_args)

--- a/docker/engine.conf.inc
+++ b/docker/engine.conf.inc
@@ -12,6 +12,11 @@ db_uri = mysql://se_user:CHANGEME@mysql/scoring_engine?charset=utf8mb4
 # else, set to number of concurrent tasks
 worker_num_concurrent_tasks = -1
 
+# default to main
+# but this allows you to have some workers
+# running certain work but not others
+worker_queue = main
+
 # Set to null to disable caching
 cache_type = redis
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -36,14 +36,16 @@ Configuration Keys
      - Amount of time (seconds) the engine sleeps between rounds
    * - worker_refresh_time
      - Amount of time (seconds) the engine will sleep for in-between polls of worker status
+   * - worker_num_concurrent_tasks
+     - The number of concurrent tasks the worker will run. Set to -1 to default to number of processors.
+   * - worker_queue
+     - The queue name for a worker to pull tasks from. This can be used to control which workers get which service checks. Default is 'main'
    * - timezone
      - Local timezone of the competition
    * - debug
      - Determines wether or not the engine should be run in debug mode (useful for development)
    * - db_uri
      - Database connection URI
-   * - worker_num_concurrent_tasks
-     - The number of concurrent tasks the worker will run. Set to -1 to default to number of processors.
    * - cache_type
      - The type of storage for the cache. Set to null to disable caching
    * - redis_host

--- a/engine.conf.inc
+++ b/engine.conf.inc
@@ -17,6 +17,11 @@ db_uri = sqlite:////tmp/engine.db
 # else, set to number of concurrent tasks
 worker_num_concurrent_tasks = -1
 
+# default to main
+# but this allows you to have some workers
+# running certain work but not others
+worker_queue = main
+
 # Set to null to disable caching
 cache_type = redis
 

--- a/scoring_engine/competition.py
+++ b/scoring_engine/competition.py
@@ -89,6 +89,10 @@ class Competition(dict):
         assert 'host' in service, "{0} {1} service must have a 'host' field".format(team_name, service['name'])
         assert type(service['host']) is str, "{0} {1} service 'host' field must be a string".format(team_name, service['name'])
 
+        # Verify service worker_queue if it exists
+        if 'worker_queue' in service:
+            assert type(service['worker_queue']) is str, "{0} {1} service 'worker_queue' field must be a string".format(team_name, service['name'])
+
         # Verify service port
         assert 'port' in service, "{0} {1} service must have a 'port' field".format(team_name, service['name'])
         assert type(service['port']) is int, "{0} {1} service 'port' field must be an integer".format(team_name, service['name'])
@@ -164,6 +168,8 @@ class Competition(dict):
                         port=service_dict['port'],
                         points=service_dict['points']
                     )
+                    if 'worker_queue' in service_dict:
+                        service_obj.worker_queue = service_dict['worker_queue']
                     db_session.add(service_obj)
                     if 'accounts' in service_dict:
                         for account_dict in service_dict['accounts']:

--- a/scoring_engine/config_loader.py
+++ b/scoring_engine/config_loader.py
@@ -33,6 +33,17 @@ class ConfigLoader(object):
             'int'
         )
 
+        self.worker_num_concurrent_tasks = self.parse_sources(
+            'worker_num_concurrent_tasks',
+            int(self.parser['OPTIONS']['worker_num_concurrent_tasks']),
+            'int'
+        )
+
+        self.worker_queue = self.parse_sources(
+            'worker_queue',
+            self.parser['OPTIONS']['worker_queue'],
+        )
+
         self.timezone = self.parse_sources(
             'timezone',
             self.parser['OPTIONS']['timezone']
@@ -62,12 +73,6 @@ class ConfigLoader(object):
         self.redis_password = self.parse_sources(
             'redis_password',
             self.parser['OPTIONS']['redis_password']
-        )
-
-        self.worker_num_concurrent_tasks = self.parse_sources(
-            'worker_num_concurrent_tasks',
-            int(self.parser['OPTIONS']['worker_num_concurrent_tasks']),
-            'int'
         )
 
     def parse_sources(self, key_name, default_value, obj_type='str'):

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -142,7 +142,7 @@ class Engine(object):
                 check_obj = check_class(environment)
                 command_str = check_obj.command()
                 job = Job(environment_id=environment.id, command=command_str)
-                task = execute_command.delay(job)
+                task = execute_command.apply_async(args=[job], queue=service.worker_queue)
                 team_name = environment.service.team.name
                 if team_name not in task_ids:
                     task_ids[team_name] = []

--- a/scoring_engine/models/service.py
+++ b/scoring_engine/models/service.py
@@ -18,6 +18,7 @@ class Service(Base):
     environments = relationship('Environment', back_populates="service")
     host = Column(String(50), nullable=False)
     port = Column(Integer, default=0)
+    worker_queue = Column(String(50), default="main")
 
     def check_result_for_round(self, round_num):
         for check in self.checks:

--- a/tests/integration/engine.conf.inc
+++ b/tests/integration/engine.conf.inc
@@ -8,9 +8,8 @@ debug = False
 
 db_uri = mysql://se_user:CHANGEME@mysql/scoring_engine?charset=utf8mb4
 
-# Set to -1 to use default number of processors for tasks
-# else, set to number of concurrent tasks
 worker_num_concurrent_tasks = -1
+worker_queue = main
 
 # Set to null to disable caching
 cache_type = redis

--- a/tests/scoring_engine/engine.conf.inc
+++ b/tests/scoring_engine/engine.conf.inc
@@ -9,9 +9,8 @@ debug = False
 # SQLite
 db_uri = sqlite:////tmp/test_engine.db
 
-# Set to -1 to use default number of processors for tasks
-# else, set to number of concurrent tasks
 worker_num_concurrent_tasks = 4
+worker_queue = main
 
 # Set to null to disable caching
 cache_type = null

--- a/tests/scoring_engine/models/test_service.py
+++ b/tests/scoring_engine/models/test_service.py
@@ -32,6 +32,21 @@ class TestService(UnitTest):
         assert service.check_name == "ICMP IPv4 Check"
         assert service.port == 0
         assert service.points == 100
+        assert service.worker_queue == 'main'
+
+    def test_basic_service_with_worker_queue(self):
+        team = generate_sample_model_tree('Team', self.session)
+        service = Service(name="Example Service", team=team, check_name="ICMP IPv4 Check", host='127.0.0.1', worker_queue='somequeue')
+        self.session.add(service)
+        self.session.commit()
+        assert service.id is not None
+        assert service.name == "Example Service"
+        assert service.team == team
+        assert service.team_id == team.id
+        assert service.check_name == "ICMP IPv4 Check"
+        assert service.port == 0
+        assert service.points == 100
+        assert service.worker_queue == 'somequeue'
 
     def test_basic_service_with_points(self):
         team = generate_sample_model_tree('Team', self.session)

--- a/tests/scoring_engine/test_competition.py
+++ b/tests/scoring_engine/test_competition.py
@@ -232,6 +232,10 @@ class TestServiceData(CompetitionDataTest):
         self.setup['teams'][0]['services'][0]['environments'] = 'a string'
         self.verify_error("Team1 SSH service 'environments' field must be an array")
 
+    def test_bad_worker_queue(self):
+        self.setup['teams'][0]['services'][0]['worker_queue'] = []
+        self.verify_error("Team1 SSH service 'worker_queue' field must be a string")
+
 
 class TestAccountData(CompetitionDataTest):
     def test_no_username(self):

--- a/tests/scoring_engine/test_config_loader.py
+++ b/tests/scoring_engine/test_config_loader.py
@@ -47,6 +47,9 @@ class TestConfigLoader(object):
     def test_worker_num_concurrent_tasks(self):
         assert self.config.worker_num_concurrent_tasks == 4
 
+    def test_worker_queue(self):
+        assert self.config.worker_queue == 'main'
+
     def test_parse_sources_int_environment(self):
         os.environ["SCORINGENGINE_ROUND_SLEEP_TIME"] = '1'
         assert self.config.parse_sources('round_sleep_time', '1234', 'int') == 1


### PR DESCRIPTION
https://github.com/scoringengine/scoringengine/issues/514

This allows competitions to have workers spun up that live internally to a team's network, and will only be tasked with only checking certain services on team1.