### PR TITLE
Fix overview service status query using wrong round identifier

### DIFF
--- a/scoring_engine/web/views/api/overview.py
+++ b/scoring_engine/web/views/api/overview.py
@@ -243,7 +243,8 @@ def overview_get_data():
         checks = (
             db.session.query(Service.name, Check.result)
             .join(Service)
-            .filter(Check.round_id == last_round)
+            .join(Round)
+            .filter(Round.number == last_round)
             .order_by(Service.name, Service.team_id)
             .all()
         )


### PR DESCRIPTION
## Problem

The overview page was showing red X's for services that were actually passing checks.

## Root Cause

The service status query was filtering on `Check.round_id` (foreign key to `Round.id`) but comparing it against `last_round` which contains `Round.number`.

These values diverge after round 1 — e.g., round 5 might have `id=47`, causing the query to return no results or stale data from an old round.

## Fix

Join on Round table and filter on `Round.number`, matching the pattern used elsewhere in the same function.

```diff
-            .filter(Check.round_id == last_round)
+            .join(Round)
+            .filter(Round.number == last_round)
```

Reported by @ION28