### PR TITLE
Add functionality for playwright based checks and fix client-side javascript character input restrictions

### DIFF
--- a/scoring_engine/checks/bin/conftest.py
+++ b/scoring_engine/checks/bin/conftest.py
@@ -3,10 +3,26 @@ import pytest
 def pytest_addoption(parser):
     parser.addoption("--scheme", action="store", default="")
     parser.addoption("--hostip", action="store", default="")
+    parser.addoption("--hostname", action="store", default="")
     parser.addoption("--hostport", action="store", default="")
     parser.addoption("--basepath", action="store", default="")
     parser.addoption("--username", action="store", default="")
     parser.addoption("--password", action="store", default="")
+
+@pytest.fixture(scope="session")
+def browser_type_launch_args(browser_type_launch_args, pytestconfig):
+    host_ip = pytestconfig.getoption("--hostip")
+    host_name = pytestconfig.getoption("--hostname")
+
+    # We only apply the rule if a hostip is actually provided
+    if host_ip and host_name:
+        return {
+            **browser_type_launch_args,
+            "args": [
+                f"--host-resolver-rules=MAP {host_name} {host_ip}"
+            ],
+        }
+    return browser_type_launch_args
 
 @pytest.fixture(scope="session")
 def browser_context_args(browser_context_args):

--- a/scoring_engine/web/static/vendor/js/utils.js
+++ b/scoring_engine/web/static/vendor/js/utils.js
@@ -19,8 +19,8 @@ var ScoringEngineUtils = (function() {
         if (value.startsWith(" ") || value.endsWith(" ")) {
             return "Input cannot start or end with a space";
         }
-        if (/^[A-Za-z0-9\.,@=:\/\-\|\(\); !]+$/.test(value) == false) {
-            return "Invalid characters detected in input. Allowed characters are AlphaNumeric and any of . , @ = : / - | ( ) ;";
+        if (/^[A-Za-z0-9\.,@=:\/\-\|\(\)\^$; !]+$/.test(value) == false) {
+            return "Invalid characters detected in input. Allowed characters are AlphaNumeric and any of . , @ = : / - | ( ) ^ $ ; space !";
         }
     }
 


### PR DESCRIPTION
This addresses two primary items:

Add static hostname to IP mapping option in playwright-based checks :
This functionality enables certain web applications who redirect in certain ways where cookies would get tied to an IP instead of a domain which would not work without this mapping ability

Fix client-side javascript character input restrictions:
Update client-side javascript to allow for ^ and $ characters in user entered strings such as in the matching content field where regex expressions are often used