### PR TITLE
refactor: eliminate SQLAlchemy legacy .get and fix cache type

### DIFF
--- a/scoring_engine/cache.py
+++ b/scoring_engine/cache.py
@@ -2,9 +2,17 @@ from flask_caching import Cache
 from scoring_engine.config import config
 
 
-cache = Cache(config={
-    'CACHE_TYPE': config.cache_type,
-    'CACHE_REDIS_HOST': config.redis_host,
-    'CACHE_REDIS_PORT': config.redis_port,
-    'CACHE_REDIS_PASSWORD': config.redis_password,
-})
+_CACHE_TYPE_MAP = {
+    "redis": "flask_caching.backends.rediscache.RedisCache",
+    "null": "flask_caching.backends.nullcache.NullCache",
+    "simple": "flask_caching.backends.simplecache.SimpleCache",
+}
+
+cache = Cache(
+    config={
+        "CACHE_TYPE": _CACHE_TYPE_MAP.get(config.cache_type, config.cache_type),
+        "CACHE_REDIS_HOST": config.redis_host,
+        "CACHE_REDIS_PORT": config.redis_port,
+        "CACHE_REDIS_PASSWORD": config.redis_password,
+    }
+)

--- a/scoring_engine/db.py
+++ b/scoring_engine/db.py
@@ -24,7 +24,7 @@ def verify_db_ready(session):
     try:
         from scoring_engine.models.user import User
 
-        session.query(User).get(1)
+        session.get(User, 1)
     except (OperationalError, ProgrammingError):
         ready = False
     return ready

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -232,7 +232,7 @@ class Engine(object):
                 for team_name, task_ids in task_ids.items():
                     for task_id in task_ids:
                         task = execute_command.AsyncResult(task_id)
-                        environment = self.session.query(Environment).get(task.result["environment_id"])
+                        environment = self.session.get(Environment, task.result["environment_id"])
                         if task.result["errored_out"]:
                             result = False
                             reason = CHECK_TIMED_OUT_TEXT

--- a/scoring_engine/web/__init__.py
+++ b/scoring_engine/web/__init__.py
@@ -53,7 +53,7 @@ def create_app():
 
     @login_manager.user_loader
     def load_user(user_id):
-        return session.query(User).get(int(user_id))
+        return session.get(User, int(user_id))
 
     app.register_blueprint(welcome.mod)
     app.register_blueprint(services.mod)

--- a/scoring_engine/web/views/admin.py
+++ b/scoring_engine/web/views/admin.py
@@ -88,7 +88,7 @@ def inject_scores():
 @login_required
 def inject_inject(inject_id):
     if current_user.is_white_team:
-        inject = session.query(Inject).get(inject_id)
+        inject = session.get(Inject, inject_id)
         return render_template("admin/inject.html", inject=inject)
     else:
         return redirect(url_for("auth.unauthorized"))
@@ -98,7 +98,7 @@ def inject_inject(inject_id):
 @login_required
 def service(id):
     if current_user.is_white_team:
-        service = session.query(Service).get(id)
+        service = session.get(Service, id)
         blue_teams = Team.get_all_blue_teams()
         if service is None:
             return redirect(url_for("auth.unauthorized"))

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -47,7 +47,7 @@ from . import mod
 def admin_update_environment():
     if current_user.is_white_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            environment = session.query(Environment).get(int(request.form["pk"]))
+            environment = session.get(Environment, int(request.form["pk"]))
             if environment:
                 if request.form["name"] == "matching_content":
                     environment.matching_content = html.escape(request.form["value"])
@@ -63,7 +63,7 @@ def admin_update_environment():
 def admin_update_property():
     if current_user.is_white_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            property_obj = session.query(Property).get(int(request.form["pk"]))
+            property_obj = session.get(Property, int(request.form["pk"]))
             if property_obj:
                 if request.form["name"] == "property_name":
                     property_obj.name = html.escape(request.form["value"])
@@ -81,7 +81,7 @@ def admin_update_property():
 def admin_update_check():
     if current_user.is_white_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            check = session.query(Check).get(int(request.form["pk"]))
+            check = session.get(Check, int(request.form["pk"]))
             if check:
                 modified_check = False
                 if request.form["name"] == "check_value":
@@ -112,7 +112,7 @@ def admin_update_check():
 def admin_update_host():
     if current_user.is_white_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            service = session.query(Service).get(int(request.form["pk"]))
+            service = session.get(Service, int(request.form["pk"]))
             if service:
                 if request.form["name"] == "host":
                     service.host = html.escape(request.form["value"])
@@ -130,7 +130,7 @@ def admin_update_host():
 def admin_update_port():
     if current_user.is_white_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            service = session.query(Service).get(int(request.form["pk"]))
