### PR TITLE
Add Fog of War mode to hide scores from non-admin users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,20 @@ class TestMyFeature(UnitTest):
 
 Integration tests: `make run-integration-tests` (requires testbed services)
 
+## Pull Request Guidelines
+
+**One feature per PR**: Always create separate branches and PRs for each distinct feature. Avoid "mono PRs" that combine multiple unrelated features.
+
+Good:
+- `feature/mobile-responsive-scoreboard` - only CSS changes for mobile
+- `feature/fog-of-war` - only fog of war logic
+- `feature/webhooks` - only webhook notifications
+
+Bad:
+- Single PR with mobile CSS + fog of war + webhooks + new scoring system
+
+**Reasoning**: Separate PRs are easier to review, test, revert, and discuss. If one feature needs changes, it doesn't block others.
+
 ## Security Checklist
 
 - Never log credentials in check output

--- a/bin/setup
+++ b/bin/setup
@@ -1,31 +1,24 @@
 #!/usr/bin/env python
+import optparse
+import os
 from datetime import datetime, timedelta
 from random import choice, randint, sample
 
-import optparse
-import os
-
-from scoring_engine.models.inject import Template, Inject
-from scoring_engine.models.team import Team
-from scoring_engine.models.service import Service
-from scoring_engine.models.round import Round
-from scoring_engine.models.check import Check
-from scoring_engine.models.flag import Flag, Solve, Platform, FlagTypeEnum, Perm
-
-from scoring_engine.models.notifications import Notification
-from scoring_engine.models.setting import Setting
-from scoring_engine.db import db, init_db, delete_db, verify_db_ready
-from scoring_engine.config import config
 from scoring_engine.competition import Competition
+from scoring_engine.config import config
+from scoring_engine.db import db, delete_db, init_db, verify_db_ready
+from scoring_engine.engine.basic_check import CHECK_FAILURE_TEXT, CHECK_SUCCESS_TEXT, CHECK_TIMED_OUT_TEXT
 from scoring_engine.logger import logger
+from scoring_engine.models.check import Check
+from scoring_engine.models.flag import Flag, FlagTypeEnum, Perm, Platform, Solve
+from scoring_engine.models.inject import Inject, Template
+from scoring_engine.models.notifications import Notification
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
 from scoring_engine.version import version
 from scoring_engine.web import create_app
-from scoring_engine.engine.basic_check import (
-    CHECK_SUCCESS_TEXT,
-    CHECK_FAILURE_TEXT,
-    CHECK_TIMED_OUT_TEXT,
-)
-
 
 parser = optparse.OptionParser()
 parser.add_option("--overwrite-db", action="store_true", default=False)
@@ -176,6 +169,11 @@ with app.app_context():
     db.session.add(Setting(name="dynamic_scoring_late_start_round", value=str(config.dynamic_scoring_late_start_round)))
     db.session.add(Setting(name="dynamic_scoring_late_multiplier", value=str(config.dynamic_scoring_late_multiplier)))
 
+    # Fog of War Settings (hide scores from non-admin users)
+    logger.info("Creating the Fog of War Settings")
+    db.session.add(Setting(name="fog_of_war_enabled", value=config.fog_of_war_enabled))
+    db.session.add(Setting(name="overview_show_round_info", value=config.overview_show_round_info))
+
     db.session.commit()
 
     if options.example:
@@ -290,7 +288,7 @@ with app.app_context():
             )
             flag.platform = choice([Platform.nix, Platform.windows])
             # Most flags should be non-dummy so they show up (only ~20% dummy)
-            flag.dummy = (i % 5 == 0)
+            flag.dummy = i % 5 == 0
             flag.type = choice([FlagTypeEnum.file, FlagTypeEnum.pipe, FlagTypeEnum.net, FlagTypeEnum.reg])
             flag.perm = choice([Perm.user, Perm.root])
             flag.data = {"path": f"/tmp/flag_{i}.txt", "content": f"FLAG_{i}_CONTENT"}

