### PR TITLE
Add caching to Setting.get_setting() method

### DIFF
--- a/scoring_engine/models/setting.py
+++ b/scoring_engine/models/setting.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column, Integer, Text, desc
+from time import time
 
 from scoring_engine.models.base import Base
 from scoring_engine.db import session
@@ -10,6 +11,10 @@ class Setting(Base):
     name = Column(Text, nullable=False)
     _value_text = Column(Text, nullable=False)
     _value_type = Column(Text, nullable=False)
+
+    # In-memory cache with TTL
+    _cache = {}
+    _cache_ttl = 60  # Cache TTL in seconds (default: 60 seconds)
 
     def __init__(self, *args, **kwargs):
         self.name = kwargs['name']
@@ -41,6 +46,34 @@ class Setting(Base):
         self._value_type = self.map_value_type(value)
         self._value_text = str(value)
 
-    @staticmethod
-    def get_setting(name):
-        return session.query(Setting).filter(Setting.name == name).order_by(desc(Setting.id)).first()
+    @classmethod
+    def get_setting(cls, name):
+        """
+        Get a setting by name with in-memory caching.
+        Cache entries expire after _cache_ttl seconds.
+        """
+        current_time = time()
+
+        # Check if setting is in cache and not expired
+        if name in cls._cache:
+            cached_value, cached_time = cls._cache[name]
+            if current_time - cached_time < cls._cache_ttl:
+                return cached_value
+
+        # Query database and update cache
+        setting = session.query(Setting).filter(Setting.name == name).order_by(desc(Setting.id)).first()
+        if setting:
+            cls._cache[name] = (setting, current_time)
+        return setting
+
+    @classmethod
+    def clear_cache(cls, name=None):
+        """
+        Clear the settings cache.
+        If name is provided, only clear that specific setting from cache.
+        Otherwise, clear the entire cache.
+        """
+        if name:
+            cls._cache.pop(name, None)
+        else:
+            cls._cache.clear()

--- a/scoring_engine/models/setting.py
+++ b/scoring_engine/models/setting.py
@@ -58,7 +58,8 @@ class Setting(Base):
         if name in cls._cache:
             cached_value, cached_time = cls._cache[name]
             if current_time - cached_time < cls._cache_ttl:
-                return cached_value
+                # Merge the cached object back into the session to avoid DetachedInstanceError
+                return session.merge(cached_value, load=False)
 
         # Query database and update cache
         setting = session.query(Setting).filter(Setting.name == name).order_by(desc(Setting.id)).first()

--- a/tests/scoring_engine/models/test_setting.py
+++ b/tests/scoring_engine/models/test_setting.py
@@ -65,10 +65,10 @@ class TestSetting(UnitTest):
         assert result1.value == 'initial_value'
         assert 'cached_setting' in Setting._cache
 
-        # Second call should return cached value (same object reference)
+        # Second call should return cached value with same data
         result2 = Setting.get_setting('cached_setting')
         assert result2.value == 'initial_value'
-        assert result1 is result2  # Same cached object
+        assert result1.id == result2.id  # Same setting from cache
 
     def test_get_setting_cache_expiration(self):
         # Clear cache before test

--- a/tests/scoring_engine/models/test_setting.py
+++ b/tests/scoring_engine/models/test_setting.py
@@ -1,6 +1,7 @@
 from scoring_engine.models.setting import Setting
 
 from tests.scoring_engine.unit_test import UnitTest
+from time import sleep
 
 
 class TestSetting(UnitTest):
@@ -49,3 +50,97 @@ class TestSetting(UnitTest):
         assert setting.value == 'somevalue'
         self.session.add(setting)
         self.session.commit()
+
+    def test_get_setting_caching(self):
+        # Clear cache before test
+        Setting.clear_cache()
+
+        # Create a setting
+        setting = Setting(name='cached_setting', value='initial_value')
+        self.session.add(setting)
+        self.session.commit()
+
+        # First call should query database and cache the result
+        result1 = Setting.get_setting('cached_setting')
+        assert result1.value == 'initial_value'
+        assert 'cached_setting' in Setting._cache
+
+        # Second call should return cached value (same object reference)
+        result2 = Setting.get_setting('cached_setting')
+        assert result2.value == 'initial_value'
+        assert result1 is result2  # Same cached object
+
+    def test_get_setting_cache_expiration(self):
+        # Clear cache before test
+        Setting.clear_cache()
+
+        # Set a very short TTL for testing
+        original_ttl = Setting._cache_ttl
+        Setting._cache_ttl = 1  # 1 second TTL
+
+        # Create a setting
+        setting = Setting(name='expiring_setting', value='first_value')
+        self.session.add(setting)
+        self.session.commit()
+
+        # First call caches the setting
+        result1 = Setting.get_setting('expiring_setting')
+        assert result1.value == 'first_value'
+
+        # Update the setting in database
+        new_setting = Setting(name='expiring_setting', value='second_value')
+        self.session.add(new_setting)
+        self.session.commit()
+
+        # Immediate call should still return cached value
+        result2 = Setting.get_setting('expiring_setting')
+        assert result2.value == 'first_value'
+
+        # Wait for cache to expire
+        sleep(1.5)
+
+        # After expiration, should get updated value from database
+        result3 = Setting.get_setting('expiring_setting')
+        assert result3.value == 'second_value'
+
+        # Restore original TTL
+        Setting._cache_ttl = original_ttl
+
+    def test_clear_cache_all(self):
+        # Create and cache multiple settings
+        setting1 = Setting(name='setting1', value='value1')
+        setting2 = Setting(name='setting2', value='value2')
+        self.session.add(setting1)
+        self.session.add(setting2)
+        self.session.commit()
+
+        Setting.get_setting('setting1')
+        Setting.get_setting('setting2')
+
+        assert len(Setting._cache) >= 2
+
+        # Clear entire cache
+        Setting.clear_cache()
+        assert len(Setting._cache) == 0
+
+    def test_clear_cache_specific(self):
+        # Clear cache before test
+        Setting.clear_cache()
+
+        # Create and cache multiple settings
+        setting1 = Setting(name='setting_a', value='value_a')
+        setting2 = Setting(name='setting_b', value='value_b')
+        self.session.add(setting1)
+        self.session.add(setting2)
+        self.session.commit()
+
+        Setting.get_setting('setting_a')
+        Setting.get_setting('setting_b')
+
+        assert 'setting_a' in Setting._cache
+        assert 'setting_b' in Setting._cache
+
+        # Clear only one setting from cache
+        Setting.clear_cache('setting_a')
+        assert 'setting_a' not in Setting._cache
+        assert 'setting_b' in Setting._cache


### PR DESCRIPTION
Implement a simple in-memory cache for Setting.get_setting() to reduce repeated database queries.

Changes:
- Added _cache and _cache_ttl class variables to Setting model
- Modified get_setting() to check cache before querying database
- Cache entries expire after 60 seconds (configurable via _cache_ttl)
- Added clear_cache() method for manual cache invalidation
- Added comprehensive tests for caching, expiration, and cache clearing

Impact: Settings are queried frequently in engine.py but rarely change during runtime, making caching an effective optimization.