+            service = session.get(Service, int(request.form["pk"]))
             if service:
                 if request.form["name"] == "port":
                     service.port = int(request.form["value"])
@@ -148,7 +148,7 @@ def admin_update_port():
 def admin_update_worker_queue():
     if current_user.is_white_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            service = session.query(Service).get(int(request.form["pk"]))
+            service = session.get(Service, int(request.form["pk"]))
             if service:
                 if request.form["name"] == "worker_queue":
                     service.worker_queue = request.form["value"]
@@ -163,7 +163,7 @@ def admin_update_worker_queue():
 def admin_update_points():
     if current_user.is_white_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            service = session.query(Service).get(int(request.form["pk"]))
+            service = session.get(Service, int(request.form["pk"]))
             if service:
                 if request.form["name"] == "points":
                     service.points = int(request.form["value"])
@@ -385,7 +385,7 @@ def get_check_progress_total():
 @login_required
 def admin_get_inject_templates_id(template_id):
     if current_user.is_white_team:
-        template = session.query(Template).get(int(template_id))
+        template = session.get(Template, int(template_id))
         data = dict(
             id=template.id,
             title=template.title,
@@ -415,7 +415,7 @@ def admin_get_inject_templates_id(template_id):
 def admin_put_inject_templates_id(template_id):
     if current_user.is_white_team:
         data = request.get_json()
-        template = session.query(Template).get(int(template_id))
+        template = session.get(Template, int(template_id))
         if template:
             if data.get("title"):
                 template.title = data["title"]
@@ -486,7 +486,7 @@ def admin_put_inject_templates_id(template_id):
 @login_required
 def admin_delete_inject_templates_id(template_id):
     if current_user.is_white_team:
-        template = session.query(Template).get(int(template_id))
+        template = session.get(Template, int(template_id))
         if template:
             session.delete(template)
             session.commit()
@@ -542,7 +542,7 @@ def admin_post_inject_grade(inject_id):
     if current_user.is_white_team:
         data = request.get_json()
         if "score" in data.keys() and data.get("score") != "":
-            inject = session.query(Inject).get(inject_id)
+            inject = session.get(Inject, inject_id)
             if inject:
                 inject.graded = datetime.utcnow()
                 inject.status = "Graded"
@@ -675,7 +675,7 @@ def admin_import_inject_templates():
             for d in data:
                 if d.get("id"):
                     template_id = d["id"]
-                    t = session.query(Template).get(int(template_id))
+                    t = session.get(Template, int(template_id))
                     # Update template if it exists
                     if t:
                         if d.get("title"):
@@ -703,7 +703,7 @@ def admin_import_inject_templates():
                         # for rubric in d["rubric"]:
                         #     if rubric.get("id"):
                         #         rubric_id = rubric["id"]
-                        #     r = session.query(Rubric).get(int(rubric_id))
+                        #     r = session.get(Rubric, int(rubric_id))
                         #     # Update rubric if it exists
                         #     if r:
                         #         if rubric.get("value"):
@@ -893,7 +893,7 @@ def admin_update_template():
     if current_user.is_white_team:
         print(request.form)
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            template = session.query(Template).get(int(request.form["pk"]))
+            template = session.get(Template, int(request.form["pk"]))
             if template:
                 modified_check = False
                 if request.form["name"] == "template_state":

--- a/scoring_engine/web/views/api/agent.py
+++ b/scoring_engine/web/views/api/agent.py
@@ -62,7 +62,7 @@ def get_host_info() -> Tuple[Team, str, Platform]:
 
     # Try to parse the team_input as an integer (ID)
     if team_input.isdigit():
-        team: Team = session.query(Team).get(int(team_input))
+        team: Team = session.get(Team, int(team_input))
     else:
         team: Team = session.query(Team).filter_by(name=team_input).first()
 
@@ -104,7 +104,8 @@ def do_checkin(team, host, platform):
     }
 
     # TODO - this is a gross dev hack
-    if cache.config["CACHE_TYPE"] == "null":
+    cache_type = cache.config["CACHE_TYPE"]
+    if cache_type == "null" or cache_type.endswith("NullCache"):
         cache_dict[host] = now
         # print(cache_dict)
     else:

--- a/scoring_engine/web/views/api/flags.py
+++ b/scoring_engine/web/views/api/flags.py
@@ -19,7 +19,7 @@ from . import make_cache_key, mod
 @login_required
 @cache.cached(make_cache_key=make_cache_key)
 def api_flags():
-    team = session.query(Team).get(current_user.team.id)
+    team = session.get(Team, current_user.team.id)
     if team is None or not current_user.team == team or not (current_user.is_red_team or current_user.is_white_team):
         return jsonify({"status": "Unauthorized"}), 403
 
