### PR TITLE
Handle freerdp package rename in worker image

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -73,7 +73,9 @@ RUN \
     unixodbc-dev
 
 # RDP Check
-RUN apt-get install -y freerdp2-x11
+# freerdp2-x11 was renamed to freerdp3-x11 on newer distributions
+RUN apt-get update && \
+    (apt-get install -y freerdp2-x11 || apt-get install -y freerdp3-x11)
 
 # NFS Check
 RUN apt-get install -y libnfs-dev

--- a/docs/source/installation/worker.rst
+++ b/docs/source/installation/worker.rst
@@ -91,7 +91,8 @@ Install dependencies for RDP check
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
-  apt-get install -y freerdp-x11
+  # Package name changed in newer distributions
+  apt-get install -y freerdp2-x11 || apt-get install -y freerdp3-x11
 
 Install dependencies for MSSQL check
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- allow Docker worker image to install freerdp2-x11 or freerdp3-x11
- document freerdp package rename for RDP check dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bcrypt')*
- `./tests/integration/run.sh` *(fails: make: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689bfc7d2704832983b23c9fc1bbfc32