### PR TITLE
Make optional modules configurable and expose status

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -151,8 +151,13 @@ session.add(Setting(name="blue_team_update_account_usernames", value=config.blue
 session.add(Setting(name="blue_team_update_account_passwords", value=config.blue_team_update_account_passwords))
 session.add(Setting(name="blue_team_view_check_output", value=config.blue_team_view_check_output))
 session.add(Setting(name="agent_checkin_interval_sec", value=config.target_round_time // 5))
-session.add(Setting(name="agent_show_flag_early_mins", value=config.agent_show_flag_early_mins))
-session.add(Setting(name="agent_psk", value=config.agent_psk))
+
+bta_module = config.module("black_team_agent")
+if bta_module.get("configured"):
+    session.add(
+        Setting(name="agent_show_flag_early_mins", value=config.agent_show_flag_early_mins)
+    )
+    session.add(Setting(name="agent_psk", value=config.agent_psk))
 session.commit()
 
 if options.example:

--- a/docs/source/bta.rst
+++ b/docs/source/bta.rst
@@ -12,7 +12,9 @@ Configuration
 =============
 
 Two settings must be configured before BTAs can communicate with the
-engine:
+engine. If either value is missing the module is disabled, the
+``/api/agent/checkin`` endpoint will return HTTP 503, and the admin
+status page will highlight the missing configuration:
 
 ``agent_psk``
   Pre-shared key used to derive per-team encryption keys.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -35,7 +35,7 @@ Configuration Keys
    * - target_round_time
      - Length of time (seconds) the engine should target per round
    * - agent_psk
-     - The pre-shared key used for encryption between BTA and the Scoring Engine
+     - Pre-shared key used for the optional Black Team Agent integration. When omitted the module is disabled and the admin status page will note that configuration is required to enable it.
    * - agent_show_flag_early_mins
      - The length of time in minutes before a flag becomes active that BTA can grab the flag details
    * - worker_refresh_time
@@ -61,10 +61,24 @@ Configuration Keys
    * - db_uri
      - Database connection URI
    * - cache_type
-     - The type of storage for the cache. Set to null to disable caching
+     - The type of storage for the cache. Set to ``null`` to disable caching. When enabled additional Redis settings must be provided.
    * - redis_host
-     - The hostname/ip of the redis server
+     - The hostname/ip of the redis server (required when caching is enabled)
    * - redis_port
-     - The port of the redis server
+     - The port of the redis server (required when caching is enabled)
    * - redis_password
      - The password used to connect to redis (if no password, leave empty)
+
+Optional Modules
+----------------
+
+Several capabilities are considered non-core and are disabled unless they are explicitly configured. The engine surfaces their status in three places:
+
+* During startup the log stream will highlight missing values for optional modules.
+* The admin portal status page lists each module along with whether it is enabled and ready.
+* The documentation in this section identifies which configuration keys are required for each module.
+
+Currently the optional modules are:
+
+* **Black Team Agent** – requires ``agent_psk`` and ``agent_show_flag_early_mins``. Without these values the agent API remains disabled.
+* **Redis Cache** – requires ``cache_type`` to be set to a Redis backend along with ``redis_host`` and ``redis_port``.

--- a/scoring_engine/web/templates/admin/status.html
+++ b/scoring_engine/web/templates/admin/status.html
@@ -28,6 +28,35 @@ Round Stats
       </tr>
     </tbody>
   </table>
+  {% if module_status %}
+  <h4>Module Status</h4>
+  <table class="table table-striped table-bordered table-compact">
+    <thead>
+      <tr>
+        <th>Module</th>
+        <th>Enabled</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for module in module_status %}
+      <tr class="{% if module.configured %}success{% elif module.enabled %}warning{% else %}active{% endif %}">
+        <td>{{ module.name }}</td>
+        <td>{{ 'Yes' if module.enabled else 'No' }}</td>
+        <td>
+          {% if module.configured %}
+            Ready
+          {% elif module.missing %}
+            Missing configuration: {{ module.missing | join(', ') }}
+          {% else %}
+            Disabled
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
 </div>
 <script>
   function getEngineStats() {

--- a/scoring_engine/web/views/admin.py
+++ b/scoring_engine/web/views/admin.py
@@ -2,6 +2,7 @@ from flask import Blueprint, redirect, render_template, url_for
 from flask_login import current_user, login_required
 from operator import itemgetter
 
+from scoring_engine.config import config
 from scoring_engine.models.user import User
 from scoring_engine.models.team import Team
 from scoring_engine.models.inject import Inject
@@ -19,7 +20,11 @@ mod = Blueprint("admin", __name__)
 def status():
     if current_user.is_white_team:
         blue_teams = Team.get_all_blue_teams()
-        return render_template("admin/status.html", blue_teams=blue_teams)
+        return render_template(
+            "admin/status.html",
+            blue_teams=blue_teams,
+            module_status=config.modules,
+        )
     else:
         return redirect(url_for("auth.unauthorized"))
 

--- a/tests/scoring_engine/test_config_loader.py
+++ b/tests/scoring_engine/test_config_loader.py
@@ -70,6 +70,18 @@ class TestConfigLoader(object):
     def test_worker_queue(self):
         assert self.config.worker_queue == "main"
 
+    def test_module_status_includes_black_team_agent(self):
+        modules = {module["key"]: module for module in self.config.modules}
+        agent_module = modules["black_team_agent"]
+        assert agent_module["enabled"] is True
+        assert agent_module["configured"] is True
+
+    def test_module_status_includes_cache(self):
+        modules = {module["key"]: module for module in self.config.modules}
+        cache_module = modules["redis_cache"]
+        assert cache_module["enabled"] is False
+        assert cache_module["configured"] is False
+
     def test_parse_sources_int_environment(self):
         os.environ["SCORINGENGINE_ROUND_SLEEP_TIME"] = "1"
         assert self.config.parse_sources("round_sleep_time", "1234", "int") == 1


### PR DESCRIPTION
## Summary
- refactor the configuration loader to track optional modules, warn about missing values, and expose module status information
- show module readiness on the admin status page and guard the black team agent API when configuration is absent
- document optional module expectations and update setup/tests for the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f62602673483298b83542af0d6fc9c