### PR TITLE
Add mobile-responsive CSS for scoreboard and admin pages

### DIFF
--- a/scoring_engine/web/static/css/main.css
+++ b/scoring_engine/web/static/css/main.css
@@ -169,3 +169,58 @@ a.editable-click {
 .lefthand-nav {
     width: 20%;
 }
+
+/* Mobile Responsive Styles */
+@media (max-width: 768px) {
+    .md-page {
+        padding: 0px 10px 15px 10px;
+        max-width: 100%;
+        margin: 5px;
+    }
+
+    .lefthand-nav {
+        width: 100%;
+        margin-bottom: 15px;
+    }
+
+    .settings_middle_column {
+        width: 100%;
+    }
+
+    .card {
+        width: 100%;
+        float: none;
+    }
+
+    /* Ensure charts are readable on mobile */
+    #teamBar, #teamLine {
+        height: 300px !important;
+        min-height: 250px;
+    }
+
+    /* Better table handling on mobile */
+    .table-responsive {
+        border: none;
+    }
+
+    /* Adjust admin sidebar for mobile */
+    .panel-group {
+        margin-bottom: 10px;
+    }
+}
+
+@media (max-width: 576px) {
+    .md-page {
+        padding: 0px 5px 10px 5px;
+        margin: 2px;
+    }
+
+    #teamBar, #teamLine {
+        height: 250px !important;
+    }
+
+    /* Stack navbar items better */
+    .navbar-nav {
+        padding: 10px 0;
+    }
+}


### PR DESCRIPTION
## Summary
- Add responsive styles for screens ≤768px (tablets)
- Add responsive styles for screens ≤576px (phones)
- Make navigation, cards, and charts adapt to smaller screens
- Improve table display on mobile devices
- Ensure charts remain readable with minimum heights

Part of Tier 1 Quick Wins implementation (#20 from roadmap).

## Test plan
- [ ] Test scoreboard page on mobile viewport (Chrome DevTools)
- [ ] Test admin pages on tablet viewport
- [ ] Verify charts resize properly
- [ ] Test navigation collapse on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)