### PR TITLE
Add tests for low coverage API modules

### DIFF
--- a/tests/scoring_engine/web/views/test_api.py
+++ b/tests/scoring_engine/web/views/test_api.py
@@ -1,10 +1,13 @@
 import json
+from datetime import datetime, timedelta
 
-from scoring_engine.models.team import Team
-from scoring_engine.models.service import Service
-from scoring_engine.models.round import Round
 from scoring_engine.models.check import Check
-
+from scoring_engine.models.environment import Environment
+from scoring_engine.models.inject import Inject, Template
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.team import Team
+from scoring_engine.web.views.api.service import is_valid_user_input
 from tests.scoring_engine.web.web_test import WebTest
 
 
@@ -15,24 +18,24 @@ class TestAPI(WebTest):
         self.create_default_user()
 
     def test_auth_required_admin_get_round_progress(self):
-        self.verify_auth_required('/api/admin/get_round_progress')
+        self.verify_auth_required("/api/admin/get_round_progress")
 
     def test_auth_required_admin_get_teams(self):
-        self.verify_auth_required('/api/admin/get_teams')
+        self.verify_auth_required("/api/admin/get_teams")
 
     def test_auth_required_admin_update_password(self):
-        self.verify_auth_required_post('/api/admin/update_password')
+        self.verify_auth_required_post("/api/admin/update_password")
 
     def test_auth_required_admin_add_user(self):
-        self.verify_auth_required_post('/api/admin/add_user')
+        self.verify_auth_required_post("/api/admin/add_user")
 
     def test_auth_required_profile_update_password(self):
-        self.verify_auth_required_post('/api/profile/update_password')
+        self.verify_auth_required_post("/api/profile/update_password")
 
     def test_auth_required_service_get_checks_id(self):
-        self.verify_auth_required('/api/service/1/checks')
+        self.verify_auth_required("/api/service/1/checks")
 
