### PR TITLE
Add red team capture statistics to scoreboard

### DIFF
--- a/scoring_engine/web/templates/scoreboard.html
+++ b/scoring_engine/web/templates/scoreboard.html
@@ -259,5 +259,86 @@
             });
         }, 30000);
     </script>
+
+    <hr>
+    <h3 class="text-center">Red Team Captures</h3>
+    <div class="row mb-3">
+        <div class="col-md-6 offset-md-3 text-center">
+            <span class="badge bg-danger fs-6 me-2" id="redTeamTotalCaptures">0 Captures</span>
+            <span class="badge bg-dark fs-6" id="redTeamTotalPoints">0.0 Points</span>
+        </div>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="table-dark">
+                <tr>
+                    <th>Team</th>
+                    <th class="text-center">Linux User</th>
+                    <th class="text-center">Linux Root</th>
+                    <th class="text-center">Linux Score</th>
+                    <th class="text-center">Windows User</th>
+                    <th class="text-center">Windows Root</th>
+                    <th class="text-center">Windows Score</th>
+                    <th class="text-center">Total</th>
+                    <th class="text-center">Score</th>
+                </tr>
+            </thead>
+            <tbody id="redTeamTableBody">
+                <tr>
+                    <td colspan="9" class="text-center">Loading...</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <p class="text-muted text-center small">
+        <em>Scoring: Root capture = 1.0 point, User capture = 0.5 points (per platform)</em>
+    </p>
+    <script>
+        function loadRedTeamData() {
+            $.getJSON('/api/scoreboard/get_red_team_data')
+                .done(function(data) {
+                    $('#redTeamTotalCaptures').text(data.total_captures + ' Captures');
+                    $('#redTeamTotalPoints').text(data.total_red_points.toFixed(1) + ' Points');
+
+                    var tbody = $('#redTeamTableBody');
+                    tbody.empty();
+
+                    if (data.captures.length === 0) {
+                        tbody.append('<tr><td colspan="9" class="text-center">No captures yet</td></tr>');
+                        return;
+                    }
+
+                    // Sort by total score descending
+                    data.captures.sort(function(a, b) {
+                        return b.total_score - a.total_score;
+                    });
+
+                    data.captures.forEach(function(team) {
+                        var row = '<tr>' +
+                            '<td>' + team.team + '</td>' +
+                            '<td class="text-center">' + team.nix_user + '</td>' +
+                            '<td class="text-center">' + team.nix_root + '</td>' +
+                            '<td class="text-center">' + team.nix_score.toFixed(1) + '</td>' +
+                            '<td class="text-center">' + team.windows_user + '</td>' +
+                            '<td class="text-center">' + team.windows_root + '</td>' +
+                            '<td class="text-center">' + team.windows_score.toFixed(1) + '</td>' +
+                            '<td class="text-center"><strong>' + team.total_captures + '</strong></td>' +
+                            '<td class="text-center"><strong>' + team.total_score.toFixed(1) + '</strong></td>' +
+                            '</tr>';
+                        tbody.append(row);
+                    });
+                })
+                .fail(function(jqXHR, textStatus, errorThrown) {
+                    console.error('Failed to load red team data:', textStatus, errorThrown);
+                    $('#redTeamTableBody').html('<tr><td colspan="9" class="text-center text-danger">Failed to load data</td></tr>');
+                });
+        }
+
+        // Load initial data
+        loadRedTeamData();
+
+        // Update every 30 seconds
+        setInterval(loadRedTeamData, 30000);
+    </script>
 </div>
 {% endblock %}

