### PR TITLE
Add setup wizard for unconfigured engine

### DIFF
--- a/scoring_engine/web/__init__.py
+++ b/scoring_engine/web/__init__.py
@@ -36,6 +36,7 @@ def create_app():
         api,
         admin,
         about,
+        setup,
     )
 
     cache.init_app(app)
@@ -69,5 +70,6 @@ def create_app():
     app.register_blueprint(api.mod)
     app.register_blueprint(admin.mod)
     app.register_blueprint(about.mod)
+    app.register_blueprint(setup.mod)
 
     return app

--- a/scoring_engine/web/templates/setup.html
+++ b/scoring_engine/web/templates/setup.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container md-page">
+  {% if step == 1 %}
+  <h3>Create Admin Account</h3>
+  <form method="post">
+    <div class="form-group">
+      <input class="form-control" type="text" name="username" placeholder="Username" required>
+    </div>
+    <div class="form-group">
+      <input class="form-control" type="password" name="password" placeholder="Password" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Next</button>
+  </form>
+
+  {% elif step == 2 %}
+  <h3>Number of Teams</h3>
+  <form method="post">
+    <div class="form-group">
+      <input class="form-control" type="number" name="num_teams" value="1" min="1" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Next</button>
+  </form>
+
+  {% elif step == 3 %}
+  <h3>Add Services</h3>
+  <form method="post">
+    <div class="form-group">
+      <input class="form-control" type="text" name="service_name" placeholder="Service Name" required>
+    </div>
+    <div class="form-group">
+      <select class="form-control" name="check_name">
+        {% for check in checks %}
+        <option value="{{ check }}">{{ check }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="form-group">
+      <input class="form-control" type="text" name="host" placeholder="Host" required>
+    </div>
+    <div class="form-group">
+      <input class="form-control" type="number" name="port" value="0" required>
+    </div>
+    <div class="form-group">
+      <input class="form-control" type="number" name="points" value="100" required>
+    </div>
+    <div class="form-group">
+      <input class="form-control" type="text" name="matching_content" value="SUCCESS" placeholder="Matching Content">
+    </div>
+    <div class="form-group">
+      <textarea class="form-control" name="properties" placeholder="key=value per line"></textarea>
+    </div>
+    <button type="submit" name="action" value="add" class="btn btn-secondary">Add Service</button>
+    <button type="submit" name="action" value="finish" class="btn btn-primary">Finish</button>
+  </form>
+  {% if services %}
+  <h4>Configured Services</h4>
+  <ul>
+    {% for svc in services %}
+    <li>{{ svc['name'] }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+  {% else %}
+  <h3>Setup Complete</h3>
+  {% if competition_exists %}
+  <a class="btn btn-primary" href="{{ url_for('setup.export') }}">Download competition.yaml</a>
+  {% else %}
+  <p>No competition file generated.</p>
+  {% endif %}
+  {% endif %}
+</div>
+{% endblock %}
+

--- a/scoring_engine/web/views/setup.py
+++ b/scoring_engine/web/views/setup.py
@@ -1,0 +1,138 @@
+import os
+import yaml
+
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    session as flask_session,
+    send_file,
+)
+
+from scoring_engine.db import session as db_session
+from scoring_engine.engine.engine import Engine
+from scoring_engine.competition import Competition
+
+mod = Blueprint("setup", __name__)
+
+
+def competition_file_path():
+    return os.path.abspath(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "..",
+            "..",
+            "..",
+            "bin",
+            "competition.yaml",
+        )
+    )
+
+
+@mod.route("/setup", methods=["GET", "POST"])
+def setup():
+    comp_path = competition_file_path()
+    step = int(request.args.get("step", 1))
+    data = flask_session.get("setup", {})
+
+    if step == 1:
+        if request.method == "POST":
+            data["admin"] = {
+                "username": request.form.get("username", "admin"),
+                "password": request.form.get("password", "changeme"),
+            }
+            flask_session["setup"] = data
+            return redirect(url_for("setup.setup", step=2))
+        return render_template("setup.html", step=1)
+
+    if step == 2:
+        if request.method == "POST":
+            data["num_teams"] = int(request.form.get("num_teams", 1))
+            flask_session["setup"] = data
+            return redirect(url_for("setup.setup", step=3))
+        return render_template("setup.html", step=2)
+
+    if step == 3:
+        checks_dir = os.path.abspath(
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "checks")
+        )
+        available_checks = Engine.load_check_files(checks_dir)
+        check_names = [c.__name__ for c in available_checks]
+        if request.method == "POST":
+            service = {
+                "name": request.form.get("service_name"),
+                "check_name": request.form.get("check_name"),
+                "host": request.form.get("host"),
+                "port": int(request.form.get("port", 0)),
+                "points": int(request.form.get("points", 100)),
+            }
+            matching_content = request.form.get("matching_content", "SUCCESS")
+            props_raw = request.form.get("properties", "")
+            properties = []
+            for line in props_raw.splitlines():
+                if line.strip():
+                    key, value = line.split("=", 1)
+                    properties.append({"name": key.strip(), "value": value.strip()})
+            env = {"matching_content": matching_content}
+            if properties:
+                env["properties"] = properties
+            service["environments"] = [env]
+            services = data.get("services", [])
+            services.append(service)
+            data["services"] = services
+            flask_session["setup"] = data
+            if request.form.get("action") == "finish":
+                teams = [
+                    {
+                        "name": "White Team",
+                        "color": "White",
+                        "users": [
+                            {
+                                "username": data["admin"]["username"],
+                                "password": data["admin"]["password"],
+                            }
+                        ],
+                    }
+                ]
+                services_config = data.get("services", [])
+                for i in range(1, data.get("num_teams", 1) + 1):
+                    teams.append(
+                        {
+                            "name": f"Team {i}",
+                            "color": "Blue",
+                            "users": [
+                                {
+                                    "username": f"team{i}user1",
+                                    "password": "changeme",
+                                }
+                            ],
+                            "services": services_config,
+                        }
+                    )
+
+                competition_dict = {"teams": teams, "flags": []}
+                yaml_str = yaml.dump(competition_dict, sort_keys=False)
+                os.makedirs(os.path.dirname(comp_path), exist_ok=True)
+                with open(comp_path, "w") as f:
+                    f.write(yaml_str)
+                competition = Competition.parse_yaml_str(yaml_str)
+                competition.save(db_session)
+                return redirect(url_for("setup.setup", step=4))
+            return redirect(url_for("setup.setup", step=3))
+        return render_template(
+            "setup.html", step=3, checks=check_names, services=data.get("services", [])
+        )
+
+    competition_exists = os.path.exists(comp_path)
+    return render_template("setup.html", step=4, competition_exists=competition_exists)
+
+
+@mod.route("/setup/export")
+def export():
+    comp_path = competition_file_path()
+    if os.path.exists(comp_path):
+        return send_file(comp_path, as_attachment=True, download_name="competition.yaml")
+    return redirect(url_for("setup.setup"))
+

