### PR TITLE
Enhance version system with git info and detailed version tracking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ replace = 'version = "{new_version}"'
 
 [[tool.bumpversion.files]]
 filename = "scoring_engine/version.py"
-search = 'version = "{current_version}"'
-replace = 'version = "{new_version}"'
+search = 'BASE_VERSION = "{current_version}"'
+replace = 'BASE_VERSION = "{new_version}"'
 
 [tool.flake8]
 exclude = [".git", "*__init__.py"]

--- a/scoring_engine/version.py
+++ b/scoring_engine/version.py
@@ -1,15 +1,102 @@
 import os
+import subprocess
 
 from scoring_engine.config import config
 
+# Base version - updated by bump-my-version
+BASE_VERSION = "1.2.0"
+
+
+def get_git_info():
+    """
+    Get git commit hash and tag information.
+    Returns tuple of (commit_hash, is_tagged_release, tag_name).
+    """
+    commit_hash = None
+    is_tagged_release = False
+    tag_name = None
+
+    # First check environment variable (set by Makefile/Docker)
+    if "SCORINGENGINE_VERSION" in os.environ:
+        env_version = os.environ["SCORINGENGINE_VERSION"]
+        # If it looks like a version tag (v1.2.0), it's a release
+        if env_version.startswith("v") and "." in env_version:
+            is_tagged_release = True
+            tag_name = env_version
+        else:
+            # Otherwise treat as commit hash
+            commit_hash = env_version
+        return commit_hash, is_tagged_release, tag_name
+
+    # Try to get git info directly
+    try:
+        # Get current commit hash
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            commit_hash = result.stdout.strip()
+
+        # Check if current commit has a version tag
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--exact-match", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            tag = result.stdout.strip()
+            if tag.startswith("v") and "." in tag:
+                is_tagged_release = True
+                tag_name = tag
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        # Git not available or not in a git repo
+        pass
+
+    return commit_hash, is_tagged_release, tag_name
+
+
+def get_version_info():
+    """
+    Get comprehensive version information.
+    Returns dict with version details.
+    """
+    commit_hash, is_tagged_release, tag_name = get_git_info()
+
+    info = {
+        "base_version": BASE_VERSION,
+        "commit": commit_hash,
+        "is_release": is_tagged_release,
+        "tag": tag_name,
+        "is_dev": config.debug,
+    }
+
+    # Build the display version string
+    if is_tagged_release:
+        # Tagged release: just show version
+        display = BASE_VERSION
+    elif commit_hash:
+        # Development build with commit: show version+commit
+        display = f"{BASE_VERSION}+{commit_hash}"
+    else:
+        # No git info available: just show base version
+        display = BASE_VERSION
+
+    if config.debug:
+        display += "-dev"
+
+    info["display"] = display
+    return info
+
 
 def get_version():
-    version = "1.2.0"
-    if "SCORINGENGINE_VERSION" in os.environ:
-        version = os.environ["SCORINGENGINE_VERSION"]
-    if config.debug:
-        version += "-dev"
-    return version
+    """Get the display version string for backwards compatibility."""
+    return get_version_info()["display"]
 
 
+# For backwards compatibility
 version = get_version()
+version_info = get_version_info()

--- a/scoring_engine/version.py
+++ b/scoring_engine/version.py
@@ -52,8 +52,9 @@ def get_git_info():
             if tag.startswith("v") and "." in tag:
                 is_tagged_release = True
                 tag_name = tag
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        # Git not available or not in a git repo
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError, Exception):
+        # Git not available, not in a git repo, or running in restricted environment
+        # (e.g., Celery worker with soft time limits)
         pass
 
     return commit_hash, is_tagged_release, tag_name

--- a/scoring_engine/web/templates/about.html
+++ b/scoring_engine/web/templates/about.html
@@ -14,7 +14,7 @@
   <div class="col-sm-8 col-sm-offset-2 text-center" >
     <ul class="list-inline center-block">
       <li><h5><a href="https://scoringengine.readthedocs.io/en/latest/installation.html">Setup your own!</a></h5></li>
-      <li><h5>Version: {{version}}</h5></li>
+      <li><h5>Version: {{version_info.base_version}}{% if version_info.commit %} (<a href="https://github.com/scoringengine/scoringengine/commit/{{version_info.commit}}">{{version_info.commit}}</a>){% endif %}{% if version_info.is_dev %} <span class="label label-warning">dev</span>{% endif %}</h5></li>
       <li><h5><a href="https://github.com/scoringengine/scoringengine/issues/new">File a bug</a></h5></li>
     </ul>
   </div>

--- a/scoring_engine/web/views/about.py
+++ b/scoring_engine/web/views/about.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, render_template
-from scoring_engine.version import version
+from scoring_engine.version import version, version_info
 from scoring_engine.models.setting import Setting
 
 mod = Blueprint('about', __name__)
@@ -8,4 +8,4 @@ mod = Blueprint('about', __name__)
 @mod.route('/about')
 def about():
     about_content = Setting.get_setting('about_page_content').value
