### PR TITLE
Remove round check container after use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,4 +78,4 @@ rebuild-integration-new: build-integration stop-integration clean-integration ru
 
 .PHONY: integration-get-round
 integration-get-round:
-	docker compose -f $(MAIN_DOCKER) -f $(TESTBED_DOCKER) -f $(INTEGRATION_DOCKER) -p $(PROJECT_NAME) run --no-deps engine bash -c "python -c 'from scoring_engine.models.round import Round; print(\"(Round {0})\".format(Round.get_last_round_num()))'"
+        docker compose -f $(MAIN_DOCKER) -f $(TESTBED_DOCKER) -f $(INTEGRATION_DOCKER) -p $(PROJECT_NAME) run --rm --no-deps engine bash -c "python -c 'from scoring_engine.models.round import Round; print(\"(Round {0})\".format(Round.get_last_round_num()))'"

--- a/Makefile
+++ b/Makefile
@@ -78,4 +78,4 @@ rebuild-integration-new: build-integration stop-integration clean-integration ru
 
 .PHONY: integration-get-round
 integration-get-round:
-        docker compose -f $(MAIN_DOCKER) -f $(TESTBED_DOCKER) -f $(INTEGRATION_DOCKER) -p $(PROJECT_NAME) run --rm --no-deps engine bash -c "python -c 'from scoring_engine.models.round import Round; print(\"(Round {0})\".format(Round.get_last_round_num()))'"
+	docker compose -f $(MAIN_DOCKER) -f $(TESTBED_DOCKER) -f $(INTEGRATION_DOCKER) -p $(PROJECT_NAME) run --rm --no-deps engine bash -c "python -c 'from scoring_engine.models.round import Round; print(\"(Round {0})\".format(Round.get_last_round_num()))'"


### PR DESCRIPTION
## Summary
- remove integration round check container after each run to avoid orphans

## Testing
- `pytest` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab98e8530c83299bd9919584e3f3fa