### PR TITLE
Implement WinRM check

### DIFF
--- a/bin/competition.yaml
+++ b/bin/competition.yaml
@@ -256,6 +256,19 @@ teams:
         value: A scoring engine test subject!
       - name: body
         value: This is the body of the email
+  # - name: WinRM
+  #   check_name: WinRMCheck
+  #   host: testbed_winrm
+  #   port: 0
+  #   points: 100
+  #   accounts:
+  #   - username: tttesterson
+  #     password: testpass
+  #  environments:
+  #   - matching_content: "^SUCCESS"
+  #     properties:
+  #     - name: commands
+  #       value: ipconfig /all;whoami
   # - name: Wordpress
   #   check_name: WordpressCheck
   #   host: testbed_wordpress
@@ -644,6 +657,19 @@ teams:
         value: A scoring engine test subject!
       - name: body
         value: This is the body of the email
+  # - name: WinRM
+  #   check_name: WinRMCheck
+  #   host: testbed_winrm
+  #   port: 0
+  #   points: 100
+  #   accounts:
+  #   - username: tttesterson
+  #     password: testpass
+  #  environments:
+  #   - matching_content: "^SUCCESS"
+  #     properties:
+  #     - name: commands
+  #       value: ipconfig /all;whoami
   # - name: Wordpress
   #   check_name: WordpressCheck
   #   host: testbed_wordpress
@@ -1032,6 +1058,19 @@ teams:
         value: A scoring engine test subject!
       - name: body
         value: This is the body of the email
+  # - name: WinRM
+  #   check_name: WinRMCheck
+  #   host: testbed_winrm
+  #   port: 0
+  #   points: 100
+  #   accounts:
+  #   - username: tttesterson
+  #     password: testpass
+  #  environments:
+  #   - matching_content: "^SUCCESS"
+  #     properties:
+  #     - name: commands
+  #       value: ipconfig /all;whoami
   # - name: Wordpress
   #   check_name: WordpressCheck
   #   host: testbed_wordpress
@@ -1420,6 +1459,19 @@ teams:
         value: A scoring engine test subject!
       - name: body
         value: This is the body of the email
+  # - name: WinRM
+  #   check_name: WinRMCheck
+  #   host: testbed_winrm
+  #   port: 0
+  #   points: 100
+  #   accounts:
+  #   - username: tttesterson
+  #     password: testpass
+  #  environments:
+  #   - matching_content: "^SUCCESS"
+  #     properties:
+  #     - name: commands
+  #       value: ipconfig /all;whoami
   # - name: Wordpress
   #   check_name: WordpressCheck
   #   host: testbed_wordpress
@@ -1808,6 +1860,19 @@ teams:
         value: A scoring engine test subject!
       - name: body
         value: This is the body of the email
+  # - name: WinRM
+  #   check_name: WinRMCheck
+  #   host: testbed_winrm
+  #   port: 0
+  #   points: 100
+  #   accounts:
+  #   - username: tttesterson
+  #     password: testpass
+  #  environments:
+  #   - matching_content: "^SUCCESS"
+  #     properties:
+  #     - name: commands
+  #       value: ipconfig /all;whoami
   # - name: Wordpress
   #   check_name: WordpressCheck
   #   host: testbed_wordpress

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -25,6 +25,9 @@ RUN apt-get install -y medusa
 RUN pip install -I "cryptography>=2.4,<2.5"
 RUN pip install "paramiko>=2.4,<2.5"
 
+# WinRM Check
+RUN pip install -I "pywinrm>=0.4.1,<0.4.2"
+
 # Elasticsearch Check
 RUN pip install -I "requests>=2.21,<2.22"
 

--- a/docs/source/checks.rst
+++ b/docs/source/checks.rst
@@ -18,3 +18,4 @@ Implemented Checks
 .. include:: checks/smtp.rst
 .. include:: checks/ssh.rst
 .. include:: checks/vnc.rst
+.. include:: checks/winrm.rst

