### PR TITLE
Fix Elasticsearch testbed Docker build

### DIFF
--- a/docker/testbed/elasticsearch/Dockerfile
+++ b/docker/testbed/elasticsearch/Dockerfile
@@ -1,12 +1,14 @@
-FROM ubuntu:24.10
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
   apt-get update && \
-  apt-get install -y openjdk-8-jre curl && \
-  curl -s -L https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.2.deb -o elasticsearch-6.1.2.deb && \
-  dpkg -i elasticsearch-6.1.2.deb
-
+  apt-get install -y --no-install-recommends openjdk-8-jre-headless curl && \
+  rm -rf /var/lib/apt/lists/* && \
+  curl -s -L https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.2.deb -o /tmp/elasticsearch-6.1.2.deb && \
+  dpkg -i /tmp/elasticsearch-6.1.2.deb && \
+  rm /tmp/elasticsearch-6.1.2.deb
 EXPOSE 9200
-
 USER elasticsearch
 CMD ["/usr/share/elasticsearch/bin/elasticsearch", "-Enetwork.host=0.0.0.0"]

--- a/docker/testbed/ftp/Dockerfile
+++ b/docker/testbed/ftp/Dockerfile
@@ -1,8 +1,12 @@
-FROM ubuntu:24.10
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
-  apt-get update && apt-get install -y --no-install-recommends vsftpd && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends vsftpd && \
   apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
   echo "local_enable=YES" >> /etc/vsftpd.conf && \
   echo "write_enable=YES" >> /etc/vsftpd.conf && \
   echo "dirlist_enable=YES" >> /etc/vsftpd.conf && \
@@ -13,7 +17,7 @@ RUN \
   echo 'ttesterson:testpass' | chpasswd && \
   echo 'rpeterson:otherpass' | chpasswd && \
   mkdir /ftp_files && \
-  echo 'canary' | tee -a > /ftp_files/testfile.txt && \
+  printf 'canary\n' > /ftp_files/testfile.txt && \
   chmod 777 -R /ftp_files
 
 EXPOSE 21

--- a/docker/testbed/smtp/Dockerfile
+++ b/docker/testbed/smtp/Dockerfile
@@ -1,10 +1,12 @@
-FROM ubuntu:24.10
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN \
   apt-get update && \
-  apt-get -y install openssl postfix sasl2-bin
+  apt-get -y install openssl postfix sasl2-bin && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN \
   mkdir /etc/postfix/ssl && \


### PR DESCRIPTION
## Summary
- switch the Elasticsearch testbed container to Ubuntu 20.04 to use supported APT repositories
- configure noninteractive package installation and clean the cache after installing Java 8 and curl
- switch the FTP and SMTP testbed containers to Ubuntu 22.04 so that supported package repositories are used during builds
- clear cached package indexes in the FTP and SMTP images and fix creation of the FTP sample file

## Testing
- pre-commit run --files docker/testbed/elasticsearch/Dockerfile
- pre-commit run --files docker/testbed/ftp/Dockerfile docker/testbed/smtp/Dockerfile *(fails: `pre-commit` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d8909f20832993a79b72f6b498ba