@@ -51,7 +51,7 @@ def api_flags():
 @login_required
 @cache.cached(make_cache_key=make_cache_key)
 def api_flags_solves():
-    # team = session.query(Team).get(current_user.team.id)
+    # team = session.get(Team, current_user.team.id)
     # if team is None or not current_user.team == team or not (current_user.is_red_team or current_user.is_white_team):
     #     return jsonify({"status": "Unauthorized"}), 403
 

--- a/scoring_engine/web/views/api/injects.py
+++ b/scoring_engine/web/views/api/injects.py
@@ -19,7 +19,7 @@ from . import make_cache_key, mod
 @mod.route("/api/injects")
 @login_required
 def api_injects():
-    team = session.query(Team).get(current_user.team.id)
+    team = session.get(Team, current_user.team.id)
     if team is None or not current_user.team == team or not (current_user.is_blue_team or current_user.is_red_team):
         return jsonify({"status": "Unauthorized"}), 403
     data = list()
@@ -51,7 +51,7 @@ def api_injects():
 @mod.route("/api/inject/<inject_id>/submit", methods=["POST"])
 @login_required
 def api_injects_submit(inject_id):
-    inject = session.query(Inject).get(inject_id)
+    inject = session.get(Inject, inject_id)
     if inject.team is None or not current_user.team == inject.team or not current_user.is_blue_team:
         return jsonify({"status": "Unauthorized"}), 403
     if datetime.utcnow() > inject.template.end_time:
@@ -66,7 +66,7 @@ def api_injects_submit(inject_id):
 @mod.route("/api/inject/<inject_id>/upload", methods=["POST"])
 @login_required
 def api_injects_file_upload(inject_id):
-    inject = session.query(Inject).get(inject_id)
+    inject = session.get(Inject, inject_id)
     if inject.team is None or not current_user.team == inject.team or not current_user.is_blue_team:
         return jsonify({"status": "Unauthorized"}), 403
 
@@ -106,7 +106,7 @@ def api_injects_file_upload(inject_id):
 @cache.cached(make_cache_key=make_cache_key)
 @login_required
 def api_inject(inject_id):
-    inject = session.query(Inject).get(inject_id)
+    inject = session.get(Inject, inject_id)
     if inject is None or not (current_user.team == inject.team or current_user.is_white_team):
         return jsonify({"status": "Unauthorized"}), 403
 
@@ -139,7 +139,7 @@ def api_inject(inject_id):
 @cache.cached(make_cache_key=make_cache_key)
 @login_required
 def api_inject_comments(inject_id):
-    inject = session.query(Inject).get(inject_id)
+    inject = session.get(Inject, inject_id)
     if inject is None or not (current_user.team == inject.team or current_user.is_white_team):
         return jsonify({"status": "Unauthorized"}), 403
 
@@ -163,7 +163,7 @@ def api_inject_comments(inject_id):
 @mod.route("/api/inject/<inject_id>/comment", methods=["POST"])
 @login_required
 def api_inject_add_comment(inject_id):
-    inject = session.query(Inject).get(inject_id)
+    inject = session.get(Inject, inject_id)
     if inject is None or not (current_user.team == inject.team or current_user.is_white_team):
         return jsonify({"status": "Unauthorized"}), 403
     if datetime.utcnow() > inject.template.end_time:
@@ -187,7 +187,7 @@ def api_inject_add_comment(inject_id):
 @cache.cached(make_cache_key=make_cache_key)
 @login_required
 def api_inject_files(inject_id):
-    inject = session.query(Inject).get(inject_id)
+    inject = session.get(Inject, inject_id)
     if inject is None or not (current_user.team == inject.team or current_user.is_white_team):
         return jsonify({"status": "Unauthorized"}), 403
 
@@ -206,7 +206,7 @@ def api_inject_files(inject_id):
 @mod.route("/api/inject/<inject_id>/files/<file_id>/download")
 @login_required
 def api_inject_download(inject_id, file_id):
-    inject = session.query(Inject).get(inject_id)
+    inject = session.get(Inject, inject_id)
     if inject is None or not (current_user.team == inject.team or current_user.is_white_team):
         return jsonify({"status": "Unauthorized"}), 403
 

--- a/scoring_engine/web/views/api/service.py
+++ b/scoring_engine/web/views/api/service.py
@@ -23,7 +23,7 @@ from . import make_cache_key, mod
 @login_required
 @cache.cached(make_cache_key=make_cache_key)
 def service_get_checks(service_id):
