### PR TITLE
Add weighted scoring to balance service/inject/flag scores

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -176,6 +176,13 @@ with app.app_context():
     db.session.add(Setting(name="dynamic_scoring_late_start_round", value=str(config.dynamic_scoring_late_start_round)))
     db.session.add(Setting(name="dynamic_scoring_late_multiplier", value=str(config.dynamic_scoring_late_multiplier)))
 
+    # Weighted Scoring Settings (balance service/inject/flag scores)
+    logger.info("Creating the Weighted Scoring Settings")
+    db.session.add(Setting(name="weighted_scoring_enabled", value=config.weighted_scoring_enabled))
+    db.session.add(Setting(name="service_weight", value=str(config.service_weight)))
+    db.session.add(Setting(name="inject_weight", value=str(config.inject_weight)))
+    db.session.add(Setting(name="flag_weight", value=str(config.flag_weight)))
+
     db.session.commit()
 
     if options.example:

--- a/engine.conf.inc
+++ b/engine.conf.inc
@@ -68,3 +68,14 @@ dynamic_scoring_early_multiplier = 2.0
 dynamic_scoring_late_start_round = 50
 # Multiplier for late rounds (e.g., 0.5 = 0.5x points)
 dynamic_scoring_late_multiplier = 0.5
+
+# Weighted Scoring Configuration
+# When enabled, applies multipliers to balance different score types
+# Useful when services total 10000 points but injects only 100 points
+weighted_scoring_enabled = False
+# Weight applied to service uptime scores (default 1.0 = no change)
+service_weight = 1.0
+# Weight applied to inject scores (default 1.0 = no change)
+inject_weight = 1.0
+# Weight applied to flag capture scores (default 1.0 = no change)
+flag_weight = 1.0

--- a/scoring_engine/config_loader.py
+++ b/scoring_engine/config_loader.py
@@ -224,6 +224,36 @@ class ConfigLoader(object):
             "float",
         )
 
