### PR TITLE
Refactor setup script handling

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,70 +1,34 @@
 #!/usr/bin/env python
+"""Populate the Scoring Engine database with default or example data."""
+
+from __future__ import annotations
+
+import argparse
+import os
 from datetime import datetime, timedelta
 from random import choice, randint, sample
 
-import optparse
-import os
-
-from scoring_engine.models.inject import Template, Inject
-from scoring_engine.models.team import Team
-from scoring_engine.models.service import Service
-from scoring_engine.models.round import Round
-from scoring_engine.models.check import Check
-from scoring_engine.models.flag import Flag, Solve
-
-from scoring_engine.models.notifications import Notification
-from scoring_engine.models.setting import Setting
-from scoring_engine.db import session, init_db, delete_db, verify_db_ready
-from scoring_engine.config import config
 from scoring_engine.competition import Competition
-from scoring_engine.logger import logger
-from scoring_engine.version import version
+from scoring_engine.config import config
+from scoring_engine.db import delete_db, init_db, session, verify_db_ready
 from scoring_engine.engine.basic_check import (
-    CHECK_SUCCESS_TEXT,
     CHECK_FAILURE_TEXT,
+    CHECK_SUCCESS_TEXT,
     CHECK_TIMED_OUT_TEXT,
 )
+from scoring_engine.logger import logger
+from scoring_engine.models.check import Check
+from scoring_engine.models.flag import Flag, Solve
+from scoring_engine.models.inject import Inject, Template
+from scoring_engine.models.notifications import Notification
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.version import version
 
 
-parser = optparse.OptionParser()
-parser.add_option("--overwrite-db", action="store_true", default=False)
-parser.add_option("--example", action="store_true", default=False)
-
-options, arguments = parser.parse_args()
-
-# In order to handle docker-compose usability
-# we have a check to see if the SCORINGENGINE_EXAMPLE environment
-# variable is true. If it is, we want to populate
-# the db with example data
-if "SCORINGENGINE_EXAMPLE" in os.environ and os.environ["SCORINGENGINE_EXAMPLE"].lower() == "true":
-    options.overwrite_db = True
-    options.example = True
-
-# If the SCORINGENGINE_OVERWRITE_DB environment variable is set
-# we want to delete any previous data in the db
-if "SCORINGENGINE_OVERWRITE_DB" in os.environ and os.environ["SCORINGENGINE_OVERWRITE_DB"].lower() == "true":
-    options.overwrite_db = os.environ["SCORINGENGINE_OVERWRITE_DB"] == "true"
-
-logger.info("Starting Setup v.{0}".format(version))
-
-if not options.overwrite_db:
-    if verify_db_ready(session):
-        logger.error("Exiting script and not overwriting db...must use --overwrite-db to overwrite data.")
-        exit()
-    else:
-        # Database doesn't exist, so continuing on to setup script
-        logger.debug("Database doesn't exist yet...")
-
-logger.info("Setting up DB")
-delete_db(session)
-init_db(session)
-
-competition_config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "competition.yaml")
-sample_competition_str = open(competition_config_file, "r").read()
-competition = Competition.parse_yaml_str(sample_competition_str)
-competition.save(session)
-
-about_content = """
+ABOUT_CONTENT = """
 <h4>Use the following credentials to login</h4>
 <ul>
     <li>whiteteamuser:testpass</li>
@@ -75,7 +39,7 @@ about_content = """
     <li>team10user1:testpass</li>
 </ul>"""
 
-welcome_content = """
+WELCOME_CONTENT = """
 <div class="row">
     <h1 class="text-center">Diamond Sponsors</h1>
 </div>
@@ -138,36 +102,134 @@ welcome_content = """
 </div>
 """
 
