### PR TITLE
Migrate to Flask-SQLAlchemy

### DIFF
--- a/bin/engine
+++ b/bin/engine
@@ -25,13 +25,13 @@ total_rounds = 0
 if 'SCORINGENGINE_NUM_ROUNDS' in os.environ:
     total_rounds = int(os.environ['SCORINGENGINE_NUM_ROUNDS'])
 
-if not verify_db_ready(session):
-    logger.error("Database is not initialized, must run 'bin/setup' before starting the engine.")
-    sys.exit(1)
-
 app = create_app()
 
 with app.app_context():
+    if not verify_db_ready():
+        logger.error("Database is not initialized, must run 'bin/setup' before starting the engine.")
+        sys.exit(1)
+
     engine = Engine(total_rounds=total_rounds)
     logger.info("Starting Engine v.{0}".format(version))
     engine.run()

--- a/bin/setup
+++ b/bin/setup
@@ -19,6 +19,7 @@ from scoring_engine.config import config
 from scoring_engine.competition import Competition
 from scoring_engine.logger import logger
 from scoring_engine.version import version
+from scoring_engine.web import create_app
 from scoring_engine.engine.basic_check import (
     CHECK_SUCCESS_TEXT,
     CHECK_FAILURE_TEXT,
@@ -47,8 +48,11 @@ if "SCORINGENGINE_OVERWRITE_DB" in os.environ and os.environ["SCORINGENGINE_OVER
 
 logger.info("Starting Setup v.{0}".format(version))
 
+app = create_app()
+app.app_context().push()
+
 if not options.overwrite_db:
-    if verify_db_ready(session):
+    if verify_db_ready():
         logger.error("Exiting script and not overwriting db...must use --overwrite-db to overwrite data.")
         exit()
     else:
@@ -56,8 +60,8 @@ if not options.overwrite_db:
         logger.debug("Database doesn't exist yet...")
 
 logger.info("Setting up DB")
-delete_db(session)
-init_db(session)
+delete_db()
+init_db()
 
 competition_config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "competition.yaml")
 sample_competition_str = open(competition_config_file, "r").read()

--- a/bin/web
+++ b/bin/web
@@ -3,7 +3,7 @@
 import sys
 
 from scoring_engine.web import create_app
-from scoring_engine.db import session, verify_db_ready
+from scoring_engine.db import verify_db_ready
 
 from scoring_engine.version import version
 from scoring_engine.logger import logger
@@ -12,10 +12,11 @@ from scoring_engine.logger import logger
 application = create_app()
 
 if __name__ == "__main__":
-    if not verify_db_ready(session):
-        logger.error("Database is not initialized, must run 'bin/setup' before starting the web app.")
-        sys.exit(1)
+    with application.app_context():
+        if not verify_db_ready():
+            logger.error("Database is not initialized, must run 'bin/setup' before starting the web app.")
+            sys.exit(1)
 
-    logger.info("Starting Web v.{0}".format(version))
+        logger.info("Starting Web v.{0}".format(version))
 
-    application.run(host="0.0.0.0", port=8000)
+        application.run(host="0.0.0.0", port=8000)

--- a/tests/integration/test_integrations.py
+++ b/tests/integration/test_integrations.py
@@ -4,6 +4,10 @@ from scoring_engine.models.team import Team
 from scoring_engine.models.service import Service
 from scoring_engine.models.check import Check
 from scoring_engine.db import session
+from scoring_engine.web import create_app
+
+app = create_app()
+app.app_context().push()
 
 NUM_TESTBED_SERVICES = 14
 NUM_OVERALL_ROUNDS = 5

--- a/tests/scoring_engine/engine/test_engine.py
+++ b/tests/scoring_engine/engine/test_engine.py
@@ -1,7 +1,6 @@
 from scoring_engine.engine.engine import Engine
 
 from scoring_engine.models.setting import Setting
-from scoring_engine.web import create_app
 
 from scoring_engine.checks.agent import AgentCheck
 from scoring_engine.checks.icmp import ICMPCheck
@@ -45,12 +44,7 @@ class TestEngine(UnitTest):
 
         self.session.commit()
 
-        self.app = create_app()
-        self.ctx = self.app.app_context()
-        self.ctx.push()
-
     def teardown_method(self):
-        self.ctx.pop()
         super(TestEngine, self).teardown_method()
 
     def test_init(self):

--- a/tests/scoring_engine/unit_test.py
+++ b/tests/scoring_engine/unit_test.py
@@ -1,17 +1,22 @@
 from scoring_engine.db import session, delete_db, init_db
 from scoring_engine.models.setting import Setting
+from scoring_engine.web import create_app
 
 
 class UnitTest(object):
     def setup_method(self):
+        self.app = create_app()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
         self.session = session
-        delete_db(self.session)
-        init_db(self.session)
+        delete_db()
+        init_db()
         self.create_default_settings()
 
     def teardown_method(self):
-        delete_db(self.session)
+        delete_db()
         self.session.remove()
+        self.ctx.pop()
 
     def create_default_settings(self):
         self.session.add(

--- a/tests/scoring_engine/web/web_test.py
+++ b/tests/scoring_engine/web/web_test.py
@@ -1,7 +1,6 @@
 import importlib
 from flask import render_template as render_template_orig
 
-from scoring_engine.web import create_app
 from scoring_engine.models.team import Team
 from scoring_engine.models.user import User
 
@@ -13,13 +12,9 @@ class WebTest(UnitTest):
 
     def setup_method(self):
         super(WebTest, self).setup_method()
-        self.app = create_app()
         self.app.config["TESTING"] = True
         self.app.config["WTF_CSRF_ENABLED"] = False
-
         self.client = self.app.test_client()
-        self.ctx = self.app.app_context()
-        self.ctx.push()
 
         view_name = self.__class__.__name__[4:]
         self.view_module = importlib.import_module("scoring_engine.web.views." + view_name.lower(), "*")
@@ -28,7 +23,6 @@ class WebTest(UnitTest):
         self.mock_obj.side_effect = lambda *args, **kwargs: render_template_orig(*args, **kwargs)
 
     def teardown_method(self):
-        self.ctx.pop()
         super(WebTest, self).teardown_method()
 
     def build_args(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- Switch database layer to Flask-SQLAlchemy and remove monkeypatched queries
- Initialize SQLAlchemy through Flask app configuration and context
- Update scripts and tests to use new database session

## Testing
- `pytest -v tests/`

------
https://chatgpt.com/codex/tasks/task_e_68abb75806808329a8ad21aa3db9fae3