### PR TITLE
mariadb version upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     # ports:
     #   - 6379:6379
   mysql:
-    image: mysql:5
+    image: mariadb:10
     environment:
       - MYSQL_ROOT_PASSWORD=CHANGEME
       - MYSQL_DATABASE=scoring_engine

--- a/docs/source/installation/web.rst
+++ b/docs/source/installation/web.rst
@@ -5,7 +5,7 @@ Install MySQL Server
 ^^^^^^^^^^^^^^^^^^^^
 ::
 
-  apt-get install -y mysql-server
+  apt-get install -y mariadb-server
   sed -i -e 's/127.0.0.1/0.0.0.0/g' /etc/mysql/mysql.conf.d/mysqld.cnf
   systemctl restart mysql
 


### PR DESCRIPTION
This fixes any of the weird encoding issues that mysql has because mysql doesn't nicely support utf8mb4, but apparently mariadb supports it out the box