### PR TITLE
round: append timezone to round start time

### DIFF
--- a/scoring_engine/models/check.py
+++ b/scoring_engine/models/check.py
@@ -35,4 +35,4 @@ class Check(Base):
     @property
     def local_completed_timestamp(self):
         completed_timezone_obj = pytz.timezone('UTC').localize(self.completed_timestamp)
-        return completed_timezone_obj.astimezone(pytz.timezone(config.timezone)).strftime('%Y-%m-%d %H:%M:%S')
+        return completed_timezone_obj.astimezone(pytz.timezone(config.timezone)).strftime('%Y-%m-%d %H:%M:%S %Z')

--- a/scoring_engine/models/round.py
+++ b/scoring_engine/models/round.py
@@ -28,4 +28,4 @@ class Round(Base):
     @property
     def local_round_start(self):
         round_start_obj = pytz.timezone('UTC').localize(self.round_start)
-        return round_start_obj.astimezone(pytz.timezone(config.timezone)).strftime('%Y-%m-%d %H:%M:%S')
+        return round_start_obj.astimezone(pytz.timezone(config.timezone)).strftime('%Y-%m-%d %H:%M:%S %Z')


### PR DESCRIPTION
this should fix https://github.com/scoringengine/scoringengine/issues/687 while I investigate any other datetimes that need to display timezones for users