### PR TITLE
Allow config debug to toggle check output from worker

### DIFF
--- a/bin/worker
+++ b/bin/worker
@@ -14,11 +14,15 @@ if 'SCORINGENGINE_EXAMPLE' in os.environ and os.environ['SCORINGENGINE_EXAMPLE']
     print("SCORINGENGINE_EXAMPLE environment variable is true, so skipping running the worker.")
     sys.exit(0)
 
+celery_log_level = "error"
+if config.debug is True:
+  celery_log_level = "info"
+
 workdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scoring_engine/engine')
 celery_args = [
     'celery',
     '--workdir={0}'.format(workdir),
-    '--loglevel=info',
+    '--loglevel={0}'.format(celery_log_level),
     'worker',
 ]
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -43,7 +43,7 @@ Configuration Keys
    * - timezone
      - Local timezone of the competition
    * - debug
-     - Determines wether or not the engine should be run in debug mode (useful for development)
+     - Determines wether or not the engine should be run in debug mode (useful for development). The worker will also display output from all checks.
    * - db_uri
      - Database connection URI
    * - cache_type

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -15,7 +15,7 @@ Create Config File
   cp engine.conf.inc engine.conf
   sed -i '' 's/debug = False/debug = True/g' engine.conf
 
-.. hint:: If debug is set to True, the web ui will automatically reload on changes to local file modifications, which can help speed up development.
+.. hint:: If debug is set to True, the web ui will automatically reload on changes to local file modifications, which can help speed up development. This config setting will also tell the worker to output all check output to stdout.
 
 Install Required Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Each worker docker container log would be populated with the stdout of each check command ran, which could be useful for debugging, but not in "production".

This PR allows the config.debug config key to control this behavior.

By default (config.debug is False), we still output this from the worker:
```
2019-02-20 17:39:38,128 [INFO] Running cmd for {'environment_id': 10, 'command': "/app/scoring_engine/engine/../checks/bin/ftp_check 'testbed_ftp' 21 'ttesterson' 'testpass' '/ftp_files/testfile.txt' 'Sample file contents'"}
```