### PR TITLE
Add score rollback feature for admin recalculation

### DIFF
--- a/scoring_engine/web/templates/admin/settings.html
+++ b/scoring_engine/web/templates/admin/settings.html
@@ -55,5 +55,182 @@
       </div>
     </div>
   </form>
+
+  <!-- Score Rollback Section -->
+  <hr class="my-4">
+  <h4 class="text-danger"><i class="bi bi-exclamation-triangle"></i> Score Rollback (Danger Zone)</h4>
+  <p class="text-muted">Roll back competition data to a specific round. This permanently deletes all rounds, checks, and related data from the specified round onwards.</p>
+
+  <div class="card border-danger mb-4">
+    <div class="card-body">
+      <div class="row align-items-end">
+        <div class="col-md-3">
+          <label for="rollbackRoundNumber" class="form-label">Rollback to before round:</label>
+          <input type="number" class="form-control" id="rollbackRoundNumber" min="1" placeholder="Round number">
+        </div>
+        <div class="col-md-2">
+          <button type="button" class="btn btn-outline-secondary" id="previewRollbackBtn">
+            Preview
+          </button>
+        </div>
+        <div class="col-md-5">
+          <div id="rollbackPreview" class="d-none">
+            <span class="text-muted">Will delete:</span>
+            <span id="rollbackPreviewRounds" class="badge bg-danger">0 rounds</span>
+            <span id="rollbackPreviewChecks" class="badge bg-warning text-dark">0 checks</span>
+            <span id="rollbackPreviewKB" class="badge bg-secondary">0 KB entries</span>
+          </div>
+        </div>
+        <div class="col-md-2">
+          <button type="button" class="btn btn-danger" id="executeRollbackBtn" disabled>
+            <i class="bi bi-trash"></i> Rollback
+          </button>
+        </div>
+      </div>
+      <div id="rollbackError" class="alert alert-danger mt-3 d-none"></div>
+      <div id="rollbackSuccess" class="alert alert-success mt-3 d-none"></div>
+    </div>
+  </div>
+
+  <!-- Rollback Confirmation Modal -->
+  <div class="modal fade" id="rollbackConfirmModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header bg-danger text-white">
+          <h5 class="modal-title">
+            <i class="bi bi-exclamation-triangle"></i> Confirm Score Rollback
+          </h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <p><strong>This action cannot be undone!</strong></p>
+          <p>You are about to delete:</p>
+          <ul>
+            <li><span id="confirmRounds">0</span> rounds</li>
+            <li><span id="confirmChecks">0</span> checks</li>
+            <li><span id="confirmKB">0</span> KB entries</li>
+          </ul>
+          <p>Type <strong>ROLLBACK</strong> to confirm:</p>
+          <input type="text" class="form-control" id="rollbackConfirmInput" placeholder="Type ROLLBACK">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-danger" id="confirmRollbackBtn" disabled>
+            Delete Data
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  $(document).ready(function() {
+    var previewData = null;
+
+    // Preview rollback
+    $('#previewRollbackBtn').click(function() {
+      var roundNumber = $('#rollbackRoundNumber').val();
+      if (!roundNumber || roundNumber < 1) {
+        $('#rollbackError').removeClass('d-none').text('Please enter a valid round number');
+        return;
+      }
+
+      $('#rollbackError').addClass('d-none');
+      $('#rollbackSuccess').addClass('d-none');
+
+      $.ajax({
+        url: '/api/admin/rollback/preview',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({ round_number: parseInt(roundNumber) }),
+        success: function(data) {
+          if (data.status === 'success') {
+            previewData = data;
+            $('#rollbackPreview').removeClass('d-none');
+            $('#rollbackPreviewRounds').text(data.will_delete.rounds + ' rounds');
+            $('#rollbackPreviewChecks').text(data.will_delete.checks + ' checks');
+            $('#rollbackPreviewKB').text(data.will_delete.kb_entries + ' KB entries');
+
+            if (data.will_delete.rounds > 0) {
+              $('#executeRollbackBtn').prop('disabled', false);
+            } else {
+              $('#executeRollbackBtn').prop('disabled', true);
+            }
+          } else {
+            $('#rollbackError').removeClass('d-none').text(data.message);
+          }
+        },
+        error: function(xhr) {
+          var msg = 'Error previewing rollback';
+          try { msg = JSON.parse(xhr.responseText).message; } catch(e) {}
+          $('#rollbackError').removeClass('d-none').text(msg);
+        }
+      });
+    });
+
+    // Open confirmation modal
+    $('#executeRollbackBtn').click(function() {
+      if (!previewData) return;
+
+      $('#confirmRounds').text(previewData.will_delete.rounds);
+      $('#confirmChecks').text(previewData.will_delete.checks);
+      $('#confirmKB').text(previewData.will_delete.kb_entries);
+      $('#rollbackConfirmInput').val('');
+      $('#confirmRollbackBtn').prop('disabled', true);
+
+      var modal = new bootstrap.Modal(document.getElementById('rollbackConfirmModal'));
+      modal.show();
+    });
+
+    // Enable confirm button when user types ROLLBACK
+    $('#rollbackConfirmInput').on('input', function() {
+      if ($(this).val() === 'ROLLBACK') {
+        $('#confirmRollbackBtn').prop('disabled', false);
+      } else {
+        $('#confirmRollbackBtn').prop('disabled', true);
+      }
+    });
+
+    // Execute rollback
+    $('#confirmRollbackBtn').click(function() {
+      var roundNumber = $('#rollbackRoundNumber').val();
+
+      $.ajax({
+        url: '/api/admin/rollback',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({
+          round_number: parseInt(roundNumber),
+          confirm: true
+        }),
+        success: function(data) {
+          bootstrap.Modal.getInstance(document.getElementById('rollbackConfirmModal')).hide();
+
+          if (data.status === 'success') {
+            $('#rollbackSuccess').removeClass('d-none').html(
+              '<strong>Rollback complete!</strong> Deleted ' +
+              data.deleted.rounds + ' rounds, ' +
+              data.deleted.checks + ' checks, ' +
+              data.deleted.kb_entries + ' KB entries. ' +
+              'Current round is now: ' + data.new_current_round
+            );
+            $('#rollbackPreview').addClass('d-none');
+            $('#executeRollbackBtn').prop('disabled', true);
+            previewData = null;
+          } else {
+            $('#rollbackError').removeClass('d-none').text(data.message);
+          }
+        },
+        error: function(xhr) {
+          bootstrap.Modal.getInstance(document.getElementById('rollbackConfirmModal')).hide();
+          var msg = 'Error executing rollback';
+          try { msg = JSON.parse(xhr.responseText).message; } catch(e) {}
+          $('#rollbackError').removeClass('d-none').text(msg);
+        }
+      });
+    });
+  });
+  </script>
+
 </div>
 {% endblock %}

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func
 
 from scoring_engine.cache_helper import (
+    update_all_cache,
     update_all_inject_data,
     update_inject_comments,
     update_inject_data,
@@ -1519,5 +1520,154 @@ def admin_check_dry_run():
             "port": service.port,
             "matching_content": environment.matching_content,
             "environment_id": environment.id,
+        }
+    )
+
+
+@mod.route("/api/admin/rollback", methods=["POST"])
+@login_required
+def admin_rollback():
+    """
+    Rollback competition data to a specific round.
+
+    Deletes all rounds, checks, and KB entries from the specified round onwards.
+    This is a destructive operation - use with caution.
+
+    Request JSON:
+    {
+        "round_number": 10,  // Delete this round and all after it
+        "confirm": true      // Required to confirm destructive action
+    }
+    """
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"status": "error", "message": "Request body required"}), 400
+
+    round_number = data.get("round_number")
+    confirm = data.get("confirm", False)
+
+    if round_number is None:
+        return jsonify({"status": "error", "message": "round_number is required"}), 400
+
+    try:
+        round_number = int(round_number)
+    except (ValueError, TypeError):
+        return jsonify({"status": "error", "message": "round_number must be an integer"}), 400
+
+    if round_number < 1:
+        return jsonify({"status": "error", "message": "round_number must be >= 1"}), 400
+
+    if not confirm:
+        return jsonify({"status": "error", "message": "confirm=true required for destructive operation"}), 400
+
+    # Get current round count for validation
+    current_round = Round.get_last_round_num()
+    if current_round == 0:
+        return jsonify({"status": "error", "message": "No rounds exist to rollback"}), 400
+
+    if round_number > current_round:
+        return jsonify(
+            {"status": "error", "message": f"round_number ({round_number}) exceeds current round ({current_round})"}
+        ), 400
+
+    # Get rounds to delete
+    rounds_to_delete = db.session.query(Round).filter(Round.number >= round_number).all()
+    round_ids = [r.id for r in rounds_to_delete]
+
+    # Count checks to delete
+    checks_count = db.session.query(Check).filter(Check.round_id.in_(round_ids)).count()
+
+    # Count KB entries to delete
+    kb_count = db.session.query(KB).filter(KB.round_num >= round_number).count()
+
+    # Delete checks first (foreign key constraint)
+    db.session.query(Check).filter(Check.round_id.in_(round_ids)).delete(synchronize_session=False)
+
+    # Delete KB entries
+    db.session.query(KB).filter(KB.round_num >= round_number).delete(synchronize_session=False)
+
+    # Delete rounds
+    rounds_count = len(rounds_to_delete)
+    for round_obj in rounds_to_delete:
+        db.session.delete(round_obj)
+
+    db.session.commit()
+
+    # Clear all caches to force recalculation
+    from flask import current_app
+
+    update_all_cache(current_app)
+
+    return jsonify(
+        {
+            "status": "success",
+            "message": f"Rolled back to before round {round_number}",
+            "deleted": {
+                "rounds": rounds_count,
+                "checks": checks_count,
+                "kb_entries": kb_count,
+            },
+            "new_current_round": Round.get_last_round_num(),
+        }
+    )
+
+
+@mod.route("/api/admin/rollback/preview", methods=["POST"])
+@login_required
+def admin_rollback_preview():
+    """Preview what would be deleted by a rollback operation."""
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"status": "error", "message": "Request body required"}), 400
+
+    round_number = data.get("round_number")
+    if round_number is None:
+        return jsonify({"status": "error", "message": "round_number is required"}), 400
+
+    try:
+        round_number = int(round_number)
+    except (ValueError, TypeError):
+        return jsonify({"status": "error", "message": "round_number must be an integer"}), 400
+
+    if round_number < 1:
+        return jsonify({"status": "error", "message": "round_number must be >= 1"}), 400
+
+    current_round = Round.get_last_round_num()
+    if current_round == 0:
+        return jsonify(
+            {
+                "status": "success",
+                "current_round": 0,
+                "round_number": round_number,
+                "will_delete": {"rounds": 0, "checks": 0, "kb_entries": 0},
+            }
+        )
+
+    # Get rounds that would be deleted
+    rounds_to_delete = db.session.query(Round).filter(Round.number >= round_number).all()
+    round_ids = [r.id for r in rounds_to_delete]
+
+    # Count checks
+    checks_count = db.session.query(Check).filter(Check.round_id.in_(round_ids)).count() if round_ids else 0
+
+    # Count KB entries
+    kb_count = db.session.query(KB).filter(KB.round_num >= round_number).count()
+
+    return jsonify(
+        {
+            "status": "success",
+            "current_round": current_round,
+            "round_number": round_number,
+            "will_delete": {
+                "rounds": len(rounds_to_delete),
+                "checks": checks_count,
+                "kb_entries": kb_count,
+            },
         }
     )