--- a/scoring_engine/web/views/welcome.py
+++ b/scoring_engine/web/views/welcome.py
@@ -1,6 +1,10 @@
-from flask import Blueprint, render_template
+import os
+from flask import Blueprint, render_template, redirect, url_for
 
+from scoring_engine.db import session
 from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from .setup import competition_file_path
 
 mod = Blueprint('welcome', __name__)
 
@@ -8,5 +12,9 @@ mod = Blueprint('welcome', __name__)
 @mod.route('/')
 @mod.route("/index")
 def home():
+    comp_exists = os.path.exists(competition_file_path())
+    teams_exist = session.query(Team).count() > 0
+    if not comp_exists or not teams_exist:
+        return redirect(url_for('setup.setup'))
     welcome_content = Setting.get_setting('welcome_page_content').value
     return render_template('welcome.html', welcome_content=welcome_content)

--- a/tests/scoring_engine/web/views/test_setup.py
+++ b/tests/scoring_engine/web/views/test_setup.py
@@ -1,0 +1,60 @@
+import tempfile
+from pathlib import Path
+from mock import patch
+
+from tests.scoring_engine.web.web_test import WebTest
+
+
+class TestSetup(WebTest):
+    def test_redirect_when_no_teams(self):
+        resp = self.client.get("/")
+        assert resp.status_code == 302
+        assert resp.location.endswith("/setup")
+
+    def test_redirect_when_missing_competition(self):
+        self.create_default_user()
+        with patch(
+            "scoring_engine.web.views.welcome.os.path.exists", return_value=False
+        ):
+            resp = self.client.get("/")
+        assert resp.status_code == 302
+        assert resp.location.endswith("/setup")
+
+    def test_wizard_creates_competition_yaml(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        comp_file = Path(tmp_dir.name) / "competition.yaml"
+        with patch(
+            "scoring_engine.web.views.setup.competition_file_path",
+            return_value=str(comp_file),
+        ):
+            resp = self.client.post(
+                "/setup?step=1",
+                data={"username": "admin", "password": "pass"},
+            )
+            assert resp.status_code == 302
+            assert resp.location.endswith("step=2")
+
+            resp = self.client.post(
+                "/setup?step=2", data={"num_teams": "1"}
+            )
+            assert resp.status_code == 302
+            assert resp.location.endswith("step=3")
+
+            resp = self.client.post(
+                "/setup?step=3",
+                data={
+                    "service_name": "Web",
+                    "check_name": "HTTPCheck",
+                    "host": "localhost",
+                    "port": "80",
+                    "points": "100",
+                    "matching_content": "OK",
+                    "properties": "useragent=UA\nvhost=example.com\nuri=/",
+                    "action": "finish",
+                },
+            )
+            assert resp.status_code == 302
+            assert resp.location.endswith("step=4")
+            assert comp_file.exists()
+        tmp_dir.cleanup()
+


### PR DESCRIPTION
## Summary
- Provide interactive setup wizard to build competition.yaml and bootstrap database
- Allow admins to create accounts, specify team count, configure services, and export config
- Cover wizard flow with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae71b9677c832993ae2ed64806aa9c