--- a/engine.conf.inc
+++ b/engine.conf.inc
@@ -68,3 +68,9 @@ dynamic_scoring_early_multiplier = 2.0
 dynamic_scoring_late_start_round = 50
 # Multiplier for late rounds (e.g., 0.5 = 0.5x points)
 dynamic_scoring_late_multiplier = 0.5
+
+# Fog of War Configuration
+# When enabled, hides scores from non-admin users
+fog_of_war_enabled = False
+# Whether to show round info on the overview page
+overview_show_round_info = True

--- a/scoring_engine/config_loader.py
+++ b/scoring_engine/config_loader.py
@@ -22,9 +22,7 @@ class ConfigLoader(object):
             Path to the configuration file relative to this module. Defaults to
             ``"../engine.conf"``.
         """
-        config_location = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), location
-        )
+        config_location = os.path.join(os.path.dirname(os.path.abspath(__file__)), location)
 
         self.parser = configparser.ConfigParser()
         # Attempt to read the supplied configuration file.  In the test
@@ -50,9 +48,7 @@ class ConfigLoader(object):
         if not self.parser.has_section("OPTIONS"):
             self.parser.add_section("OPTIONS")
 
-        self.debug = self.parse_sources(
-            "debug", self.parser["OPTIONS"]["debug"].lower() == "true", "bool"
-        )
+        self.debug = self.parse_sources("debug", self.parser["OPTIONS"]["debug"].lower() == "true", "bool")
 
         self.checks_location = self.parse_sources(
             "checks_location",
@@ -131,31 +127,19 @@ class ConfigLoader(object):
             self.parser["OPTIONS"]["worker_queue"],
         )
 
-        self.timezone = self.parse_sources(
-            "timezone", self.parser["OPTIONS"]["timezone"]
-        )
+        self.timezone = self.parse_sources("timezone", self.parser["OPTIONS"]["timezone"])
 
-        self.upload_folder = self.parse_sources(
-            "upload_folder", self.parser["OPTIONS"]["upload_folder"]
-        )
+        self.upload_folder = self.parse_sources("upload_folder", self.parser["OPTIONS"]["upload_folder"])
 
         self.db_uri = self.parse_sources("db_uri", self.parser["OPTIONS"]["db_uri"])
 
-        self.cache_type = self.parse_sources(
-            "cache_type", self.parser["OPTIONS"]["cache_type"]
-        )
+        self.cache_type = self.parse_sources("cache_type", self.parser["OPTIONS"]["cache_type"])
 
-        self.redis_host = self.parse_sources(
-            "redis_host", self.parser["OPTIONS"]["redis_host"]
-        )
+        self.redis_host = self.parse_sources("redis_host", self.parser["OPTIONS"]["redis_host"])
 
-        self.redis_port = self.parse_sources(
-            "redis_port", int(self.parser["OPTIONS"]["redis_port"]), "int"
-        )
+        self.redis_port = self.parse_sources("redis_port", int(self.parser["OPTIONS"]["redis_port"]), "int")
 
-        self.redis_password = self.parse_sources(
-            "redis_password", self.parser["OPTIONS"]["redis_password"]
-        )
+        self.redis_password = self.parse_sources("redis_password", self.parser["OPTIONS"]["redis_password"])
 
         # SLA Penalty Configuration
         self.sla_enabled = self.parse_sources(
@@ -222,6 +206,20 @@ class ConfigLoader(object):
             "dynamic_scoring_late_multiplier",
             float(self.parser["OPTIONS"].get("dynamic_scoring_late_multiplier", "0.5")),
             "float",
+        )
+
+        # Fog of War Configuration (hide scores from non-admin users)
+        self.fog_of_war_enabled = self.parse_sources(
+            "fog_of_war_enabled",
+            self.parser["OPTIONS"].get("fog_of_war_enabled", "false").lower() == "true",
+            "bool",
+        )
+
+        # Overview display setting
+        self.overview_show_round_info = self.parse_sources(
+            "overview_show_round_info",
+            self.parser["OPTIONS"].get("overview_show_round_info", "true").lower() == "true",
+            "bool",
         )
 
     def parse_sources(self, key_name, default_value, obj_type="str"):

--- a/scoring_engine/web/templates/admin/permissions.html
+++ b/scoring_engine/web/templates/admin/permissions.html
@@ -8,6 +8,31 @@
     <div class="row">
       <div class="col-xs-12 col-sm-6 col-md-4">
         <div class="panel panel-default">
+          <div class="panel-heading">Fog of War</div>
+          <ul class="list-group">
+            <li class="list-group-item">
+              <form id="fog_of_war_form" method="POST" action="{{ url_for('api.admin_update_fog_of_war') }}" role="form">
+                Hide Scores (Fog of War)
+                <div class="permission-switch pull-right">
+                  <input id="fog_of_war_enabled" type="checkbox" onchange="$('#fog_of_war_form').submit();" {{ 'checked' if fog_of_war_enabled == true }}/>
+                  <label for="fog_of_war_enabled" class="label-primary"></label>
+                </div>
+              </form>
+            </li>
+            <li class="list-group-item">
+              <form id="overview_show_round_info_form" method="POST" action="{{ url_for('api.admin_update_overview_show_round_info') }}" role="form">
+                Show Round Info on Overview
+                <div class="permission-switch pull-right">
+                  <input id="overview_show_round_info" type="checkbox" onchange="$('#overview_show_round_info_form').submit();" {{ 'checked' if overview_show_round_info == true }}/>
+                  <label for="overview_show_round_info" class="label-primary"></label>
+                </div>
+              </form>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-4">
+        <div class="panel panel-default">
           <div class="panel-heading">Blue Teams</div>
           <ul class="list-group">
             <li class="list-group-item">

--- a/scoring_engine/web/views/admin.py
+++ b/scoring_engine/web/views/admin.py
@@ -1,14 +1,14 @@
-from flask import Blueprint, redirect, render_template, url_for
-from flask_login import current_user, login_required
 from operator import itemgetter
 
-from scoring_engine.models.user import User
-from scoring_engine.models.team import Team
+from flask import Blueprint, redirect, render_template, url_for
+from flask_login import current_user, login_required
+
+from scoring_engine.db import db
 from scoring_engine.models.inject import Inject
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
-from scoring_engine.db import db
-
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
 
 mod = Blueprint("admin", __name__)
 
@@ -67,9 +67,7 @@ def inject_templates():
     if current_user.is_white_team:
         blue_teams = Team.get_all_blue_teams()
         red_teams = Team.get_all_red_teams()
-        return render_template(
-            "admin/templates.html", blue_teams=blue_teams, red_teams=red_teams
-        )
+        return render_template("admin/templates.html", blue_teams=blue_teams, red_teams=red_teams)
     else:
         return redirect(url_for("auth.unauthorized"))
 
@@ -103,9 +101,7 @@ def service(id):
         if service is None:
             return redirect(url_for("auth.unauthorized"))
 
-        return render_template(
-            "admin/service.html", service=service, blue_teams=blue_teams
-        )
+        return render_template("admin/service.html", service=service, blue_teams=blue_teams)
     else:
         return redirect(url_for("auth.unauthorized"))
 
@@ -139,19 +135,19 @@ def permissions():
         return render_template(
             "admin/permissions.html",
             blue_teams=blue_teams,
-            blue_team_update_hostname=Setting.get_setting(
-                "blue_team_update_hostname"
-            ).value,
+            blue_team_update_hostname=Setting.get_setting("blue_team_update_hostname").value,
             blue_team_update_port=Setting.get_setting("blue_team_update_port").value,
-            blue_team_update_account_usernames=Setting.get_setting(
-                "blue_team_update_account_usernames"
-            ).value,
-            blue_team_update_account_passwords=Setting.get_setting(
-                "blue_team_update_account_passwords"
-            ).value,
-            blue_team_view_check_output=Setting.get_setting(
-                "blue_team_view_check_output"
-            ).value,
+            blue_team_update_account_usernames=Setting.get_setting("blue_team_update_account_usernames").value,
+            blue_team_update_account_passwords=Setting.get_setting("blue_team_update_account_passwords").value,
+            blue_team_view_check_output=Setting.get_setting("blue_team_view_check_output").value,
+            fog_of_war_enabled=(
+                Setting.get_setting("fog_of_war_enabled").value if Setting.get_setting("fog_of_war_enabled") else False
+            ),
+            overview_show_round_info=(
+                Setting.get_setting("overview_show_round_info").value
+                if Setting.get_setting("overview_show_round_info")
+                else True
+            ),
         )
     else:
         return redirect(url_for("auth.unauthorized"))

--- a/tests/scoring_engine/web/views/api/test_fog_of_war.py
+++ b/tests/scoring_engine/web/views/api/test_fog_of_war.py
@@ -1,0 +1,199 @@
+"""Tests for Fog of War functionality"""
+import json
+
+from scoring_engine.models.check import Check
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+from scoring_engine.web import create_app
+from tests.scoring_engine.unit_test import UnitTest
+
+
+class TestFogOfWar(UnitTest):
+    """Tests for fog of war scoreboard hiding functionality"""
+
+    def setup_method(self):
+        super(TestFogOfWar, self).setup_method()
+        self.app = create_app()
+        self.app.config["TESTING"] = True
+        self.app.config["WTF_CSRF_ENABLED"] = False
+        self.client = self.app.test_client()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+        # Create teams
+        self.white_team = Team(name="White Team", color="White")
+        self.blue_team = Team(name="Blue Team 1", color="Blue")
+        self.blue_team2 = Team(name="Blue Team 2", color="Blue")
+        self.red_team = Team(name="Red Team", color="Red")
+
+        self.session.add_all(
+            [self.white_team, self.blue_team, self.blue_team2, self.red_team]
+        )
+        self.session.commit()
+
+        # Create users
+        self.white_user = User(
+            username="whiteuser", password="pass", team=self.white_team
+        )
+        self.blue_user = User(
+            username="blueuser", password="pass", team=self.blue_team
+        )
+        self.red_user = User(username="reduser", password="pass", team=self.red_team)
+
+        self.session.add_all([self.white_user, self.blue_user, self.red_user])
+        self.session.commit()
+
+        # Create fog of war setting (disabled by default)
+        self.fog_setting = Setting(name="fog_of_war_enabled", value=False)
+        self.overview_setting = Setting(name="overview_show_round_info", value=True)
+        self.session.add_all([self.fog_setting, self.overview_setting])
+        self.session.commit()
+
+        # Create a round and some checks to generate scores
+        self.round = Round(number=1)
+        self.session.add(self.round)
+        self.session.commit()
+
+        # Create services for blue teams
+        self.service1 = Service(
+            name="HTTP",
+            check_name="HTTPCheck",
+            host="10.0.0.1",
+            port=80,
+            points=100,
+            team=self.blue_team,
+        )
+        self.service2 = Service(
+            name="HTTP",
+            check_name="HTTPCheck",
+            host="10.0.0.2",
+            port=80,
+            points=100,
+            team=self.blue_team2,
+        )
+        self.session.add_all([self.service1, self.service2])
+        self.session.commit()
+
+        # Create successful checks to generate scores
+        check1 = Check(round=self.round, service=self.service1)
+        check1.finished(True, "Success", "OK", "ping")
+        check2 = Check(round=self.round, service=self.service2)
+        check2.finished(True, "Success", "OK", "ping")
+        self.session.add_all([check1, check2])
+        self.session.commit()
+
+    def teardown_method(self):
+        Setting.clear_cache()
+        self.ctx.pop()
+        super(TestFogOfWar, self).teardown_method()
+
+    def login(self, username, password):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def logout(self):
+        return self.client.get("/logout", follow_redirects=True)
+
+    def test_scoreboard_bar_data_visible_when_fog_disabled(self):
+        """Scores should be visible when fog of war is disabled"""
+        Setting.clear_cache()
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        # Scores should be numeric, not "?"
+        assert "?" not in data["service_scores"]
+        assert "fog_of_war" not in data or data.get("fog_of_war") is False
+
+    def test_scoreboard_bar_data_hidden_when_fog_enabled(self):
+        """Scores should be hidden when fog of war is enabled for non-admin users"""
+        # Enable fog of war
+        self.fog_setting.value = True
+        self.session.commit()
+        Setting.clear_cache()
+
+        # Anonymous user should see hidden scores
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data.get("fog_of_war") is True
+        assert all(score == "?" for score in data["service_scores"])
+
+    def test_scoreboard_bar_data_visible_for_white_team_when_fog_enabled(self):
+        """White team should always see scores even when fog of war is enabled"""
+        # Enable fog of war
+        self.fog_setting.value = True
+        self.session.commit()
+        Setting.clear_cache()
+
+        # Login as white team
+        self.login("whiteuser", "pass")
+
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        # White team should see actual scores
+        assert "fog_of_war" not in data or data.get("fog_of_war") is False
+        assert "?" not in data["service_scores"]
+
+    def test_scoreboard_line_data_hidden_when_fog_enabled(self):
+        """Line chart data should be empty when fog of war is enabled"""
+        # Enable fog of war
+        self.fog_setting.value = True
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.get("/api/scoreboard/get_line_data")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data.get("fog_of_war") is True
+        # Scores should be empty arrays
+        for team in data["team"]:
+            assert team["scores"] == []
+
+    def test_overview_data_scores_hidden_when_fog_enabled(self):
+        """Overview should hide scores but show service status when fog enabled"""
+        # Enable fog of war
+        self.fog_setting.value = True
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        # First row is "Current Score" - values should be "?"
+        scores_row = data["data"][0]
+        assert scores_row[0] == "Current Score"
+        for score in scores_row[1:]:
+            assert score == "?"
+
+        # Second row is "Current Place" - values should be "?"
+        places_row = data["data"][1]
+        assert places_row[0] == "Current Place"
+        for place in places_row[1:]:
+            assert place == "?"
+
+    def test_fog_of_war_toggle_requires_white_team(self):
+        """Only white team should be able to toggle fog of war"""
+        Setting.clear_cache()
+
+        # Try as blue team - should fail
+        self.login("blueuser", "pass")
+        resp = self.client.post("/api/admin/update_fog_of_war")
+        assert resp.status_code == 403
+        self.logout()
+
+        # Try as white team - should succeed
+        self.login("whiteuser", "pass")
+        resp = self.client.post(
+            "/api/admin/update_fog_of_war", follow_redirects=False
+        )
+        # Should redirect to permissions page on success
+        assert resp.status_code == 302
+        assert "permissions" in resp.location


### PR DESCRIPTION
## Summary
- Add `fog_of_war_enabled` and `overview_show_round_info` settings
- White team can always see scores, even when fog of war is enabled
- Scoreboard API returns "?" instead of actual scores when fog is active
- Overview page still shows service up/down status but hides scores/places
- Admin toggle added to permissions page for easy control
- Config defaults: fog of war off by default

Part of Tier 1 Quick Wins implementation (#7 from roadmap).

## Test plan
- [ ] Verify scores visible when fog of war disabled
- [ ] Enable fog of war and verify scores show "?" for non-admin users
- [ ] Login as white team and verify scores still visible with fog enabled
- [ ] Check that overview shows service status but not scores
- [ ] Toggle fog of war on/off from admin permissions page

## Tests Added
- 6 unit tests covering fog of war functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)