### PR TITLE
Fix stats API case clause for SQLAlchemy 2 compatibility

### DIFF
--- a/scoring_engine/web/views/api/stats.py
+++ b/scoring_engine/web/views/api/stats.py
@@ -1,26 +1,24 @@
+import html
 from collections import defaultdict
-from flask import request, jsonify
-from flask_login import current_user, login_required
 from functools import wraps
+
+import pytz
+from flask import jsonify, request
+from flask_login import current_user, login_required
 from sqlalchemy import desc
 from sqlalchemy.sql import case, func
 
-import html
-import pytz
-
 from scoring_engine.cache import cache
+from scoring_engine.cache_helper import (update_overview_data,
+                                         update_service_data,
+                                         update_services_data)
 from scoring_engine.config import config
 from scoring_engine.db import session
-from scoring_engine.cache_helper import (
-    update_overview_data,
-    update_services_data,
-    update_service_data,
-)
 from scoring_engine.models.account import Account
-from scoring_engine.models.service import Service
-from scoring_engine.models.setting import Setting
 from scoring_engine.models.check import Check
 from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
 
 from . import make_cache_key, mod
@@ -31,7 +29,11 @@ from . import make_cache_key, mod
 @cache.cached(make_cache_key=make_cache_key)
 def api_stats():
     team = session.query(Team).get(current_user.team.id)
-    if team is None or not current_user.team == team or not (current_user.is_blue_team or current_user.is_white_team):
+    if (
+        team is None
+        or not current_user.team == team
+        or not (current_user.is_blue_team or current_user.is_white_team)
+    ):
         return jsonify({"status": "Unauthorized"}), 403
 
     if current_user.is_blue_team:
@@ -43,11 +45,17 @@ def api_stats():
                 Round.id.label("round_id"),
                 Round.round_start,
                 Round.round_end,
-                func.sum(case([(Check.result == True, 1)], else_=0)).label("num_successful_checks"),
-                func.sum(case([(Check.result == False, 1)], else_=0)).label("num_unsuccessful_checks"),
+                func.sum(case((Check.result == True, 1), else_=0)).label(
+                    "num_successful_checks"
+                ),
+                func.sum(case((Check.result == False, 1), else_=0)).label(
+                    "num_unsuccessful_checks"
+                ),
             )
             .outerjoin(Check, Round.id == Check.round_id)
-            .join(Service, Check.service_id == Service.id)  # Ensure checks are linked to services
+            .join(
+                Service, Check.service_id == Service.id
+            )  # Ensure checks are linked to services
             .filter(Round.id <= last_round)
             .filter(Service.team_id == team.id)  # Limit results to the specified team
             .group_by(Round.id, Round.round_start, Round.round_end)
@@ -58,8 +66,12 @@ def api_stats():
             stats.append(
                 {
                     "round_id": row[0],
-                    "start_time": row[1].astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z"),
-                    "end_time": row[2].astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z"),
+                    "start_time": row[1]
+                    .astimezone(pytz.timezone(config.timezone))
+                    .strftime("%Y-%m-%d %H:%M:%S %Z"),
+                    "end_time": row[2]
+                    .astimezone(pytz.timezone(config.timezone))
+                    .strftime("%Y-%m-%d %H:%M:%S %Z"),
                     "total_seconds": (row[2] - row[1]).seconds,
                     "num_up_services": row[3],
                     "num_down_services": row[4],
@@ -77,10 +89,16 @@ def api_stats():
                 Round.id.label("round_id"),
                 Round.round_start,
                 Round.round_end,
-                func.sum(case([(Check.result == True, 1)], else_=0)).label("num_successful_checks"),
-                func.sum(case([(Check.result == False, 1)], else_=0)).label("num_unsuccessful_checks"),
+                func.sum(case((Check.result == True, 1), else_=0)).label(
+                    "num_successful_checks"
+                ),
+                func.sum(case((Check.result == False, 1), else_=0)).label(
+                    "num_unsuccessful_checks"
+                ),
             )
-            .outerjoin(Check, Round.id == Check.round_id)  # Include all rounds even if no checks are present
+            .outerjoin(
+                Check, Round.id == Check.round_id
+            )  # Include all rounds even if no checks are present
             .filter(Round.id <= last_round)
             .group_by(Round.id, Round.round_start, Round.round_end)
             .order_by(desc(Round.id))
@@ -91,8 +109,12 @@ def api_stats():
             stats.append(
                 {
                     "round_id": row[0],
-                    "start_time": row[1].astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z"),
-                    "end_time": row[2].astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z"),
+                    "start_time": row[1]
+                    .astimezone(pytz.timezone(config.timezone))
+                    .strftime("%Y-%m-%d %H:%M:%S %Z"),
+                    "end_time": row[2]
+                    .astimezone(pytz.timezone(config.timezone))
+                    .strftime("%Y-%m-%d %H:%M:%S %Z"),
                     "total_seconds": (row[2] - row[1]).seconds,
                     "num_up_services": row[3],
                     "num_down_services": row[4],


### PR DESCRIPTION
## Summary
- update SQLAlchemy `case` usage in stats API to use positional arguments for SQLAlchemy 2
- apply formatting updates from pre-commit hooks

## Testing
- `pre-commit run --files scoring_engine/web/views/api/stats.py` *(fails: Error code '#' supplied to 'ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$')*
- `pytest` *(fails: PendingRollbackError errors and 3 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aba18017e88329b87c62307b02cadb