-logger.info("Creating the default Settings")
-session.add(Setting(name="about_page_content", value=about_content))
-session.add(Setting(name="welcome_page_content", value=welcome_content))
-session.add(Setting(name="target_round_time", value=config.target_round_time))
-session.add(Setting(name="worker_refresh_time", value=config.worker_refresh_time))
-session.add(Setting(name="engine_paused", value=config.engine_paused))
-session.add(Setting(name="pause_duration", value=config.pause_duration))
-session.add(Setting(name="blue_team_update_hostname", value=config.blue_team_update_hostname))
-session.add(Setting(name="blue_team_update_port", value=config.blue_team_update_port))
-session.add(Setting(name="blue_team_update_account_usernames", value=config.blue_team_update_account_usernames))
-session.add(Setting(name="blue_team_update_account_passwords", value=config.blue_team_update_account_passwords))
-session.add(Setting(name="blue_team_view_check_output", value=config.blue_team_view_check_output))
-session.add(Setting(name="agent_checkin_interval_sec", value=config.target_round_time // 5))
-session.add(Setting(name="agent_show_flag_early_mins", value=config.agent_show_flag_early_mins))
-session.add(Setting(name="agent_psk", value=config.agent_psk))
-session.commit()
 
-if options.example:
-    # Simulate Rounds
+def build_argument_parser() -> argparse.ArgumentParser:
+    """Create the command line argument parser for the setup script."""
+
+    parser = argparse.ArgumentParser(
+        description="Initialise the database with default settings and optional example data.",
+    )
+    parser.add_argument(
+        "--overwrite-db",
+        action="store_true",
+        help="Drop and recreate the database even if it already exists.",
+    )
+    parser.add_argument(
+        "--example",
+        action="store_true",
+        help="Populate the database with randomly generated example data.",
+    )
+    return parser
+
+
+def str_to_bool(value: str) -> bool:
+    """Return True when *value* represents a truthy string."""
+
+    return str(value).strip().lower() == "true"
+
+
+def apply_environment_overrides(args: argparse.Namespace) -> None:
+    """Apply environment variable overrides to the parsed arguments."""
+
+    example_env = os.getenv("SCORINGENGINE_EXAMPLE")
+    if example_env and str_to_bool(example_env):
+        args.overwrite_db = True
+        args.example = True
+
+    overwrite_env = os.getenv("SCORINGENGINE_OVERWRITE_DB")
+    if overwrite_env:
+        overwrite_env = overwrite_env.strip().lower()
+        if overwrite_env in {"true", "false"}:
+            args.overwrite_db = overwrite_env == "true"
+        else:
+            logger.warning(
+                "Ignoring invalid SCORINGENGINE_OVERWRITE_DB value '%s'. Expected 'true' or 'false'.",
+                overwrite_env,
+            )
+
+
+def ensure_database_state(overwrite_db: bool) -> None:
+    """Abort when the database exists and overwrite was not requested."""
+
+    if overwrite_db:
+        return
+
+    if verify_db_ready(session):
+        logger.error(
+            "Exiting script and not overwriting db...must use --overwrite-db to overwrite data.",
+        )
+        raise SystemExit(1)
+
+    logger.debug("Database doesn't exist yet...")
+
+
+def load_competition_configuration() -> None:
+    """Load the default competition definition into the database."""
+
+    logger.info("Setting up DB")
+    delete_db(session)
+    init_db(session)
+
+    competition_config_file = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "competition.yaml",
+    )
+    with open(competition_config_file, "r", encoding="utf-8") as competition_config:
+        sample_competition_str = competition_config.read()
+
+    competition = Competition.parse_yaml_str(sample_competition_str)
+    competition.save(session)
+
+
+def create_default_settings() -> None:
+    """Persist the default settings required for a fresh installation."""
+
+    logger.info("Creating the default Settings")
+    session.add(Setting(name="about_page_content", value=ABOUT_CONTENT))
+    session.add(Setting(name="welcome_page_content", value=WELCOME_CONTENT))
+    session.add(Setting(name="target_round_time", value=config.target_round_time))
+    session.add(Setting(name="worker_refresh_time", value=config.worker_refresh_time))
+    session.add(Setting(name="engine_paused", value=config.engine_paused))
+    session.add(Setting(name="pause_duration", value=config.pause_duration))
+    session.add(Setting(name="blue_team_update_hostname", value=config.blue_team_update_hostname))
+    session.add(Setting(name="blue_team_update_port", value=config.blue_team_update_port))
+    session.add(
+        Setting(
+            name="blue_team_update_account_usernames",
+            value=config.blue_team_update_account_usernames,
+        )
+    )
+    session.add(
+        Setting(
+            name="blue_team_update_account_passwords",
+            value=config.blue_team_update_account_passwords,
+        )
+    )
+    session.add(Setting(name="blue_team_view_check_output", value=config.blue_team_view_check_output))
+    session.add(Setting(name="agent_checkin_interval_sec", value=config.target_round_time // 5))
+    session.add(Setting(name="agent_show_flag_early_mins", value=config.agent_show_flag_early_mins))
+    session.add(Setting(name="agent_psk", value=config.agent_psk))
+    session.commit()
+
+
+def simulate_rounds() -> None:
+    """Populate the database with example round data."""
+
     num_rounds = randint(200, 250)
-    logger.info("Simulating " + str(num_rounds) + " rounds")
+    logger.info("Simulating %s rounds", num_rounds)
+    services = session.query(Service).all()
     for num_round in range(1, num_rounds + 1):
         round_obj = Round(
             number=num_round,
             round_start=datetime.now() - timedelta(hours=randint(0, 24), minutes=randint(0, 60)),
             round_end=datetime.now() + timedelta(hours=randint(0, 24), minutes=randint(0, 60)),
         )
-        print(f"{(round_obj.round_start - round_obj.round_end).seconds}")
-        # session.add(round_obj)
-        services = session.query(Service).all()
+        logger.debug(
+            "Round %s spans %s seconds",
+            num_round,
+            (round_obj.round_end - round_obj.round_start).seconds,
+        )
+
         for service in services:
             output = ""
             if randint(0, 1) == 1:
@@ -177,10 +239,7 @@ if options.example:
             else:
                 result = False
                 output = "Errored output"
-                if randint(0, 1) == 1:
-                    reason = CHECK_FAILURE_TEXT
-                else:
-                    reason = CHECK_TIMED_OUT_TEXT
+                reason = choice([CHECK_FAILURE_TEXT, CHECK_TIMED_OUT_TEXT])
 
             command = "ping -c 1 127.0.0.1"
             check = Check(round=round_obj, service=service)
@@ -188,9 +247,12 @@ if options.example:
             session.add(check)
     session.commit()
 
-    # Simulate Injects
+
+def simulate_injects() -> None:
+    """Populate the database with example inject data."""
+
     num_injects = randint(5, 15)
-    logger.info("Simulating " + str(num_injects) + " Injects")
+    logger.info("Simulating %s Injects", num_injects)
     for _ in range(num_injects):
         template = Template(
             title="Journey to Mordor",
@@ -202,20 +264,6 @@ if options.example:
         )
         session.add(template)
 
-        # rubric_0 = Rubric(
-        #     deliverable="Damn hobbitses kept my precious!", value=0, template=template
-        # )
-        # rubric_50 = Rubric(
-        #     deliverable="You gave it your best effort, but died along the way.",
-        #     value=50,
-        #     template=template,
-        # )
-        # rubric_100 = Rubric(
-        #     deliverable="You saved the world!", value=100, template=template
-        # )
-
-        # session.add_all([template, rubric_0, rubric_50, rubric_100])
-
         for team in Team.get_all_blue_teams():
             inject = Inject(
                 team=team,
@@ -226,24 +274,28 @@ if options.example:
             session.add(inject)
         session.commit()
 
-    # Simulate Notifications
+
+def simulate_notifications(team_ids: list[int]) -> None:
+    """Populate the database with example notification data."""
+
     num_notifications = randint(50, 100)
-    logger.info("Simulating " + str(num_notifications) + " Notifications")
-    team_ids = [id[0] for id in session.query(Team.id).all()]
+    logger.info("Simulating %s Notifications", num_notifications)
     for _ in range(num_notifications):
         notification = Notification(
             message="Test Notification",
             target="/admin/notifications",
         )
-        if randint(0, 1) == 1:
-            notification.is_read = True
+        notification.is_read = bool(randint(0, 1))
         notification.team_id = choice(team_ids)
         session.add(notification)
         session.commit()
 
-    # Simulate Flags
+
+def simulate_flags(team_ids: list[int]) -> None:
+    """Populate the database with example flag and solve data."""
+
     num_flags = randint(10, 20)
-    logger.info("Simulating " + str(num_flags) + " Flags")
+    logger.info("Simulating %s Flags", num_flags)
     for _ in range(num_flags):
         flag = Flag(
             start_time=datetime.now() - timedelta(minutes=randint(0, 60)),
@@ -257,7 +309,6 @@ if options.example:
         session.add(flag)
         session.commit()
 
-        # Simulate Solves
         for team_id in sample(team_ids, randint(1, len(team_ids))):
             solve = Solve(
                 flag=flag,
@@ -266,3 +317,40 @@ if options.example:
             )
             session.add(solve)
             session.commit()
+
+
+def populate_example_data() -> None:
+    """Generate example data for a development environment."""
+
+    simulate_rounds()
+    simulate_injects()
+    team_ids = [id_[0] for id_ in session.query(Team.id).all()]
+    simulate_notifications(team_ids)
+    simulate_flags(team_ids)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse arguments and apply environment variable overrides."""
+
+    parser = build_argument_parser()
+    args = parser.parse_args()
+    apply_environment_overrides(args)
+    return args
+
+
+def main() -> None:
+    """Entry-point for the setup script."""
+
+    args = parse_args()
+
+    logger.info("Starting Setup v.%s", version)
+    ensure_database_state(args.overwrite_db)
+    load_competition_configuration()
+    create_default_settings()
+
+    if args.example:
+        populate_example_data()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the deprecated optparse usage with argparse and support environment overrides through a helper
- organize setup responsibilities into focused functions for database initialization and example data seeding
- capture static HTML content as module constants and improve logging clarity during setup

## Testing
- `pre-commit run --files bin/setup` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d04dd6a0832983b5a48303f30397