### PR TITLE
Speed up builds during development

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -17,7 +17,6 @@ COPY docker/wait-for-container.sh /app/wait-for-container.sh
 COPY docker/wait-for-port.sh /app/wait-for-port.sh
 COPY setup.py /app/setup.py
 COPY docker/engine.conf.inc /app/engine.conf
-COPY scoring_engine /app/scoring_engine
 
 WORKDIR /app
 
@@ -32,4 +31,13 @@ USER engine
 # Automatically source into python virtual environment
 ENV PATH=/venv/bin:$PATH
 
-RUN pip install -e .
+# Copy over files required for setup.py
+COPY scoring_engine/__init__.py /app/scoring_engine/__init__.py
+COPY scoring_engine/version.py /app/scoring_engine/version.py
+COPY scoring_engine/config.py /app/scoring_engine/config.py
+COPY scoring_engine/config_loader.py /app/scoring_engine/config_loader.py
+
+# Only install dependencies, don't install scoring engine
+# Credit goes to https://stackoverflow.com/a/53251585
+RUN python setup.py egg_info
+RUN pip install -r *.egg-info/requires.txt

--- a/docker/bootstrap/Dockerfile
+++ b/docker/bootstrap/Dockerfile
@@ -3,4 +3,7 @@ FROM scoringengine/base
 COPY bin/setup /app/bin/setup
 COPY bin/competition.yaml /app/bin/competition.yaml
 
+COPY scoring_engine /app/scoring_engine
+RUN pip install -e .
+
 CMD ["./wait-for-port.sh", "mysql:3306", "python", "/app/bin/setup"]

--- a/docker/engine/Dockerfile
+++ b/docker/engine/Dockerfile
@@ -2,4 +2,7 @@ FROM scoringengine/base
 
 COPY bin/engine /app/bin/engine
 
+COPY scoring_engine /app/scoring_engine
+RUN pip install -e .
+
 CMD ["./wait-for-container.sh", "bootstrap", "/app/bin/engine"]

--- a/docker/tester/Dockerfile
+++ b/docker/tester/Dockerfile
@@ -1,7 +1,5 @@
 FROM scoringengine/base
 
-COPY tests /app/tests
-
 USER root
 
 RUN \
@@ -21,5 +19,8 @@ RUN \
 
 USER engine
 
+COPY scoring_engine /app/scoring_engine
+RUN pip install -e .
+COPY tests /app/tests
 RUN pip install -r /app/tests/requirements.txt
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -12,6 +12,9 @@ USER engine
 
 COPY bin/web /app/bin/web
 
+COPY scoring_engine /app/scoring_engine
+RUN pip install -e .
+
 CMD ["./wait-for-container.sh", "bootstrap", "/app/bin/web"]
 
 EXPOSE 5000

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -72,4 +72,7 @@ COPY docker/worker/sudoers /etc/sudoers
 
 USER engine
 
+COPY scoring_engine /app/scoring_engine
+RUN pip install -e .
+
 CMD ["./wait-for-port.sh", "redis:6379", "/app/bin/worker"]


### PR DESCRIPTION
Currently the `scoring_engine` directory is copied over in the build of the base container. This causes builds during development to take a long time. This change will copy over the directory as the last possible step in each of the child containers. While it does duplicate a few commands across multiple dockerfiles, builds are quite a bit faster.