### PR TITLE
Fix Elasticsearch testbed Docker build

### DIFF
--- a/docker/testbed/elasticsearch/Dockerfile
+++ b/docker/testbed/elasticsearch/Dockerfile
@@ -1,12 +1,14 @@
-FROM ubuntu:24.10
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
   apt-get update && \
-  apt-get install -y openjdk-8-jre curl && \
-  curl -s -L https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.2.deb -o elasticsearch-6.1.2.deb && \
-  dpkg -i elasticsearch-6.1.2.deb
-
+  apt-get install -y --no-install-recommends openjdk-8-jre-headless curl && \
+  rm -rf /var/lib/apt/lists/* && \
+  curl -s -L https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.2.deb -o /tmp/elasticsearch-6.1.2.deb && \
+  dpkg -i /tmp/elasticsearch-6.1.2.deb && \
+  rm /tmp/elasticsearch-6.1.2.deb
 EXPOSE 9200
-
 USER elasticsearch
 CMD ["/usr/share/elasticsearch/bin/elasticsearch", "-Enetwork.host=0.0.0.0"]


### PR DESCRIPTION
## Summary
- switch the Elasticsearch testbed container to Ubuntu 20.04 to use supported APT repositories
- configure noninteractive package installation and clean the cache after installing Java 8 and curl

## Testing
- pre-commit run --files docker/testbed/elasticsearch/Dockerfile

------
https://chatgpt.com/codex/tasks/task_e_68d9d8909f20832993a79b72f6b498ba