### PR TITLE
Use Flask-SQLAlchemy for database layer

### DIFF
--- a/scoring_engine/db.py
+++ b/scoring_engine/db.py
@@ -1,33 +1,8 @@
-import bcrypt
-from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
+from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.pool import NullPool
 
 from scoring_engine.config import config
-
-
-def delete_db(session):
-    from scoring_engine.models.base import Base
-
-    Base.metadata.drop_all(session.bind)
-
-
-def init_db(session):
-    from scoring_engine.models.base import Base
-
-    Base.metadata.create_all(session.bind)
-
-
-def verify_db_ready(session):
-    ready = True
-    try:
-        from scoring_engine.models.user import User
-
-        session.query(User).get(1)
-    except (OperationalError, ProgrammingError):
-        ready = False
-    return ready
 
 
 isolation_level = "READ COMMITTED"
@@ -36,21 +11,30 @@ if "sqlite" in config.db_uri:
     # so we have to manually set it to something else
     isolation_level = "READ UNCOMMITTED"
 
-session = scoped_session(
-    sessionmaker(bind=create_engine(config.db_uri, isolation_level=isolation_level, poolclass=NullPool))
-)
-
-# db_salt = bcrypt.gensalt()
+db = SQLAlchemy(engine_options={"isolation_level": isolation_level, "poolclass": NullPool})
+session = db.session
 
 
-# This is a monkey patch so that we
-# don't need to commit before every query
-# We got weird results in the web ui when we didn't
-# have this
-def query_monkeypatch(*classname):
-    session.commit()
-    return session.orig_query(*classname)
+def delete_db(_session=None):
+    """Drop all tables from the database."""
+    db.drop_all()
 
 
-session.orig_query = session.query
-session.query = query_monkeypatch
+def init_db(_session=None):
+    """Create all tables in the database."""
+    db.create_all()
+
+
+def verify_db_ready(_session=None):
+    """Return True if the database is initialized."""
+    ready = True
+    try:
+        from scoring_engine.models.user import User
+
+        db.session.query(User).get(1)
+    except (OperationalError, ProgrammingError):
+        ready = False
+    return ready
+
+
+

--- a/scoring_engine/models/base.py
+++ b/scoring_engine/models/base.py
@@ -1,3 +1,3 @@
-from sqlalchemy.orm import declarative_base
+from scoring_engine.db import db
 
-Base = declarative_base()
+Base = db.Model

--- a/tests/integration/test_integrations.py
+++ b/tests/integration/test_integrations.py
@@ -4,6 +4,9 @@ from scoring_engine.models.team import Team
 from scoring_engine.models.service import Service
 from scoring_engine.models.check import Check
 from scoring_engine.db import session
+from scoring_engine.web import create_app
+app = create_app()
+app.app_context().push()
 
 NUM_TESTBED_SERVICES = 14
 NUM_OVERALL_ROUNDS = 5

--- a/tests/scoring_engine/engine/test_engine.py
+++ b/tests/scoring_engine/engine/test_engine.py
@@ -1,7 +1,6 @@
 from scoring_engine.engine.engine import Engine
 
 from scoring_engine.models.setting import Setting
-from scoring_engine.web import create_app
 
 from scoring_engine.checks.agent import AgentCheck
 from scoring_engine.checks.icmp import ICMPCheck

--- a/tests/scoring_engine/unit_test.py
+++ b/tests/scoring_engine/unit_test.py
@@ -1,5 +1,6 @@
-from scoring_engine.db import session, delete_db, init_db
+from scoring_engine.db import db, delete_db, init_db
 from scoring_engine.models.setting import Setting
+from scoring_engine.web import create_app
 
 
 class UnitTest(object):
@@ -12,6 +13,7 @@ class UnitTest(object):
     def teardown_method(self):
         delete_db(self.session)
         self.session.remove()
+        self.ctx.pop()
 
     def create_default_settings(self):
         self.session.add(

--- a/tests/scoring_engine/web/web_test.py
+++ b/tests/scoring_engine/web/web_test.py
@@ -1,7 +1,6 @@
 import importlib
 from flask import render_template as render_template_orig
 
-from scoring_engine.web import create_app
 from scoring_engine.models.team import Team
 from scoring_engine.models.user import User
 
@@ -18,8 +17,6 @@ class WebTest(UnitTest):
         self.app.config["WTF_CSRF_ENABLED"] = False
 
         self.client = self.app.test_client()
-        self.ctx = self.app.app_context()
-        self.ctx.push()
 
         view_name = self.__class__.__name__[4:]
         self.view_module = importlib.import_module("scoring_engine.web.views." + view_name.lower(), "*")


### PR DESCRIPTION
## Summary
- Replace manual SQLAlchemy engine/session with Flask-SQLAlchemy extension
- Update models and app factory to use `db.Model` and `db.session`
- Adjust tests to create app contexts with new database setup
- Drop query-session monkeypatch and rely on normal SQLAlchemy behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab97d37d7c83299a8b987c39e78c16