### PR TITLE
Fix admin batch operations in inject template import

### DIFF
--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -756,7 +756,6 @@ def admin_import_inject_templates():
                             for inject in injects:
                                 inject.enabled = False
 
-                        session.commit()
                     else:
                         return (
                             jsonify(
@@ -811,7 +810,7 @@ def admin_import_inject_templates():
                                 template=t,
                             )
                             session.add(inject)
-                    session.commit()
+            session.commit()
             return jsonify({"status": "Success"}), 200
         else:
             return jsonify({"status": "Error", "message": "Invalid Data"}), 400


### PR DESCRIPTION
Move db.session.commit() outside the main loop in admin_import_inject_templates function. Previously, the function was creating N commits for N templates, now it creates a single batch commit for all templates.