### PR TITLE
Modify worker to requeue jobs if worker is killed

### DIFF
--- a/scoring_engine/engine/execute_command.py
+++ b/scoring_engine/engine/execute_command.py
@@ -5,7 +5,7 @@ import subprocess
 from scoring_engine.logger import logger
 
 
-@celery_app.task(name='execute_command', soft_time_limit=30)
+@celery_app.task(name='execute_command', acks_late=True, reject_on_worker_lost=True, soft_time_limit=30)
 def execute_command(job):
     output = ""
     # Disable duplicate celery log messages


### PR DESCRIPTION
From http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_reject_on_worker_lost and http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-acks-late