### PR TITLE
docs: document cache invalidation helpers

### DIFF
--- a/scoring_engine/cache_helper.py
+++ b/scoring_engine/cache_helper.py
@@ -1,8 +1,16 @@
+"""Cache invalidation helpers for the scoring engine's web interface.
+
+These utilities clear memoized responses for various API endpoints so that
+updated scoring data is served after state changes occur.
+"""
+
 from scoring_engine.cache import cache
 from scoring_engine.web import create_app
 
 
 def update_all_cache():
+    """Clear all cached data and regenerate cached sections."""
+
     app = create_app()
     with app.app_context():
         cache.clear()
@@ -17,6 +25,8 @@ def update_all_cache():
 
 
 def update_overview_data():
+    """Invalidate cached overview API responses."""
+
     from scoring_engine.web.views.api.overview import overview_data, overview_get_data, overview_get_round_data
 
     cache.delete_memoized(overview_get_data)
@@ -25,6 +35,8 @@ def update_overview_data():
 
 
 def update_scoreboard_data():
+    """Invalidate cached scoreboard API responses."""
+
     from scoring_engine.web.views.api.scoreboard import scoreboard_get_bar_data, scoreboard_get_line_data
 
     cache.delete_memoized(scoreboard_get_bar_data)
@@ -32,6 +44,13 @@ def update_scoreboard_data():
 
 
 def update_team_stats(team_id=None):
+    """Invalidate cached team statistics.
+
+    Args:
+        team_id: Optional team identifier to target a specific team. If
+            ``None`` (default), clears stats for all teams.
+    """
+
     from scoring_engine.web.views.api.team import services_get_team_data
 
     if team_id is not None:
@@ -41,6 +60,13 @@ def update_team_stats(team_id=None):
 
 
 def update_services_navbar(team_id=None):
+    """Invalidate cached service status navbar data.
+
+    Args:
+        team_id: Optional team identifier to refresh a single team's navbar.
+            If ``None``, all teams are refreshed.
+    """
+
     from scoring_engine.web.views.api.team import team_services_status
 
     if team_id is not None:
@@ -50,6 +76,13 @@ def update_services_navbar(team_id=None):
 
 
 def update_service_data(service_id=None):
+    """Invalidate cached checks for a service.
+
+    Args:
+        service_id: Optional service identifier to refresh a single service.
+            If ``None``, all services are refreshed.
+    """
+
     from scoring_engine.web.views.api.service import service_get_checks
 
     if service_id is not None:
@@ -59,6 +92,13 @@ def update_service_data(service_id=None):
 
 
 def update_services_data(team_id=None):
+    """Invalidate cached service listings for a team.
+
+    Args:
+        team_id: Optional team identifier whose services should be
+            invalidated. If ``None``, caches for all teams are cleared.
+    """
+
     from scoring_engine.web.views.api.team import api_services
 
     if team_id is not None:
@@ -69,6 +109,8 @@ def update_services_data(team_id=None):
 
 # TODO - Break this into an API cache expiration
 def update_stats():
+    """Invalidate cached statistics page data."""
+
     from scoring_engine.web.views.stats import home
 
     cache.delete_memoized(home)


### PR DESCRIPTION
## Summary
- document cache invalidation utilities
- add docstrings for cache update helpers and their arguments

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_689bf991ce8c8329903ce729aeb2b5e9