+        # Weighted Scoring Configuration
+        # Allows admins to balance importance of different score types
+        self.weighted_scoring_enabled = self.parse_sources(
+            "weighted_scoring_enabled",
+            self.parser["OPTIONS"].get("weighted_scoring_enabled", "false").lower()
+            == "true",
+            "bool",
+        )
+
+        # Weight for service uptime scores (default 1.0 = no change)
+        self.service_weight = self.parse_sources(
+            "service_weight",
+            float(self.parser["OPTIONS"].get("service_weight", "1.0")),
+            "float",
+        )
+
+        # Weight for inject scores (default 1.0 = no change)
+        self.inject_weight = self.parse_sources(
+            "inject_weight",
+            float(self.parser["OPTIONS"].get("inject_weight", "1.0")),
+            "float",
+        )
+
+        # Weight for flag capture scores (default 1.0 = no change)
+        self.flag_weight = self.parse_sources(
+            "flag_weight",
+            float(self.parser["OPTIONS"].get("flag_weight", "1.0")),
+            "float",
+        )
+
     def parse_sources(self, key_name, default_value, obj_type="str"):
         """Return a configuration value using environment overrides when present.
 

--- a/scoring_engine/sla.py
+++ b/scoring_engine/sla.py
@@ -44,6 +44,14 @@ class SLAConfig:
             "dynamic_scoring_late_multiplier", 0.5
         )
 
+        # Weighted scoring settings (balance service/inject/flag scores)
+        self.weighted_scoring_enabled = self._get_bool_setting(
+            "weighted_scoring_enabled", False
+        )
+        self.service_weight = self._get_float_setting("service_weight", 1.0)
+        self.inject_weight = self._get_float_setting("inject_weight", 1.0)
+        self.flag_weight = self._get_float_setting("flag_weight", 1.0)
+
     def _get_setting(self, name, default):
         """Get a setting value from the database."""
         setting = Setting.get_setting(name)

--- a/scoring_engine/web/templates/admin/settings.html
+++ b/scoring_engine/web/templates/admin/settings.html
@@ -52,6 +52,77 @@
     </div>
   </form>
 
+  <!-- Weighted Scoring Configuration -->
+  <div class="panel panel-default" style="margin-top: 20px;">
+    <div class="panel-heading">
+      <h4 class="panel-title">Weighted Scoring</h4>
+    </div>
+    <div class="panel-body">
+      <p class="text-muted">Apply multipliers to balance different score types. Useful when services total 10000 points but injects only 100 points.</p>
+      <form id="weighted_scoring_form">
+        <div class="form-group">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" id="weighted_scoring_enabled" name="enabled">
+              Enable Weighted Scoring
+            </label>
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="service_weight">Service Weight</label>
+          <input type="number" step="0.1" min="0" class="form-control" id="service_weight" name="service_weight" value="1.0" style="width: 150px;">
+          <span class="help-block">Multiplier for service uptime scores (e.g., 0.5 = half points)</span>
+        </div>
+        <div class="form-group">
+          <label for="inject_weight">Inject Weight</label>
+          <input type="number" step="0.1" min="0" class="form-control" id="inject_weight" name="inject_weight" value="1.0" style="width: 150px;">
+          <span class="help-block">Multiplier for inject scores (e.g., 2.0 = double points)</span>
+        </div>
+        <div class="form-group">
+          <label for="flag_weight">Flag Weight</label>
+          <input type="number" step="0.1" min="0" class="form-control" id="flag_weight" name="flag_weight" value="1.0" style="width: 150px;">
+          <span class="help-block">Multiplier for flag capture scores</span>
+        </div>
+        <button type="button" class="btn btn-primary" onclick="saveWeightedScoring()">Save Weighted Scoring</button>
+        <span id="weighted_scoring_status" class="text-success" style="margin-left: 10px;"></span>
+      </form>
+    </div>
+  </div>
+
+  <script>
+    // Load weighted scoring settings on page load
+    $(document).ready(function() {
+      $.get('/api/admin/weighted_scoring/settings', function(data) {
+        $('#weighted_scoring_enabled').prop('checked', data.enabled);
+        $('#service_weight').val(data.service_weight);
+        $('#inject_weight').val(data.inject_weight);
+        $('#flag_weight').val(data.flag_weight);
+      });
+    });
+
+    function saveWeightedScoring() {
+      var data = {
+        enabled: $('#weighted_scoring_enabled').is(':checked'),
+        service_weight: parseFloat($('#service_weight').val()),
+        inject_weight: parseFloat($('#inject_weight').val()),
+        flag_weight: parseFloat($('#flag_weight').val())
+      };
+      $.ajax({
+        url: '/api/admin/weighted_scoring/settings',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(data),
+        success: function(response) {
+          $('#weighted_scoring_status').text('Saved!').fadeIn().delay(2000).fadeOut();
+        },
+        error: function() {
+          $('#weighted_scoring_status').removeClass('text-success').addClass('text-danger')
+            .text('Error saving settings').fadeIn().delay(2000).fadeOut();
+        }
+      });
+    }
+  </script>
+
   <div class="col-xs-3">
     <label for="ex1" class="pull-right" style="padding-top: 7px;">Welcome Page Content</label>
   </div>

--- a/tests/scoring_engine/web/views/api/test_weighted_scoring.py
+++ b/tests/scoring_engine/web/views/api/test_weighted_scoring.py
@@ -1,0 +1,256 @@
+"""Tests for Weighted Scoring functionality"""
+import json
+from datetime import datetime, timedelta
+
+from scoring_engine.models.check import Check
+from scoring_engine.models.inject import Inject, Template
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+from scoring_engine.web import create_app
+from tests.scoring_engine.unit_test import UnitTest
+
+
+class TestWeightedScoring(UnitTest):
+    """Tests for weighted scoring functionality"""
+
+    def setup_method(self):
+        super(TestWeightedScoring, self).setup_method()
+        self.app = create_app()
+        self.app.config["TESTING"] = True
+        self.app.config["WTF_CSRF_ENABLED"] = False
+        self.client = self.app.test_client()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+        # Create teams
+        self.white_team = Team(name="White Team", color="White")
+        self.blue_team = Team(name="Blue Team 1", color="Blue")
+        self.blue_team2 = Team(name="Blue Team 2", color="Blue")
+
+        self.session.add_all([self.white_team, self.blue_team, self.blue_team2])
+        self.session.commit()
+
+        # Create users
+        self.white_user = User(
+            username="whiteuser", password="pass", team=self.white_team
+        )
+        self.blue_user = User(
+            username="blueuser", password="pass", team=self.blue_team
+        )
+
+        self.session.add_all([self.white_user, self.blue_user])
+        self.session.commit()
+
+        # Create weighted scoring settings (disabled by default)
+        self.session.add(Setting(name="weighted_scoring_enabled", value=False))
+        self.session.add(Setting(name="service_weight", value="1.0"))
+        self.session.add(Setting(name="inject_weight", value="1.0"))
+        self.session.add(Setting(name="flag_weight", value="1.0"))
+        self.session.commit()
+
+        # Create a round and some checks to generate scores
+        self.round = Round(number=1)
+        self.session.add(self.round)
+        self.session.commit()
+
+        # Create services for blue teams - 100 points each
+        self.service1 = Service(
+            name="HTTP",
+            check_name="HTTPCheck",
+            host="10.0.0.1",
+            port=80,
+            points=100,
+            team=self.blue_team,
+        )
+        self.service2 = Service(
+            name="HTTP",
+            check_name="HTTPCheck",
+            host="10.0.0.2",
+            port=80,
+            points=100,
+            team=self.blue_team2,
+        )
+        self.session.add_all([self.service1, self.service2])
+        self.session.commit()
+
+        # Create successful checks to generate scores
+        check1 = Check(round=self.round, service=self.service1)
+        check1.finished(True, "Success", "OK", "ping")
+        check2 = Check(round=self.round, service=self.service2)
+        check2.finished(True, "Success", "OK", "ping")
+        self.session.add_all([check1, check2])
+        self.session.commit()
+
+        # Create inject template and inject for blue_team - 50 points
+        self.template = Template(
+            title="Test Inject",
+            scenario="Test scenario",
+            deliverable="Test deliverable",
+            score=50,
+            start_time=datetime.now() - timedelta(hours=1),
+            end_time=datetime.now() + timedelta(hours=1),
+        )
+        self.session.add(self.template)
+        self.session.commit()
+
+        self.inject = Inject(team=self.blue_team, template=self.template)
+        self.inject.score = 50
+        self.inject.status = "Graded"
+        self.session.add(self.inject)
+        self.session.commit()
+
+    def teardown_method(self):
+        Setting.clear_cache()
+        self.ctx.pop()
+        super(TestWeightedScoring, self).teardown_method()
+
+    def login(self, username, password):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def logout(self):
+        return self.client.get("/logout", follow_redirects=True)
+
+    def test_scores_unweighted_by_default(self):
+        """Scores should not be weighted when weighted scoring is disabled"""
+        Setting.clear_cache()
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        # Blue Team 1 has 100 service + 50 inject = 150
+        assert data["service_scores"][0] == "100"
+        assert data["inject_scores"][0] == "50"
+        assert data["adjusted_scores"][0] == "150"
+        assert data["weighted_scoring_enabled"] is False
+
+    def test_weighted_service_scores(self):
+        """Service scores should be multiplied by service_weight"""
+        # Enable weighted scoring with 0.5 service weight
+        setting = Setting.get_setting("weighted_scoring_enabled")
+        setting.value = True
+        self.session.commit()
+
+        weight_setting = Setting.get_setting("service_weight")
+        weight_setting.value = "0.5"
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        # Blue Team 1: 100 * 0.5 = 50 service + 50 inject = 100 total
+        assert data["service_scores"][0] == "50"
+        assert data["inject_scores"][0] == "50"
+        assert data["adjusted_scores"][0] == "100"
+        assert data["weighted_scoring_enabled"] is True
+
+    def test_weighted_inject_scores(self):
+        """Inject scores should be multiplied by inject_weight"""
+        # Enable weighted scoring with 2.0 inject weight
+        setting = Setting.get_setting("weighted_scoring_enabled")
+        setting.value = True
+        self.session.commit()
+
+        weight_setting = Setting.get_setting("inject_weight")
+        weight_setting.value = "2.0"
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        # Blue Team 1: 100 service + (50 * 2.0) = 100 inject = 200 total
+        assert data["service_scores"][0] == "100"
+        assert data["inject_scores"][0] == "100"
+        assert data["adjusted_scores"][0] == "200"
+
+    def test_combined_weights(self):
+        """Both service and inject weights should apply"""
+        # Enable weighted scoring with both weights
+        setting = Setting.get_setting("weighted_scoring_enabled")
+        setting.value = True
+        self.session.commit()
+
+        service_weight = Setting.get_setting("service_weight")
+        service_weight.value = "0.1"  # 100 * 0.1 = 10
+        inject_weight = Setting.get_setting("inject_weight")
+        inject_weight.value = "10.0"  # 50 * 10 = 500
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        # Blue Team 1: (100 * 0.1) + (50 * 10) = 10 + 500 = 510
+        assert data["service_scores"][0] == "10"
+        assert data["inject_scores"][0] == "500"
+        assert data["adjusted_scores"][0] == "510"
+
+    def test_admin_get_weighted_scoring_settings(self):
+        """White team should be able to get weighted scoring settings"""
+        self.login("whiteuser", "pass")
+        resp = self.client.get("/api/admin/weighted_scoring/settings")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert "enabled" in data
+        assert "service_weight" in data
+        assert "inject_weight" in data
+        assert "flag_weight" in data
+
+    def test_admin_update_weighted_scoring_settings(self):
+        """White team should be able to update weighted scoring settings"""
+        self.login("whiteuser", "pass")
+        resp = self.client.post(
+            "/api/admin/weighted_scoring/settings",
+            data=json.dumps({
+                "enabled": True,
+                "service_weight": 0.5,
+                "inject_weight": 2.0,
+                "flag_weight": 1.5,
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        Setting.clear_cache()
+
+        # Verify settings were saved
+        resp = self.client.get("/api/admin/weighted_scoring/settings")
+        data = json.loads(resp.data)
+        assert data["enabled"] is True
+        assert data["service_weight"] == 0.5
+        assert data["inject_weight"] == 2.0
+        assert data["flag_weight"] == 1.5
+
+    def test_non_admin_cannot_update_weighted_scoring(self):
+        """Non-admin users should not be able to update settings"""
+        self.login("blueuser", "pass")
+        resp = self.client.post(
+            "/api/admin/weighted_scoring/settings",
+            data=json.dumps({"enabled": True}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+
+    def test_weights_in_response_when_enabled(self):
+        """Weights should be included in response when weighted scoring enabled"""
+        setting = Setting.get_setting("weighted_scoring_enabled")
+        setting.value = True
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        data = json.loads(resp.data)
+        assert "weights" in data
+        assert "service" in data["weights"]
+        assert "inject" in data["weights"]
+        assert "flag" in data["weights"]


### PR DESCRIPTION
## Summary
- Add `weighted_scoring_enabled` toggle and weight settings for each score type
- Apply configurable multipliers to service, inject, and flag scores
- Add admin UI in settings page with AJAX-based configuration
- Useful when services generate far more points than injects (e.g., 10000 vs 100)

**Example use case:** If services total 10000 points but injects only 100 points, setting `inject_weight=100.0` makes inject scores equal in importance to service scores.

## Test plan
- [ ] Verify scores unchanged when weighted scoring disabled (default)
- [ ] Enable weighted scoring with service_weight=0.5, verify service scores halved
- [ ] Enable weighted scoring with inject_weight=2.0, verify inject scores doubled
- [ ] Test combined weights with both service and inject adjustments
- [ ] Configure settings via admin UI at /admin/settings
- [ ] Verify only white team can modify settings

## Tests Added
- 8 unit tests covering weighted scoring functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)