--- a/docs/source/checks/winrm.rst
+++ b/docs/source/checks/winrm.rst
@@ -1,0 +1,13 @@
+WinRM
+^^^
+Logs into a system using WinRM with an account/password, and executes command(s)
+
+`Uses Accounts`
+
+Custom Properties:
+
+.. list-table::
+   :widths: 25 50
+
+   * - commands
+     - ';' delimited list of commands to run (Ex: ipconfig /all;whoami)

--- a/scoring_engine/checks/bin/winrm_check
+++ b/scoring_engine/checks/bin/winrm_check
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+# A scoring engine check that logs into winrm and runs a command
+# The check will login each time and run ONE command
+# The idea of running separate sessions is to verify
+# the state of the machine was changed via winrm
+# IE: Login, create a file, logout, login, verify file is still there, logout
+#
+# To install: pip install -I "pywinrm"
+
+import winrm
+import sys
+
+
+if len(sys.argv) != 5:
+    print("Usage: " + sys.argv[0] + " host username password commands")
+    print("commands parameter supports multiple commands, use ';' as the delimeter")
+    sys.exit(1)
+
+host = sys.argv[1]
+username = sys.argv[2]
+password = sys.argv[3]
+commands = sys.argv[4].split(';')
+
+
+def connect_and_execute(host, username, password, command):
+    try:
+        s = winrm.Session(host, auth=(username, password), transport='ntlm')
+        split = command.split(" ")
+        if len(split) == 1:
+            r = s.run_cmd(split[0], [])
+        else:
+            r = s.run_cmd(split[0], split[1:])
+        return_code = r.status_code
+        stdout_output = r.std_out.decode('utf-8')
+        stderr_output = r.std_err.decode('utf-8')
+        return return_code, ''.join(stdout_output), ''.join(stderr_output)
+    except Exception as e:
+        print(e)
+        sys.exit(1)
+
+last_command_output = ""
+for command in commands:
+    rc, command_stdout, command_stderr = connect_and_execute(host, username, password, command)
+    if rc != 0:
+        print("ERROR: Command ran unsuccessfully: " + str(command))
+        print(command_stderr)
+        sys.exit(1)
+    last_command_output = command_stdout.rstrip()
+
+print("SUCCESS")
+print(last_command_output)

--- a/scoring_engine/checks/winrm.py
+++ b/scoring_engine/checks/winrm.py
@@ -1,0 +1,15 @@
+from scoring_engine.engine.basic_check import BasicCheck, CHECKS_BIN_PATH
+
+
+class WinRMCheck(BasicCheck):
+    required_properties = ['commands']
+    CMD = CHECKS_BIN_PATH + '/winrm_check {0} {1} {2} {3}'
+
+    def command_format(self, properties):
+        account = self.get_random_account()
+        return (
+            self.host,
+            account.username,
+            account.password,
+            properties['commands']
+        )

--- a/tests/scoring_engine/engine/test_engine.py
+++ b/tests/scoring_engine/engine/test_engine.py
@@ -26,6 +26,7 @@ from scoring_engine.checks.wordpress import WordpressCheck
 from scoring_engine.checks.nfs import NFSCheck
 from scoring_engine.checks.openvpn import OpenVPNCheck
 from scoring_engine.checks.telnet import TelnetCheck
+from scoring_engine.checks.winrm import WinRMCheck
 
 from tests.scoring_engine.unit_test import UnitTest
 
@@ -70,6 +71,7 @@ class TestEngine(UnitTest):
             NFSCheck,
             OpenVPNCheck,
             TelnetCheck,
+            WinRMCheck,
         ]
         assert set(engine.checks) == set(expected_checks)
 


### PR DESCRIPTION
This pull request is to add a WinRM check. As WinRM requires Windows, tests are not part of this pull request. The check tries to login with the given credentials using NTLM authorization and attempts to run the commands provided. The check fails if the status code for any of the commands is not 0. The code is pretty much a duplicate of the SSH check but with the paramiko pulled out and replaced by calls to pywinrm.