### PR TITLE
Fix to install LDAP and VNC dependencies

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -15,6 +15,12 @@ RUN apt-get install -y curl
 # MySQL Check
 RUN apt-get install -y mysql-client
 
+# LDAP Check
+RUN apt-get install -y ldap-utils
+
+# VNC Check
+RUN apt-get install -y medusa
+
 # SSH Check
 RUN pip install -I "cryptography>=2.4,<2.5"
 RUN pip install "paramiko>=2.4,<2.5"


### PR DESCRIPTION
The Worker Dockerfile was not currently installing ldap-utils (required for the ldapsearch command used in the LDAP check) and medusa which is used for the VNC check.