### PR TITLE
Replace libnfs dependency with system NFS utilities

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -79,9 +79,7 @@ RUN apt-get update && \
     (apt-get install -y freerdp2-x11 || apt-get install -y freerdp3-x11 || apt-get install -y freerdp)
 
 # NFS Check
-RUN apt-get install -y libnfs-dev
-# Pin to the last published Python binding for libnfs
-RUN pip install -I "libnfs==1.0.post4"
+RUN apt-get install -y nfs-common
 
 # Telnet Check
 RUN pip install -I "telnetlib3==1.0.1"

--- a/docker/worker/sudoers
+++ b/docker/worker/sudoers
@@ -18,7 +18,7 @@ Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/b
 
 # User privilege specification
 root	ALL=(ALL:ALL) ALL
-engine  ALL=(ALL:ALL) NOPASSWD: /usr/sbin/openvpn
+engine  ALL=(ALL:ALL) NOPASSWD: /usr/sbin/openvpn, /usr/bin/mount, /usr/bin/umount
 
 # Members of the admin group may gain root privileges
 %admin ALL=(ALL) ALL

--- a/docs/source/checks/nfs.rst
+++ b/docs/source/checks/nfs.rst
@@ -1,6 +1,6 @@
 NFS
 ^^^
-Uses python libnfs to login to an NFS server, write a file, login again to NFS and read a file
+Uses system NFS utilities to mount a share, write a file, and read it back to verify the contents
 
 Custom Properties:
 

--- a/docs/source/installation/worker.rst
+++ b/docs/source/installation/worker.rst
@@ -119,9 +119,7 @@ Install dependencies for NFS check
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
-  apt-get install -y libnfs-dev
-  # Install the libnfs Python bindings
-  source /home/engine/scoring_engine/env/bin/activate && pip install -I "libnfs==1.0.post4"
+  apt-get install -y nfs-common
 
 Install dependencies for OpenVPN check
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/scoring_engine/checks/bin/nfs_check
+++ b/scoring_engine/checks/bin/nfs_check
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 
-# A scoring engine check that logs into NFS, writes file
-# and then logs into NFL again, and reads the file
+# A scoring engine check that mounts an NFS share, writes a file,
+# and then reads the file back to verify the contents
 
+import os
 import sys
-import libnfs
+import subprocess
+import tempfile
 
 if len(sys.argv) != 4:
     print("Usage: " + sys.argv[0] + " host remotefilepath filecontents")
@@ -14,23 +16,40 @@ host = sys.argv[1]
 remote_filepath = sys.argv[2]
 upload_file_contents = sys.argv[3]
 
-# Connect and Upload file to server
-try:
-    nfs = libnfs.open('nfs://{0}{1}'.format(host, remote_filepath), mode='w')
-    nfs.write(upload_file_contents)
-    nfs.close()
-except Exception as err:
-    print("ERROR: {0}".format(err))
-    sys.exit(1)
+remote_dir = os.path.dirname(remote_filepath)
+remote_name = os.path.basename(remote_filepath)
 
-# Connect and Download file
-try:
-    downloaded_lines = libnfs.open('nfs://{0}{1}'.format(host, remote_filepath), mode='r').read()
-except Exception as err:
-    print("ERROR: {0}".format(err))
-    sys.exit(1)
+with tempfile.TemporaryDirectory() as mount_dir:
+    mounted = False
+    try:
+        subprocess.run([
+            "sudo",
+            "mount",
+            "-t",
+            "nfs",
+            f"{host}:{remote_dir}",
+            mount_dir,
+        ], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        mounted = True
+    except subprocess.CalledProcessError as err:
+        print(f"ERROR: {err.stderr.decode().strip()}")
+        sys.exit(1)
 
-downloaded_data = ''.join(downloaded_lines)
+    try:
+        remote_file = os.path.join(mount_dir, remote_name)
+        with open(remote_file, "w") as fh:
+            fh.write(upload_file_contents)
+        with open(remote_file, "r") as fh:
+            downloaded_data = fh.read()
+    except Exception as err:
+        print(f"ERROR: {err}")
+        if mounted:
+            subprocess.run(["sudo", "umount", mount_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        sys.exit(1)
+
+    if mounted:
+        subprocess.run(["sudo", "umount", mount_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
 if downloaded_data != upload_file_contents:
     print("ERROR: Uploaded contents do not match downloaded contents")
     sys.exit(1)


### PR DESCRIPTION
## Summary
- use nfs-common instead of libnfs for NFS checks
- allow worker to mount and unmount shares via sudo
- rewrite NFS check to mount shares and read/write using standard file operations
- update NFS documentation and install instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac551d6dfc832988f37c9dafe421ca