### PR TITLE
Limit tests workflow push trigger to master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,9 @@
 name: Tests
 on:
   push:
-    branches: "**"
+    branches: [master]
   pull_request:
-    branches:
-      - "**"
+    branches: ["**"]
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- avoid duplicate CI runs by limiting tests workflow `push` event to only run on `master`

## Testing
- `pre-commit run --files .github/workflows/tests.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ab99ad1b808329b3b4fce8f2b17fc7