### PR TITLE
Move Playwright to optional worker-playwright image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,27 @@ services:
       - SCORINGENGINE_VERSION
       - DISPLAY=:1
     privileged: true
+  # Optional: Uncomment to enable Playwright-based browser checks
+  # worker-playwright:
+  #   image: scoringengine/worker-playwright
+  #   build:
+  #     context: .
+  #     dockerfile: ./docker/worker-playwright/Dockerfile
+  #     cache_from:
+  #       - scoringengine/worker-playwright
+  #       - worker-playwright:latest
+  #   depends_on:
+  #     worker:
+  #       condition: service_started
+  #     redis:
+  #       condition: service_healthy
+  #   restart: unless-stopped
+  #   networks:
+  #     - default
+  #   environment:
+  #     - SCORINGENGINE_VERSION
+  #     - DISPLAY=:1
+  #   privileged: true
   web:
     image: scoringengine/web
     build:

--- a/docker/engine/Dockerfile
+++ b/docker/engine/Dockerfile
@@ -4,7 +4,7 @@ COPY bin/engine /app/bin/engine
 
 COPY scoring_engine /app/scoring_engine
 RUN pip install -e .
-# Note: update docker/worker/Dockerfile as well when changing playwright version
+# Note: update docker/worker-playwright/Dockerfile as well when changing playwright version
 RUN pip install -I "pytest-playwright>=0.7.0,<0.8"
 
 CMD ["/app/bin/engine"]

--- a/docker/worker-playwright/Dockerfile
+++ b/docker/worker-playwright/Dockerfile
@@ -1,0 +1,13 @@
+FROM scoringengine/worker
+
+USER root
+
+# Playwright-based advanced web checks
+# Installs playwright pytest plugin and browser dependencies
+RUN pip install --no-cache-dir -I "pytest-playwright>=0.7.0,<0.8" && \
+    playwright install-deps
+
+USER engine
+
+# Install Chromium browser for playwright checks
+RUN playwright install chromium

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -63,11 +63,6 @@ RUN pip install --no-cache-dir -I \
     "pysmb>=1.2,<1.3" \
     # Telnet checks
     "telnetlib3==1.0.1"
-    
-# Playwright-based advanced web checks
-# Note: update docker/engine/Dockerfile as well when changing playwright version
-RUN pip install -I "pytest-playwright>=0.7.0,<0.8"
-RUN playwright install-deps
 
 COPY bin/worker /app/bin/worker
 COPY docker/worker/sudoers /etc/sudoers
@@ -76,7 +71,6 @@ USER engine
 
 COPY scoring_engine /app/scoring_engine
 RUN pip install -e .
-RUN playwright install chromium
 
 # Xvfb is a virtual X server which tricks freerdp2
 # into thinking it has a screen. This is used for

--- a/docs/source/installation/airgapped.rst
+++ b/docs/source/installation/airgapped.rst
@@ -96,6 +96,9 @@ Save all built images to tar files for transfer:
   docker save scoringengine/worker -o docker-images/scoringengine-worker.tar
   docker save scoringengine/web -o docker-images/scoringengine-web.tar
 
+  # Optional: Export Playwright worker if using advanced web checks
+  # docker save scoringengine/worker-playwright -o docker-images/scoringengine-worker-playwright.tar
+
 4. Create Transfer Package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -131,6 +134,9 @@ Package everything needed for airgapped deployment:
   docker load -i docker-images/scoringengine-engine.tar
   docker load -i docker-images/scoringengine-worker.tar
   docker load -i docker-images/scoringengine-web.tar
+
+  # Optional: Load Playwright worker if exported
+  # docker load -i docker-images/scoringengine-worker-playwright.tar
 
   echo "All images loaded successfully!"
   docker images | grep -E "(scoringengine|redis|mariadb|nginx|python)"
@@ -199,6 +205,12 @@ If you prefer to save all images in a single command:
     scoringengine/web \
     -o all-images.tar
 
+  # Include Playwright worker if needed for advanced web checks:
+  # docker save \
+  #   ... \
+  #   scoringengine/worker-playwright \
+  #   -o all-images.tar
+
   # Then load on the airgapped system:
   docker load -i all-images.tar
 
@@ -247,6 +259,7 @@ You should see:
 - ``scoringengine/engine``
 - ``scoringengine/worker``
 - ``scoringengine/web``
+- ``scoringengine/worker-playwright`` (optional, if using advanced web checks)
 
 4. Configure Competition
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/installation/docker.rst
+++ b/docs/source/installation/docker.rst
@@ -26,6 +26,17 @@ You can set each environment variable before each command executed, for example:
   SCORINGENGINE_EXAMPLE=true make rebuild-new
 
 
+Optional: Playwright Worker for Advanced Web Checks
+---------------------------------------------------
+
+If your competition requires advanced browser-based checks (JavaScript execution, complex cookie/redirect scenarios), enable the optional Playwright worker:
+
+1. Uncomment the ``worker-playwright`` service in ``docker-compose.yml``
+2. Build the image: ``docker-compose build worker-playwright``
+3. Start with: ``docker-compose up -d``
+
+.. note:: The Playwright worker adds ~500MB+ to the deployment size due to the bundled Chromium browser. Only enable if needed.
+
 Production Environment
 ----------------------
 

--- a/docs/source/installation/worker.rst
+++ b/docs/source/installation/worker.rst
@@ -134,3 +134,15 @@ Install dependencies for Telnet check
 
   source /home/engine/scoring_engine/env/bin/activate && pip install -I "telnetlib3==1.0.1"
 
+Install dependencies for Playwright-based checks (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Playwright enables advanced browser-based checks for complex web applications that require JavaScript execution, cookie handling, or multi-step interactions.
+
+.. note:: Playwright with browsers requires significant disk space (~500MB+). Only install if you need advanced web checks.
+
+::
+
+  source /home/engine/scoring_engine/env/bin/activate && pip install -I "pytest-playwright>=0.7.0,<0.8"
+  playwright install-deps
+  playwright install chromium


### PR DESCRIPTION
## Summary

- Moves Playwright and Chromium browser to a separate, optional `worker-playwright` Docker image
- Reduces base worker image size by ~500MB+
- Allows deployments that don't need advanced web checks to skip the Playwright overhead

## Changes

- **New**: `docker/worker-playwright/Dockerfile` - Extends worker image with Playwright support
- **Modified**: `docker/worker/Dockerfile` - Removed Playwright installation
- **Modified**: `docker-compose.yml` - Added commented `worker-playwright` service
- **Modified**: `docker/engine/Dockerfile` - Updated comment reference
- **Modified**: Documentation for Docker, airgapped, and manual worker installations

## Usage

To enable Playwright-based browser checks:

1. Uncomment the `worker-playwright` service in `docker-compose.yml`
2. Build: `docker-compose build worker-playwright`
3. Start: `docker-compose up -d`

## Test plan

- [ ] Build base worker image without Playwright: `docker-compose build worker`
- [ ] Verify worker starts and runs non-Playwright checks
- [ ] Build worker-playwright image: `docker-compose build worker-playwright`
- [ ] Verify Playwright-based checks work with the new image
- [ ] Verify documentation renders correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)