-    service = session.query(Service).get(service_id)
+    service = session.get(Service, service_id)
     if service is None or not (current_user.team == service.team or current_user.team.is_white_team):
         return jsonify({"status": "Unauthorized"}), 403
     data = []
@@ -57,7 +57,7 @@ def service_get_checks(service_id):
 def update_service_account_info():
     if current_user.is_white_team or current_user.is_blue_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            account = session.query(Account).get(int(request.form["pk"]))
+            account = session.get(Account, int(request.form["pk"]))
             if current_user.team == account.service.team or current_user.is_white_team:
                 if account:
                     if request.form["name"] == "username":
@@ -81,7 +81,7 @@ def update_service_account_info():
 def update_host():
     if current_user.is_blue_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            service = session.query(Service).get(int(request.form["pk"]))
+            service = session.get(Service, int(request.form["pk"]))
             if service:
                 if service.team == current_user.team and request.form["name"] == "host":
                     modify_hostname_setting = Setting.get_setting("blue_team_update_hostname").value
@@ -102,7 +102,7 @@ def update_host():
 def update_port():
     if current_user.is_blue_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
-            service = session.query(Service).get(int(request.form["pk"]))
+            service = session.get(Service, int(request.form["pk"]))
             if service:
                 if service.team == current_user.team and request.form["name"] == "port":
                     modify_port_setting = Setting.get_setting("blue_team_update_port").value

--- a/scoring_engine/web/views/api/stats.py
+++ b/scoring_engine/web/views/api/stats.py
@@ -28,7 +28,7 @@ from . import make_cache_key, mod
 @login_required
 @cache.cached(make_cache_key=make_cache_key)
 def api_stats():
-    team = session.query(Team).get(current_user.team.id)
+    team = session.get(Team, current_user.team.id)
     if (
         team is None
         or not current_user.team == team

--- a/scoring_engine/web/views/api/team.py
+++ b/scoring_engine/web/views/api/team.py
@@ -20,7 +20,7 @@ from . import make_cache_key, mod
 @login_required
 @cache.cached(make_cache_key=make_cache_key)
 def services_get_team_data(team_id):
-    team = session.query(Team).get(team_id)
+    team = session.get(Team, team_id)
     if team is None or not current_user.team == team or not current_user.is_blue_team:
         return {"status": "Unauthorized"}, 403
 
@@ -32,7 +32,7 @@ def services_get_team_data(team_id):
 @login_required
 @cache.cached(make_cache_key=make_cache_key)
 def api_services(team_id):
-    team = session.query(Team).get(team_id)
+    team = session.get(Team, team_id)
     if team is None or not current_user.team == team or not current_user.is_blue_team:
         return {"status": "Unauthorized"}, 403
 
@@ -104,7 +104,7 @@ def api_services(team_id):
 @login_required
 @cache.cached(make_cache_key=make_cache_key)
 def team_services_status(team_id):
-    team = session.query(Team).get(team_id)
+    team = session.get(Team, team_id)
     if team is None or not current_user.team == team or not current_user.is_blue_team:
         return {"status": "Unauthorized"}, 403
 

--- a/scoring_engine/web/views/auth.py
+++ b/scoring_engine/web/views/auth.py
@@ -24,7 +24,7 @@ login_manager = LoginManager()
 # You can still define the user_loader function here, as it's needed for Flask-Login
 @login_manager.user_loader
 def load_user(id):
-    return session.query(User).get(int(id))
+    return session.get(User, int(id))
 
 
 # Define the before_request function

--- a/scoring_engine/web/views/injects.py
+++ b/scoring_engine/web/views/injects.py
@@ -21,7 +21,7 @@ def home():
 @mod.route("/inject/<inject_id>")
 @login_required
 def inject(inject_id):
-    inject = session.query(Inject).get(inject_id)
+    inject = session.get(Inject, inject_id)
     if (
         inject is None
         or not current_user.team == inject.team

--- a/scoring_engine/web/views/services.py
+++ b/scoring_engine/web/views/services.py
@@ -19,7 +19,7 @@ def home():
 @mod.route('/service/<id>')
 @login_required
 def service(id):
-    service = session.query(Service).get(id)
+    service = session.get(Service, id)
     if service is None or not current_user.team == service.team:
         return redirect(url_for('auth.unauthorized'))
     modify_hostname_setting = Setting.get_setting('blue_team_update_hostname').value


### PR DESCRIPTION
## Summary
- replace deprecated `Query.get` with `Session.get`
- map cache type names to full `flask_caching` backend paths and adjust null-cache check

## Testing
- `pytest`
- `flake8` *(fails: Error code '#' supplied to 'ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$')*

------
https://chatgpt.com/codex/tasks/task_e_68aba69078dc8329ba49b01cbdbb90ae