-    return render_template('about.html', version=version, about_content=about_content)
+    return render_template('about.html', version=version, version_info=version_info, about_content=about_content)

--- a/tests/scoring_engine/test_version.py
+++ b/tests/scoring_engine/test_version.py
@@ -43,28 +43,56 @@ class TestVersion(UnitTest):
         assert getattr(config, 'debug', None) is not None
 
     def test_normal_version(self):
-        # Verify it's a X.X.X
-        assert re.search(r'([\d.]+)', version).group(1) == version
+        # Verify it's a X.X.X (possibly with +commit suffix)
+        assert re.search(r'^[\d.]+', version).group(0) is not None
 
-    def test_environment_var_version(self):
-        os.environ['SCORINGENGINE_VERSION'] = 'testver'
+    def test_environment_var_commit_version(self):
+        # When SCORINGENGINE_VERSION is a commit hash, it shows as version+commit
+        os.environ['SCORINGENGINE_VERSION'] = 'abc1234'
         if 'scoring_engine.version' in sys.modules:
             del sys.modules["scoring_engine.version"]
-        from scoring_engine.version import version
-        assert version == 'testver'
+        from scoring_engine.version import version, version_info, BASE_VERSION
+        assert version == f'{BASE_VERSION}+abc1234'
+        assert version_info['commit'] == 'abc1234'
+        assert version_info['is_release'] is False
+
+    def test_environment_var_tag_version(self):
+        # When SCORINGENGINE_VERSION is a version tag, it's treated as a release
+        os.environ['SCORINGENGINE_VERSION'] = 'v1.2.0'
+        if 'scoring_engine.version' in sys.modules:
+            del sys.modules["scoring_engine.version"]
+        from scoring_engine.version import version, version_info, BASE_VERSION
+        assert version == BASE_VERSION
+        assert version_info['is_release'] is True
+        assert version_info['tag'] == 'v1.2.0'
 
     def test_debug_version(self):
         self.toggle_debug(True)
         if 'scoring_engine.version' in sys.modules:
             del sys.modules["scoring_engine.version"]
-        from scoring_engine.version import version
-        # Verify it's a X.X.X-dev
-        assert re.search(r'([\d.]+-dev)', version).group(1) == version
+        from scoring_engine.version import version, version_info
+        # Verify it ends with -dev
+        assert version.endswith('-dev')
+        assert version_info['is_dev'] is True
 
     def test_debug_env_version(self):
         self.toggle_debug(True)
         os.environ['SCORINGENGINE_VERSION'] = 'abcdefg'
         if 'scoring_engine.version' in sys.modules:
             del sys.modules["scoring_engine.version"]
-        from scoring_engine.version import version
-        assert 'abcdefg-dev' == version
+        from scoring_engine.version import version, version_info, BASE_VERSION
+        assert version == f'{BASE_VERSION}+abcdefg-dev'
+        assert version_info['commit'] == 'abcdefg'
+        assert version_info['is_dev'] is True
+
+    def test_version_info_structure(self):
+        if 'scoring_engine.version' in sys.modules:
+            del sys.modules["scoring_engine.version"]
+        from scoring_engine.version import version_info
+        # Verify version_info has all expected keys
+        assert 'base_version' in version_info
+        assert 'commit' in version_info
+        assert 'is_release' in version_info
+        assert 'tag' in version_info
+        assert 'is_dev' in version_info
+        assert 'display' in version_info


### PR DESCRIPTION
## Summary
Refactored the version system to provide more detailed version information including git commit hashes, release tags, and development status. This enables better version tracking in development and production environments.

## Key Changes

- **Refactored `scoring_engine/version.py`**:
  - Introduced `BASE_VERSION` constant for bump-my-version compatibility
  - Added `get_git_info()` function to extract git commit hash and tag information from environment variables or git commands
  - Added `get_version_info()` function that returns comprehensive version details as a dictionary
  - Maintained backward compatibility with existing `get_version()` function
  - Version string now includes commit hash for development builds (e.g., `1.2.0+abc1234`)

- **Updated version bump configuration** in `pyproject.toml`:
  - Changed search/replace pattern from `version = ` to `BASE_VERSION = ` to match new constant name

- **Enhanced about page** (`scoring_engine/web/templates/about.html`):
  - Now displays base version with optional commit hash as a clickable GitHub link
  - Shows `-dev` badge for development builds
  - Provides better visibility into what version is running

- **Updated about view** (`scoring_engine/web/views/about.py`):
  - Passes `version_info` dictionary to template alongside legacy `version` string

- **Expanded test coverage** (`tests/scoring_engine/test_version.py`):
  - Added tests for commit hash vs. release tag detection
  - Added tests for version tag format (v1.2.0)
  - Added test for version_info structure validation
  - Updated existing tests to work with new version format

## Implementation Details

- Git information is retrieved in priority order: environment variable → git commands → fallback to base version
- Environment variable `SCORINGENGINE_VERSION` can be either a commit hash or a version tag (v-prefixed)
- Git operations have a 5-second timeout to prevent hanging
- Gracefully handles missing git or non-git environments
- Development mode (`config.debug`) appends `-dev` suffix to all version strings