### PR TITLE
refactor scoreboard chart scripts

### DIFF
--- a/scoring_engine/web/templates/scoreboard.html
+++ b/scoring_engine/web/templates/scoreboard.html
@@ -11,182 +11,126 @@
     <div id="teamLine" style="width: 100%; height:400px;"></div>
     <script>
         // Bar chart for all teams
-        var teamBarChart = echarts.init(document.getElementById('teamBar'));
+        const teamBarChart = echarts.init(document.getElementById('teamBar'));
         teamBarChart.showLoading();
 
-        const serviceScores = [];
-        const injectScores = [];
-        // const totalScores = [];
+        const fetchBarData = async () => {
+            const response = await fetch('/api/scoreboard/get_bar_data');
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return response.json();
+        };
 
-        $.getJSON('/api/scoreboard/get_bar_data').done(function (data) {
-            // Service Scores
-            echarts.util.each(data.service_scores, function (score, index) {
-                serviceScores.push({
-                    value: score,
-                    // itemStyle: {
-                    //     color: '#5470c6'
-                    // }
-                });
-            });
-            // Inject Scores
-            echarts.util.each(data.inject_scores, function (score, index) {
-                injectScores.push({
-                    value: score,
-                    // itemStyle: {
-                    //     color: '#ee6666'
-                    // }
-                });
-            });
-            // Total
-            // for( var i = 0; i < serviceScores.length; i++)
-            // {
-            //     // Unary to convert to number
-            //     totalScores.push(+serviceScores[i].value + +injectScores[i].value);
-            // }
-            teamBarChart.hideLoading();
-            teamBarChart.setOption({
-                title: {
-                    text: 'Total Scores',
-                    x: 'center',
-                },
-                tooltip: {
-                    trigger: 'axis'
-                },
-                grid: {
-                    left: '3%',
-                    right: '4%',
-                    bottom: '3%',
-                    containLabel: true
-                },
-                xAxis: [
-                    {
-                        type: 'category',
-                        data: data.labels,
-                    }
-                ],
-                yAxis: {
-                    type: 'value'
-                },
-                series: [
-                    {
-                        name: 'Services',
-                        data: serviceScores,
-                        type: 'bar',
-                        stack: 'x',
-                        // label: {
-                        //     show: true
-                        // },
-                    },
-                    {
-                        name: 'Injects',
-                        data: injectScores,
-                        type: 'bar',
-                        stack: 'x',
-                        // label: {
-                        //     show: true
-                        // },
+        const updateBarChart = async () => {
+            try {
+                const data = await fetchBarData();
+                const serviceScores = data.service_scores.map((score) => ({ value: score }));
+                const injectScores = data.inject_scores.map((score) => ({ value: score }));
 
-                    },
-                    // {
-                    //     name: 'Total',
-                    //     data: totalScores,
-                    //     type: 'bar',
-                    //     stack: 'x',
-                    // },
-                ]
-            });
-        });
-
-        // Update chart every 30 seconds
-        setInterval(function () {
-            const serviceScores = [];
-            const injectScores = [];
-            $.get('/api/scoreboard/get_bar_data').done(function (data) {
-                // Service Scores
-                echarts.util.each(data.service_scores, function (score, index) {
-                    serviceScores.push({
-                        value: score,
-                    });
-                });
-                // Inject Scores
-                echarts.util.each(data.inject_scores, function (score, index) {
-                    injectScores.push({
-                        value: score,
-                    });
-                });
+                teamBarChart.hideLoading();
                 teamBarChart.setOption({
+                    title: {
+                        text: 'Total Scores',
+                        x: 'center',
+                    },
+                    tooltip: {
+                        trigger: 'axis'
+                    },
+                    grid: {
+                        left: '3%',
+                        right: '4%',
+                        bottom: '3%',
+                        containLabel: true
+                    },
+                    xAxis: [
+                        {
+                            type: 'category',
+                            data: data.labels,
+                        }
+                    ],
+                    yAxis: {
+                        type: 'value'
+                    },
                     series: [
-                        { data: serviceScores },
-                        { data: injectScores }
+                        {
+                            name: 'Services',
+                            data: serviceScores,
+                            type: 'bar',
+                            stack: 'x',
+                        },
+                        {
+                            name: 'Injects',
+                            data: injectScores,
+                            type: 'bar',
+                            stack: 'x',
+                        },
                     ]
                 });
-            });
-        }, 30000);
+            } catch (error) {
+                console.error('Unable to load bar chart data', error);
+            }
+        };
+
+        updateBarChart();
+        setInterval(updateBarChart, 30000);
     </script>
     <script>
         // Line chart for all teams
-        var teamLineChart = echarts.init(document.getElementById('teamLine'));
+        const teamLineChart = echarts.init(document.getElementById('teamLine'));
         teamLineChart.showLoading();
 
-        const seriesList = [];
-        $.getJSON('/api/scoreboard/get_line_data').done(function (data) {
-            echarts.util.each(data.team, function (team) {
-                seriesList.push({
+        const fetchLineData = async () => {
+            const response = await fetch('/api/scoreboard/get_line_data');
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return response.json();
+        };
+
+        const updateLineChart = async () => {
+            try {
+                const data = await fetchLineData();
+                const seriesList = data.team.map((team) => ({
                     name: team.name,
                     type: 'line',
                     data: team.scores,
-                    itemStyle: {
-                        color: team.color
-                    },
+                    itemStyle: { color: team.color },
                     showSymbol: false
-                });
-            });
-            teamLineChart.hideLoading();
-            teamLineChart.setOption({
-                title: {
-                    text: 'Service Scores',
-                    x: 'center',
-                },
-                tooltip: {
-                    trigger: 'axis'
-                },
-                grid: {
-                    left: '3%',
-                    right: '4%',
-                    bottom: '3%',
-                    containLabel: true
-                },
-                xAxis: {
-                    type: 'category',
-                    boundaryGap: false,
-                    data: data.rounds
-                },
-                yAxis: {
-                    type: 'value'
-                },
-                series: seriesList,
-                // label: {
-                //     show: true
-                // },
-            });
-        });
+                }));
 
-        // Update chart every 30 seconds
-        setInterval(function () {
-            const seriesList = [];
-            $.get('/api/scoreboard/get_line_data').done(function (data) {
-                echarts.util.each(data.team, function (team) {
-                    seriesList.push({
-                        name: team.name,
-                        type: 'line',
-                        data: team.scores,
-                    });
-                });
+                teamLineChart.hideLoading();
                 teamLineChart.setOption({
+                    title: {
+                        text: 'Service Scores',
+                        x: 'center',
+                    },
+                    tooltip: {
+                        trigger: 'axis'
+                    },
+                    grid: {
+                        left: '3%',
+                        right: '4%',
+                        bottom: '3%',
+                        containLabel: true
+                    },
+                    xAxis: {
+                        type: 'category',
+                        boundaryGap: false,
+                        data: data.rounds
+                    },
+                    yAxis: {
+                        type: 'value'
+                    },
                     series: seriesList,
                 });
-            });
-        }, 30000);
+            } catch (error) {
+                console.error('Unable to load line chart data', error);
+            }
+        };
+
+        updateLineChart();
+        setInterval(updateLineChart, 30000);
     </script>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- modernize scoreboard charts with fetch and async/await
- consolidate chart update logic into reusable functions
- switch to const and arrow functions for cleaner code

## Testing
- `pre-commit run --files scoring_engine/web/templates/scoreboard.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aef7822aec8329a7c2f7bd57533028