### PR TITLE
Fix N+1 queries with eager loading

### DIFF
--- a/scoring_engine/celery_stats.py
+++ b/scoring_engine/celery_stats.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm import joinedload
+
 from scoring_engine.celery_app import celery_app
 from scoring_engine.db import session
 from scoring_engine.models.service import Service
@@ -11,7 +13,7 @@ class CeleryStats:
 
         queues_facts = {}
 
-        all_services = session.query(Service).all()
+        all_services = session.query(Service).options(joinedload(Service.team)).all()
         for service in all_services:
             if service.worker_queue not in queues_facts:
                 queues_facts[service.worker_queue] = {
@@ -84,7 +86,7 @@ class CeleryStats:
             worker_facts[worker_name]['running_tasks'] = len(stats)
 
         # Produce list of Service checks this worker will run
-        all_services = session.query(Service).all()
+        all_services = session.query(Service).options(joinedload(Service.team)).all()
         for worker_name, facts in worker_facts.items():
             facts['services_running'] = []
             services_running = {}

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -828,7 +828,7 @@ def admin_inject_scores():
 
         injects = (
             session.query(Inject)
-            .options(joinedload(Inject.template))
+            .options(joinedload(Inject.template), joinedload(Inject.team))
             .order_by(Inject.template_id)
             .order_by(Inject.team_id)
             .all()

--- a/scoring_engine/web/views/api/injects.py
+++ b/scoring_engine/web/views/api/injects.py
@@ -116,7 +116,13 @@ def api_inject(inject_id):
     data["status"] = inject.status
 
     # Comments
-    comments = session.query(Comment).filter(Comment.inject == inject).order_by(Comment.time).all()
+    comments = (
+        session.query(Comment)
+        .options(joinedload(Comment.user).joinedload("team"))
+        .filter(Comment.inject == inject)
+        .order_by(Comment.time)
+        .all()
+    )
     data["comments"] = [
         {
             "id": comment.id,
@@ -144,7 +150,13 @@ def api_inject_comments(inject_id):
         return jsonify({"status": "Unauthorized"}), 403
 
     data = []
-    comments = session.query(Comment).filter(Comment.inject == inject).order_by(Comment.time).all()
+    comments = (
+        session.query(Comment)
+        .options(joinedload(Comment.user).joinedload("team"))
+        .filter(Comment.inject == inject)
+        .order_by(Comment.time)
+        .all()
+    )
     for comment in comments:
         data.append(
             {


### PR DESCRIPTION
Add SQLAlchemy joinedload to prevent N+1 queries by eagerly loading related objects:

- celery_stats.py: Add joinedload(Service.team) to prevent querying teams for each service when building queue and worker stats
- api/injects.py: Add joinedload(Comment.user).joinedload("team") to prevent querying users and teams for each comment
- api/admin.py: Add joinedload(Inject.team) to existing query options to prevent querying teams for each inject

These changes reduce database queries from hundreds per page load to just a few efficient queries with joins.