### PR TITLE
Fix issue #1074

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -44,6 +44,7 @@ jobs:
           context: .
           file: ./docker/base/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}/base:${{ env.image_tag }}
             ghcr.io/${{ github.repository }}/base:develop
@@ -57,6 +58,7 @@ jobs:
           context: .
           file: ./docker/bootstrap/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}/bootstrap:${{ env.image_tag }}
             ghcr.io/${{ github.repository }}/bootstrap:develop
@@ -70,6 +72,7 @@ jobs:
           context: .
           file: ./docker/engine/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}/engine:${{ env.image_tag }}
             ghcr.io/${{ github.repository }}/engine:develop
@@ -83,6 +86,7 @@ jobs:
           context: .
           file: ./docker/web/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}/web:${{ env.image_tag }}
             ghcr.io/${{ github.repository }}/web:develop
@@ -96,6 +100,7 @@ jobs:
           context: .
           file: ./docker/worker/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}/worker:${{ env.image_tag }}
             ghcr.io/${{ github.repository }}/worker:develop


### PR DESCRIPTION
This change enables multi-architecture Docker image builds for both linux/amd64 and linux/arm64 platforms. This resolves issues for users running the project on Apple Silicon (M1/M2/M3) Macs, who previously had to manually build images locally.

Changes:
- Added platforms: linux/amd64,linux/arm64 to all five image builds:
  - base
  - bootstrap
  - engine
  - web
  - worker

The existing Docker Buildx setup already supports multi-platform builds, so this change only requires adding the platforms parameter to each docker/build-push-action step.

Fixes #1074