### PR TITLE
Handle numeric boolean configuration env vars

### DIFF
--- a/scoring_engine/config_loader.py
+++ b/scoring_engine/config_loader.py
@@ -120,11 +120,12 @@ class ConfigLoader(object):
         """
         environment_key = "SCORINGENGINE_{}".format(key_name.upper())
         if environment_key in os.environ:
+            env_val = os.environ[environment_key]
             if obj_type.lower() == "int":
-                return int(os.environ[environment_key])
+                return int(env_val)
             elif obj_type.lower() == "bool":
-                return os.environ[environment_key].lower() == "true"
+                return env_val.lower() in ("true", "1", "yes")
             else:
-                return os.environ[environment_key]
+                return env_val
         else:
             return default_value

--- a/tests/test_config_loader_env.py
+++ b/tests/test_config_loader_env.py
@@ -1,0 +1,36 @@
+import os
+import textwrap
+from scoring_engine.config_loader import ConfigLoader
+
+
+def create_config_file(path):
+    content = textwrap.dedent("""
+    [OPTIONS]
+    checks_location = scoring_engine/checks
+    target_round_time = 180
+    worker_refresh_time = 30
+    engine_paused = False
+    pause_duration = 30
+    timezone = UTC
+    upload_folder = /tmp
+    debug = False
+    db_uri = sqlite://
+    worker_num_concurrent_tasks = -1
+    worker_queue = main
+    cache_type = null
+    redis_host = localhost
+    redis_port = 6379
+    redis_password =
+    """)
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+def test_boolean_env_values_recognized(tmp_path, monkeypatch):
+    cfg_path = tmp_path / 'engine.conf'
+    create_config_file(str(cfg_path))
+    monkeypatch.setenv('SCORINGENGINE_DEBUG', '1')
+    monkeypatch.setenv('SCORINGENGINE_ENGINE_PAUSED', '0')
+    loader = ConfigLoader(location=str(cfg_path))
+    assert loader.debug is True
+    assert loader.engine_paused is False


### PR DESCRIPTION
## Summary
- allow `ConfigLoader` to interpret `"1"`, `"true"`, and `"yes"` as `True` for boolean env vars
- add test covering numeric boolean environment variables

## Testing
- `pytest tests/test_config_loader_env.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bcrypt' and others)*

------
https://chatgpt.com/codex/tasks/task_e_689bf8502318832994c4af1621617e86