--- a/tests/scoring_engine/web/views/api/test_rollback.py
+++ b/tests/scoring_engine/web/views/api/test_rollback.py
@@ -1,0 +1,200 @@
+"""Tests for the score rollback API endpoints."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.check import Check
+from scoring_engine.models.kb import KB
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+
+
+class TestScoreRollback:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, db_session):
+        self.client = test_client
+
+        # Create teams
+        self.white_team = Team(name="White Team", color="White")
+        self.blue_team = Team(name="Blue Team 1", color="Blue")
+        db.session.add_all([self.white_team, self.blue_team])
+        db.session.commit()
+
+        # Create users
+        self.white_user = User(username="whiteuser", password="testpass", team=self.white_team)
+        self.blue_user = User(username="blueuser", password="testpass", team=self.blue_team)
+        db.session.add_all([self.white_user, self.blue_user])
+        db.session.commit()
+
+        # Create a service
+        self.service = Service(
+            name="TestService",
+            check_name="ICMPCheck",
+            host="192.168.1.1",
+            port=0,
+            points=100,
+            team=self.blue_team,
+        )
+        db.session.add(self.service)
+        db.session.commit()
+
+    def login_white_team(self):
+        return self.client.post(
+            "/login",
+            data={"username": "whiteuser", "password": "testpass"},
+            follow_redirects=True,
+        )
+
+    def login_blue_team(self):
+        return self.client.post(
+            "/login",
+            data={"username": "blueuser", "password": "testpass"},
+            follow_redirects=True,
+        )
+
+    def create_rounds(self, count):
+        """Helper to create test rounds with checks."""
+        for i in range(1, count + 1):
+            round_obj = Round(
+                number=i,
+                round_start=datetime.now(timezone.utc),
+                round_end=datetime.now(timezone.utc),
+            )
+            db.session.add(round_obj)
+            db.session.commit()
+
+            check = Check(round=round_obj, service=self.service, result=True, reason="Test check")
+            db.session.add(check)
+
+            kb = KB(round_num=i, name="task_ids", value="{}")
+            db.session.add(kb)
+
+        db.session.commit()
+
+    # === Rollback Preview Tests ===
+
+    def test_preview_requires_authentication(self):
+        resp = self.client.post("/api/admin/rollback/preview", json={"round_number": 1})
+        assert resp.status_code == 302
+
+    def test_preview_requires_white_team(self):
+        self.login_blue_team()
+        resp = self.client.post("/api/admin/rollback/preview", json={"round_number": 1})
+        assert resp.status_code == 403
+
+    def test_preview_requires_round_number(self):
+        self.login_white_team()
+        resp = self.client.post("/api/admin/rollback/preview", json={})
+        assert resp.status_code == 400
+
+    def test_preview_no_rounds(self):
+        self.login_white_team()
+        resp = self.client.post("/api/admin/rollback/preview", json={"round_number": 1})
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["current_round"] == 0
+        assert data["will_delete"]["rounds"] == 0
+
+    def test_preview_shows_correct_counts(self):
+        self.create_rounds(5)
+        self.login_white_team()
+        resp = self.client.post("/api/admin/rollback/preview", json={"round_number": 3})
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["current_round"] == 5
+        assert data["round_number"] == 3
+        assert data["will_delete"]["rounds"] == 3
+        assert data["will_delete"]["checks"] == 3
+        assert data["will_delete"]["kb_entries"] == 3
+
+    # === Rollback Tests ===
+
+    def test_rollback_requires_authentication(self):
+        resp = self.client.post("/api/admin/rollback", json={"round_number": 1, "confirm": True})
+        assert resp.status_code == 302
+
+    def test_rollback_requires_white_team(self):
+        self.login_blue_team()
+        resp = self.client.post("/api/admin/rollback", json={"round_number": 1, "confirm": True})
+        assert resp.status_code == 403
+
+    def test_rollback_requires_round_number(self):
+        self.login_white_team()
+        resp = self.client.post("/api/admin/rollback", json={"confirm": True})
+        assert resp.status_code == 400
+        assert "round_number is required" in resp.json["message"]
+
+    def test_rollback_requires_confirm(self):
+        self.create_rounds(5)
+        self.login_white_team()
+        resp = self.client.post("/api/admin/rollback", json={"round_number": 3})
+        assert resp.status_code == 400
+        assert "confirm" in resp.json["message"]
+
+    def test_rollback_no_rounds(self):
+        self.login_white_team()
+        resp = self.client.post("/api/admin/rollback", json={"round_number": 1, "confirm": True})
+        assert resp.status_code == 400
+        assert "No rounds exist" in resp.json["message"]
+
+    def test_rollback_round_exceeds_current(self):
+        self.create_rounds(5)
+        self.login_white_team()
+        resp = self.client.post("/api/admin/rollback", json={"round_number": 10, "confirm": True})
+        assert resp.status_code == 400
+        assert "exceeds current round" in resp.json["message"]
+
+    def test_rollback_success(self):
+        self.create_rounds(5)
+        self.login_white_team()
+
+        assert db.session.query(Round).count() == 5
+        assert db.session.query(Check).count() == 5
+        assert db.session.query(KB).count() == 5
+
+        resp = self.client.post("/api/admin/rollback", json={"round_number": 3, "confirm": True})
+        assert resp.status_code == 200
+        data = resp.json
+
+        assert data["status"] == "success"
+        assert data["deleted"]["rounds"] == 3
+        assert data["deleted"]["checks"] == 3
+        assert data["deleted"]["kb_entries"] == 3
+        assert data["new_current_round"] == 2
+
+        assert db.session.query(Round).count() == 2
+        assert db.session.query(Check).count() == 2
+        assert db.session.query(KB).count() == 2
+
+        remaining = [r.number for r in db.session.query(Round.number).all()]
+        assert remaining == [1, 2]
+
+    def test_rollback_all_rounds(self):
+        self.create_rounds(5)
+        self.login_white_team()
+
+        resp = self.client.post("/api/admin/rollback", json={"round_number": 1, "confirm": True})
+        assert resp.status_code == 200
+        data = resp.json
+
+        assert data["deleted"]["rounds"] == 5
+        assert data["new_current_round"] == 0
+        assert db.session.query(Round).count() == 0
+        assert db.session.query(Check).count() == 0
+        assert db.session.query(KB).count() == 0
+
+    def test_rollback_invalid_round_number(self):
+        self.login_white_team()
+
+        resp = self.client.post("/api/admin/rollback", json={"round_number": "abc", "confirm": True})
+        assert resp.status_code == 400
+
+        resp = self.client.post("/api/admin/rollback", json={"round_number": 0, "confirm": True})
+        assert resp.status_code == 400
+
+        resp = self.client.post("/api/admin/rollback", json={"round_number": -1, "confirm": True})
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- Add ability for white team to rollback competition data to a specific round
- Delete all rounds, checks, and KB entries from specified round onwards
- Clear all caches to force score recalculation

## Use Cases
- Remove test rounds run before competition starts
- Recover from configuration issues during competition
- Reset competition to a known good state

## API Endpoints
- `POST /api/admin/rollback/preview` - Preview what will be deleted
- `POST /api/admin/rollback` - Execute rollback (requires `confirm: true`)

## Safety Measures
- Preview endpoint shows exactly what will be deleted before executing
- `confirm: true` required in API request body
- UI requires typing "ROLLBACK" to confirm in modal dialog
- White team authorization required

## Changes
- `scoring_engine/web/views/api/admin.py`: New rollback endpoints
- `scoring_engine/web/templates/admin/settings.html`: Rollback UI with confirmation modal
- New test file with 14 comprehensive tests

## Test plan
- [x] Run `pytest tests/scoring_engine/web/views/api/test_rollback.py` - all 14 tests pass
- [ ] Verify rollback UI appears on admin settings page
- [ ] Test preview shows correct counts
- [ ] Verify rollback requires typing "ROLLBACK" confirmation
- [ ] Confirm caches are cleared after rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)