### PR TITLE
docs: clarify AGENTS guide testing expectations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS
+
+This file contains guidelines for navigating and working with the repository.
+
+## Repository structure
+- `scoring_engine/`: core application code for the scoring engine.
+- `tests/`: automated tests for the project.
+- `docs/`: documentation source files.
+- `configs/`: configuration samples and templates.
+- `bin/`: helper scripts and entry points.
+
+## Conventions
+- Use `rg` (ripgrep) for searching across the repository instead of `grep -R`.
+- Keep code style consistent with existing files and run `pre-commit run --files <files>` on modified files before committing.
+- Write tests for new functionality and bug fixes, placing them under `tests/` mirroring the module structure. When a change cannot be reasonably tested, note this in the pull request.
+
+## Testing
+- Run `pytest` to execute the test suite.
+- Use `pytest <path>` to run a subset of tests when working on a specific area.
+
+## Additional notes
+- Ensure documentation updates accompany code changes when relevant.
+- Commits should be scoped and descriptive.


### PR DESCRIPTION
## Summary
- expand AGENTS instructions to emphasize adding tests for new features and bug fixes, or noting why tests aren't feasible

## Testing
- `pre-commit run --files AGENTS.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_68ae710edf3483298e66462319d69f72