### PR TITLE
Add tests for Agent model and fix imports

### DIFF
--- a/scoring_engine/models/agent.py
+++ b/scoring_engine/models/agent.py
@@ -1,30 +1,18 @@
-from sqlalchemy import (
-    Column,
-    Enum,
-    Integer,
-    PickleType,
-    DateTime,
-    String,
-    UniqueConstraint,
-    ForeignKey,
-)
+import enum
+import html
+import uuid
 
+import pytz
+from sqlalchemy import (Column, DateTime, Enum, ForeignKey, Integer,
+                        PickleType, String, UniqueConstraint)
 # from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
-import pytz
-
-import html
-
-import uuid
-
-from scoring_engine.models.base import Base
-from scoring_engine.models.team import Team
 from scoring_engine.cache import cache
 from scoring_engine.config import config
-
-
-import enum
+from scoring_engine.models.base import Base
+from scoring_engine.models.flag import FlagTypeEnum, Platform
+from scoring_engine.models.team import Team
 
 
 class Agent(Base):

--- a/tests/scoring_engine/models/test_agent.py
+++ b/tests/scoring_engine/models/test_agent.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+import pytz
+
+from scoring_engine.models.agent import Agent
+from scoring_engine.models.flag import FlagTypeEnum, Platform
+from tests.scoring_engine.unit_test import UnitTest
+
+
+class TestAgent(UnitTest):
+    def test_as_dict(self):
+        start = datetime(2024, 1, 1, tzinfo=pytz.UTC)
+        end = datetime(2024, 1, 2, tzinfo=pytz.UTC)
+        agent = Agent(
+            id=1,
+            type=FlagTypeEnum.file,
+            platform=Platform.nix,
+            data={"cmd": "ls"},
+            start_time=start,
+            end_time=end,
+        )
+        assert agent.as_dict() == {
+            "id": 1,
+            "type": "file",
+            "data": {"cmd": "ls"},
+            "start_time": int(start.timestamp()),
+            "end_time": int(end.timestamp()),
+        }


### PR DESCRIPTION
## Summary
- fix Agent model imports and add coverage test for `as_dict`

## Testing
- `pytest tests/scoring_engine/models/test_agent.py --cov=scoring_engine.models.agent --cov-report=term-missing -q`
- `pre-commit run --files scoring_engine/models/agent.py tests/scoring_engine/models/test_agent.py` *(fails: Error code '#' supplied to 'ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$')*


------
https://chatgpt.com/codex/tasks/task_e_68ac528cbe60832995c0d084d8f9d46e