-    '''
+    """
     def test_api_scoreboard_get_bar_data(self):
         resp = self.client.get('api/scoreboard/get_bar_data')
         assert resp.status_code == 200
@@ -40,11 +43,11 @@ class TestAPI(WebTest):
     def test_api_scoreboard_get_line_data(self):
         resp = self.client.get('/api/scoreboard/get_line_data')
         assert resp.status_code == 200
-    '''
+    """
 
     def test_overview_data_no_teams(self):
-        overview_data = self.client.get('/api/overview/data')
-        assert json.loads(overview_data.data.decode('utf8')) == {}
+        overview_data = self.client.get("/api/overview/data")
+        assert json.loads(overview_data.data.decode("utf8")) == {}
 
     def test_overview_data(self):
         # create 1 white team, 1 red team, 5 blue teams, 3 services per team, 5 checks per service
@@ -83,53 +86,122 @@ class TestAPI(WebTest):
         }
         for team_num in range(1, 6):
             team = Team(name="team" + str(team_num), color="Blue")
-            icmp_service = Service(name="ICMP", team=team, check_name="ICMP IPv4 Check", host="127.0.0.1")
-            dns_service = Service(name="DNS", team=team, check_name="DNSCheck", host="8.8.8.8", port=53)
-            ftp_service = Service(name='FTP', team=team, check_name='FTPCheck', host='1.2.3.4', port=21)
+            icmp_service = Service(
+                name="ICMP", team=team, check_name="ICMP IPv4 Check", host="127.0.0.1"
+            )
+            dns_service = Service(
+                name="DNS", team=team, check_name="DNSCheck", host="8.8.8.8", port=53
+            )
+            ftp_service = Service(
+                name="FTP", team=team, check_name="FTPCheck", host="1.2.3.4", port=21
+            )
             self.session.add(icmp_service)
             self.session.add(dns_service)
             self.session.add(ftp_service)
             # 5 rounds of checks
             round_1 = Round(number=1)
-            icmp_check_1 = Check(round=round_1, service=icmp_service, result=True, output="example_output")
-            dns_check_1 = Check(round=round_1, service=dns_service, result=False, output="example_output")
-            ftp_check_1 = Check(round=round_1, service=ftp_service, result=True, output="example_output")
+            icmp_check_1 = Check(
+                round=round_1,
+                service=icmp_service,
+                result=True,
+                output="example_output",
+            )
+            dns_check_1 = Check(
+                round=round_1,
+                service=dns_service,
+                result=False,
+                output="example_output",
+            )
+            ftp_check_1 = Check(
+                round=round_1, service=ftp_service, result=True, output="example_output"
+            )
             self.session.add(round_1)
             self.session.add(icmp_check_1)
             self.session.add(dns_check_1)
             self.session.add(ftp_check_1)
 
             round_2 = Round(number=2)
-            icmp_check_2 = Check(round=round_2, service=icmp_service, result=True, output="example_output")
-            dns_check_2 = Check(round=round_2, service=dns_service, result=True, output="example_output")
-            ftp_check_2 = Check(round=round_2, service=ftp_service, result=True, output="example_output")
+            icmp_check_2 = Check(
+                round=round_2,
+                service=icmp_service,
+                result=True,
+                output="example_output",
+            )
+            dns_check_2 = Check(
+                round=round_2, service=dns_service, result=True, output="example_output"
+            )
+            ftp_check_2 = Check(
+                round=round_2, service=ftp_service, result=True, output="example_output"
+            )
             self.session.add(round_2)
             self.session.add(icmp_check_2)
             self.session.add(dns_check_2)
             self.session.add(ftp_check_2)
 
             round_3 = Round(number=3)
-            icmp_check_3 = Check(round=round_3, service=icmp_service, result=True, output="example_output")
-            dns_check_3 = Check(round=round_3, service=dns_service, result=False, output="example_output")
-            ftp_check_3 = Check(round=round_3, service=ftp_service, result=True, output="example_output")
+            icmp_check_3 = Check(
+                round=round_3,
+                service=icmp_service,
+                result=True,
+                output="example_output",
+            )
+            dns_check_3 = Check(
+                round=round_3,
+                service=dns_service,
+                result=False,
+                output="example_output",
+            )
+            ftp_check_3 = Check(
+                round=round_3, service=ftp_service, result=True, output="example_output"
+            )
             self.session.add(round_3)
             self.session.add(icmp_check_3)
             self.session.add(dns_check_3)
             self.session.add(ftp_check_3)
 
             round_4 = Round(number=4)
-            icmp_check_4 = Check(round=round_4, service=icmp_service, result=False, output="example_output")
-            dns_check_4 = Check(round=round_4, service=dns_service, result=False, output="example_output")
-            ftp_check_4 = Check(round=round_4, service=ftp_service, result=False, output="example_output")
+            icmp_check_4 = Check(
+                round=round_4,
+                service=icmp_service,
+                result=False,
+                output="example_output",
+            )
+            dns_check_4 = Check(
+                round=round_4,
+                service=dns_service,
+                result=False,
+                output="example_output",
+            )
+            ftp_check_4 = Check(
+                round=round_4,
+                service=ftp_service,
+                result=False,
+                output="example_output",
+            )
             self.session.add(round_4)
             self.session.add(icmp_check_4)
             self.session.add(dns_check_4)
             self.session.add(ftp_check_4)
 
             round_5 = Round(number=5)
-            icmp_check_5 = Check(round=round_5, service=icmp_service, result=last_check_results[team.name]['ICMP'], output="example_output")
-            dns_check_5 = Check(round=round_5, service=dns_service, result=last_check_results[team.name]['DNS'], output="example_output")
-            ftp_check_5 = Check(round=round_5, service=ftp_service, result=last_check_results[team.name]['FTP'], output="example_output")
+            icmp_check_5 = Check(
+                round=round_5,
+                service=icmp_service,
+                result=last_check_results[team.name]["ICMP"],
+                output="example_output",
+            )
+            dns_check_5 = Check(
+                round=round_5,
+                service=dns_service,
+                result=last_check_results[team.name]["DNS"],
+                output="example_output",
+            )
+            ftp_check_5 = Check(
+                round=round_5,
+                service=ftp_service,
+                result=last_check_results[team.name]["FTP"],
+                output="example_output",
+            )
             self.session.add(round_5)
             self.session.add(icmp_check_5)
             self.session.add(dns_check_5)
@@ -139,34 +211,100 @@ class TestAPI(WebTest):
             self.session.commit()
             teams.append(team)
 
-        overview_data = self.client.get('/api/overview/data')
-        overview_dict = json.loads(overview_data.data.decode('utf8'))
+        overview_data = self.client.get("/api/overview/data")
+        overview_dict = json.loads(overview_data.data.decode("utf8"))
         expected_dict = {
-            'team1': {
-                'FTP': {'passing': True, 'host': '1.2.3.4', 'port': 21},
-                'DNS': {'passing': True, 'host': '8.8.8.8', 'port': 53},
-                'ICMP': {'passing': True, 'host': '127.0.0.1', 'port': 0}},
-            'team2': {
-                'FTP': {'passing': False, 'host': '1.2.3.4', 'port': 21},
-                'DNS': {'passing': True, 'host': '8.8.8.8', 'port': 53},
-                'ICMP': {'passing': True, 'host': '127.0.0.1', 'port': 0}},
-            'team3': {
-                'FTP': {'passing': False, 'host': '1.2.3.4', 'port': 21},
-                'DNS': {'passing': True, 'host': '8.8.8.8', 'port': 53},
-                'ICMP': {'passing': False, 'host': '127.0.0.1', 'port': 0}},
-            'team4': {
-                'FTP': {'passing': True, 'host': '1.2.3.4', 'port': 21},
-                'DNS': {'passing': False, 'host': '8.8.8.8', 'port': 53},
-                'ICMP': {'passing': False, 'host': '127.0.0.1', 'port': 0}},
-            'team5': {
-                'FTP': {'passing': False, 'host': '1.2.3.4', 'port': 21},
-                'DNS': {'passing': False, 'host': '8.8.8.8', 'port': 53},
-                'ICMP': {'passing': False, 'host': '127.0.0.1', 'port': 0}
-            }
+            "team1": {
+                "FTP": {"passing": True, "host": "1.2.3.4", "port": 21},
+                "DNS": {"passing": True, "host": "8.8.8.8", "port": 53},
+                "ICMP": {"passing": True, "host": "127.0.0.1", "port": 0},
+            },
+            "team2": {
+                "FTP": {"passing": False, "host": "1.2.3.4", "port": 21},
+                "DNS": {"passing": True, "host": "8.8.8.8", "port": 53},
+                "ICMP": {"passing": True, "host": "127.0.0.1", "port": 0},
+            },
+            "team3": {
+                "FTP": {"passing": False, "host": "1.2.3.4", "port": 21},
+                "DNS": {"passing": True, "host": "8.8.8.8", "port": 53},
+                "ICMP": {"passing": False, "host": "127.0.0.1", "port": 0},
+            },
+            "team4": {
+                "FTP": {"passing": True, "host": "1.2.3.4", "port": 21},
+                "DNS": {"passing": False, "host": "8.8.8.8", "port": 53},
+                "ICMP": {"passing": False, "host": "127.0.0.1", "port": 0},
+            },
+            "team5": {
+                "FTP": {"passing": False, "host": "1.2.3.4", "port": 21},
+                "DNS": {"passing": False, "host": "8.8.8.8", "port": 53},
+                "ICMP": {"passing": False, "host": "127.0.0.1", "port": 0},
+            },
         }
         assert sorted(overview_dict.items()) == sorted(expected_dict.items())
 
     def test_get_engine_stats(self):
-        resp = self.auth_and_get_path('/api/admin/get_engine_stats')
-        resp_json = json.loads(resp.data.decode('ascii'))
-        assert resp_json == {'num_passed_checks': 0, 'total_checks': 0, 'round_number': 0, 'num_failed_checks': 0}
+        resp = self.auth_and_get_path("/api/admin/get_engine_stats")
+        resp_json = json.loads(resp.data.decode("ascii"))
+        assert resp_json == {
+            "num_passed_checks": 0,
+            "total_checks": 0,
+            "round_number": 0,
+            "num_failed_checks": 0,
+        }
+
+    def test_admin_update_environment(self):
+        self.login("testuser", "testpass")
+        team = self.session.query(Team).first()
+        service = Service(
+            name="Example", check_name="ICMP IPv4 Check", host="1.2.3.4", team=team
+        )
+        env = Environment(service=service, matching_content="old")
+        self.session.add_all([service, env])
+        self.session.commit()
+        resp = self.client.post(
+            "/api/admin/update_environment_info",
+            data={"pk": env.id, "name": "matching_content", "value": "new"},
+        )
+        assert resp.json == {"status": "Updated Environment Information"}
+        self.session.refresh(env)
+        assert env.matching_content == "new"
+
+    def test_service_update_host_invalid_input(self):
+        self.login("testuser", "testpass")
+        team = self.session.query(Team).first()
+        service = Service(
+            name="Example", check_name="ICMP IPv4 Check", host="1.2.3.4", team=team
+        )
+        self.session.add(service)
+        self.session.commit()
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": service.id, "name": "host", "value": "bad host"},
+        )
+        assert resp.json == {"error": "Invalid input characters detected"}
+
+    def test_is_valid_user_input(self):
+        assert is_valid_user_input("abc123", True, False)
+        assert not is_valid_user_input("bad host", True, False)
+        assert is_valid_user_input("12345", False, True)
+        assert not is_valid_user_input("12a", False, True)
+        assert is_valid_user_input("hello world", False, False)
+        assert not is_valid_user_input(" leading", False, False)
+
+    def test_inject_add_comment_no_comment(self):
+        self.login("testuser", "testpass")
+        team = self.session.query(Team).first()
+        template = Template(
+            title="t",
+            scenario="s",
+            deliverable="d",
+            score=10,
+            start_time=datetime.utcnow() - timedelta(hours=1),
+            end_time=datetime.utcnow() + timedelta(hours=1),
+        )
+        inject = Inject(team=team, template=template)
+        self.session.add_all([template, inject])
+        self.session.commit()
+        resp = self.client.post(f"/api/inject/{inject.id}/comment", json={})
+        assert resp.status_code == 400
+        assert resp.json == {"status": "No comment"}


### PR DESCRIPTION
## Summary
- cover admin environment update endpoint
- validate service host update and input helper
- exercise inject comment submission error handling

## Testing
- `pre-commit run --files tests/scoring_engine/web/views/test_api.py`
- `pytest --cov=scoring_engine --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_68aef7588b708329981778e9b0911aa7