### PR TITLE
Use existing Flask app context for cache updates

### DIFF
--- a/bin/engine
+++ b/bin/engine
@@ -8,6 +8,7 @@ from scoring_engine.engine.engine import Engine
 from scoring_engine.version import version
 from scoring_engine.logger import logger
 from scoring_engine.db import session, verify_db_ready
+from scoring_engine.web import create_app
 
 
 # In order to handle docker-compose usability
@@ -28,6 +29,9 @@ if not verify_db_ready(session):
     logger.error("Database is not initialized, must run 'bin/setup' before starting the engine.")
     sys.exit(1)
 
-engine = Engine(total_rounds=total_rounds)
-logger.info("Starting Engine v.{0}".format(version))
-engine.run()
+app = create_app()
+
+with app.app_context():
+    engine = Engine(total_rounds=total_rounds)
+    logger.info("Starting Engine v.{0}".format(version))
+    engine.run()

--- a/scoring_engine/cache_helper.py
+++ b/scoring_engine/cache_helper.py
@@ -1,10 +1,28 @@
+"""Helper functions for clearing and updating application caches."""
+
+from flask import current_app
+
 from scoring_engine.cache import cache
-from scoring_engine.web import create_app
 
 
-def update_all_cache():
-    app = create_app()
-    with app.app_context():
+def update_all_cache(app_or_ctx=None):
+    """Clear and rebuild all cached values.
+
+    Parameters
+    ----------
+    app_or_ctx : Flask app or app context, optional
+        If provided, the cache will be cleared within this application's
+        context.  If omitted, the current application context will be used.
+    """
+
+    if app_or_ctx is None:
+        app_or_ctx = current_app
+
+    context_manager = (
+        app_or_ctx.app_context() if hasattr(app_or_ctx, "app_context") else app_or_ctx
+    )
+
+    with context_manager:
         cache.clear()
 
     update_overview_data()

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from functools import partial
 from pathlib import Path
 
+from flask import current_app
+
 from scoring_engine.config import config
 from scoring_engine.models.service import Service
 from scoring_engine.models.environment import Environment
@@ -295,7 +297,7 @@ class Engine(object):
                 logger.info(stat_string)
 
             logger.info("Updating Caches")
-            update_all_cache()
+            update_all_cache(current_app)
 
             self.round_running = False
 

--- a/tests/scoring_engine/engine/test_engine.py
+++ b/tests/scoring_engine/engine/test_engine.py
@@ -1,6 +1,7 @@
 from scoring_engine.engine.engine import Engine
 
 from scoring_engine.models.setting import Setting
+from scoring_engine.web import create_app
 
 from scoring_engine.checks.agent import AgentCheck
 from scoring_engine.checks.icmp import ICMPCheck
@@ -43,6 +44,14 @@ class TestEngine(UnitTest):
         self.session.add(worker_refresh_time_obj)
 
         self.session.commit()
+
+        self.app = create_app()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+    def teardown(self):
+        self.ctx.pop()
+        super(TestEngine, self).teardown()
 
     def test_init(self):
         engine = Engine()


### PR DESCRIPTION
## Summary
- allow `update_all_cache` to reuse an existing Flask app or context instead of constructing a new one
- pass `current_app` to cache updates and run the engine within an app context
- update engine unit tests to push a Flask context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bcrypt', 'flask', 'sqlalchemy')*
- `pip install bcrypt Flask SQLAlchemy Flask-Caching Flask-Login Flask-SQLAlchemy Flask-WTF celery[redis] configparser python-dateutil pytz PyYAML ranking Werkzeug` *(fails: Could not find a version that satisfies the requirement bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_689bf9481b388329ae8e808fd525d4b5