--- a/tests/scoring_engine/web/views/api/test_red_team_scoreboard.py
+++ b/tests/scoring_engine/web/views/api/test_red_team_scoreboard.py
@@ -1,0 +1,199 @@
+import json
+from datetime import datetime, timedelta
+
+from scoring_engine.models.flag import Flag, FlagTypeEnum, Perm, Platform, Solve
+from scoring_engine.models.team import Team
+from scoring_engine.web import create_app
+from tests.scoring_engine.unit_test import UnitTest
+
+
+class TestRedTeamScoreboard(UnitTest):
+    def setup_method(self):
+        super(TestRedTeamScoreboard, self).setup_method()
+        self.app = create_app()
+        self.app.config["TESTING"] = True
+        self.app.config["WTF_CSRF_ENABLED"] = False
+        self.client = self.app.test_client()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+    def teardown_method(self):
+        self.ctx.pop()
+        super(TestRedTeamScoreboard, self).teardown_method()
+
+    def test_get_red_team_data_no_captures(self):
+        """Test endpoint returns empty captures when no flags exist."""
+        team = Team(name="Blue Team 1", color="Blue")
+        self.session.add(team)
+        self.session.commit()
+
+        resp = self.client.get("/api/scoreboard/get_red_team_data")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["total_captures"] == 0
+        assert data["total_red_points"] == 0.0
+        assert len(data["captures"]) == 1
+        assert data["captures"][0]["team"] == "Blue Team 1"
+        assert data["captures"][0]["total_score"] == 0.0
+
+    def test_get_red_team_data_with_nix_root_capture(self):
+        """Test scoring for nix root capture (1.0 points)."""
+        team = Team(name="Blue Team 1", color="Blue")
+        self.session.add(team)
+        self.session.commit()
+
+        flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.nix,
+            perm=Perm.root,
+            data={"path": "/tmp/flag.txt"},
+            start_time=datetime.now() - timedelta(hours=1),
+            end_time=datetime.now() + timedelta(hours=1),
+            dummy=False,
+        )
+        self.session.add(flag)
+        self.session.commit()
+
+        solve = Solve(flag=flag, host="test.host", team_id=team.id)
+        self.session.add(solve)
+        self.session.commit()
+
+        resp = self.client.get("/api/scoreboard/get_red_team_data")
+        data = json.loads(resp.data)
+
+        assert data["total_captures"] == 1
+        assert data["total_red_points"] == 1.0
+
+        team1_data = next((c for c in data["captures"] if c["team"] == "Blue Team 1"), None)
+        assert team1_data is not None
+        assert team1_data["nix_root"] == 1
+        assert team1_data["nix_score"] == 1.0
+        assert team1_data["total_score"] == 1.0
+
+    def test_get_red_team_data_with_windows_user_capture(self):
+        """Test scoring for windows user capture (0.5 points)."""
+        team = Team(name="Blue Team 1", color="Blue")
+        self.session.add(team)
+        self.session.commit()
+
+        flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.windows,
+            perm=Perm.user,
+            data={"path": "C:\\flag.txt"},
+            start_time=datetime.now() - timedelta(hours=1),
+            end_time=datetime.now() + timedelta(hours=1),
+            dummy=False,
+        )
+        self.session.add(flag)
+        self.session.commit()
+
+        solve = Solve(flag=flag, host="test.host", team_id=team.id)
+        self.session.add(solve)
+        self.session.commit()
+
+        resp = self.client.get("/api/scoreboard/get_red_team_data")
+        data = json.loads(resp.data)
+
+        assert data["total_captures"] == 1
+        assert data["total_red_points"] == 0.5
+
+        team1_data = next((c for c in data["captures"] if c["team"] == "Blue Team 1"), None)
+        assert team1_data is not None
+        assert team1_data["windows_user"] == 1
+        assert team1_data["windows_score"] == 0.5
+        assert team1_data["total_score"] == 0.5
+
+    def test_get_red_team_data_excludes_dummy_flags(self):
+        """Test that dummy flags are not counted in captures."""
+        team = Team(name="Blue Team 1", color="Blue")
+        self.session.add(team)
+        self.session.commit()
+
+        # Create a dummy flag (should be excluded)
+        dummy_flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.nix,
+            perm=Perm.root,
+            data={"path": "/tmp/dummy.txt"},
+            start_time=datetime.now() - timedelta(hours=1),
+            end_time=datetime.now() + timedelta(hours=1),
+            dummy=True,
+        )
+        self.session.add(dummy_flag)
+        self.session.commit()
+
+        solve = Solve(flag=dummy_flag, host="test.host", team_id=team.id)
+        self.session.add(solve)
+        self.session.commit()
+
+        resp = self.client.get("/api/scoreboard/get_red_team_data")
+        data = json.loads(resp.data)
+
+        assert data["total_captures"] == 0
+        assert data["total_red_points"] == 0.0
+
+    def test_get_red_team_data_multiple_teams_and_captures(self):
+        """Test aggregation across multiple teams and capture types."""
+        team1 = Team(name="Blue Team 1", color="Blue")
+        team2 = Team(name="Blue Team 2", color="Blue")
+        self.session.add_all([team1, team2])
+        self.session.commit()
+
+        # Team 1: nix root (1.0) + windows user (0.5) = 1.5
+        flag1 = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.nix,
+            perm=Perm.root,
+            data={"path": "/tmp/flag1.txt"},
+            start_time=datetime.now() - timedelta(hours=1),
+            end_time=datetime.now() + timedelta(hours=1),
+            dummy=False,
+        )
+        flag2 = Flag(
+            type=FlagTypeEnum.pipe,
+            platform=Platform.windows,
+            perm=Perm.user,
+            data={"path": "C:\\flag2.txt"},
+            start_time=datetime.now() - timedelta(hours=1),
+            end_time=datetime.now() + timedelta(hours=1),
+            dummy=False,
+        )
+        # Team 2: windows root (1.0)
+        flag3 = Flag(
+            type=FlagTypeEnum.reg,
+            platform=Platform.windows,
+            perm=Perm.root,
+            data={"path": "HKLM\\flag3"},
+            start_time=datetime.now() - timedelta(hours=1),
+            end_time=datetime.now() + timedelta(hours=1),
+            dummy=False,
+        )
+        self.session.add_all([flag1, flag2, flag3])
+        self.session.commit()
+
+        solve1 = Solve(flag=flag1, host="host1.team1", team_id=team1.id)
+        solve2 = Solve(flag=flag2, host="host2.team1", team_id=team1.id)
+        solve3 = Solve(flag=flag3, host="host1.team2", team_id=team2.id)
+        self.session.add_all([solve1, solve2, solve3])
+        self.session.commit()
+
+        resp = self.client.get("/api/scoreboard/get_red_team_data")
+        data = json.loads(resp.data)
+
+        assert data["total_captures"] == 3
+        assert data["total_red_points"] == 2.5  # 1.0 + 0.5 + 1.0
+
+        team1_data = next((c for c in data["captures"] if c["team"] == "Blue Team 1"), None)
+        assert team1_data["nix_root"] == 1
+        assert team1_data["nix_score"] == 1.0
+        assert team1_data["windows_user"] == 1
+        assert team1_data["windows_score"] == 0.5
+        assert team1_data["total_captures"] == 2
+        assert team1_data["total_score"] == 1.5
+
+        team2_data = next((c for c in data["captures"] if c["team"] == "Blue Team 2"), None)
+        assert team2_data["windows_root"] == 1
+        assert team2_data["windows_score"] == 1.0
+        assert team2_data["total_captures"] == 1
+        assert team2_data["total_score"] == 1.0


### PR DESCRIPTION
## Summary
- Add `/api/scoreboard/get_red_team_data` API endpoint that returns flag capture statistics per team
- Display red team captures table on scoreboard with Linux/Windows platform breakdown
- Scoring: root capture = 1.0 point, user capture = 0.5 points (per platform)
- Auto-refresh every 30 seconds along with other scoreboard data

## Changes
- `scoring_engine/web/views/api/scoreboard.py`: New `scoreboard_get_red_team_data()` endpoint
- `scoring_engine/web/templates/scoreboard.html`: Red team captures table with total stats
- New test file with 5 comprehensive tests

## Test plan
- [x] Run `pytest tests/scoring_engine/web/views/api/test_red_team_scoreboard.py` - all 5 tests pass
- [ ] Verify red team table displays on scoreboard page
- [ ] Verify captures update when flags are captured
- [ ] Verify dummy flags are excluded from counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)