### PR TITLE
Add service dependency mapping for root cause analysis

### DIFF
--- a/scoring_engine/web/templates/admin/service.html
+++ b/scoring_engine/web/templates/admin/service.html
@@ -49,6 +49,28 @@
 
   $(document).ready(function () {
     $('.password').text("************");
+
+    // Handle dependency save
+    $('#save_dependency').click(function() {
+      var parentId = $('#parent_service').val();
+      var statusEl = $('#dependency_status');
+      statusEl.text('Saving...').removeClass('text-success text-danger');
+
+      $.ajax({
+        url: '/api/admin/service/{{ service.id }}/dependency',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({ parent_id: parentId }),
+        success: function(response) {
+          statusEl.text('Saved!').addClass('text-success');
+          setTimeout(function() { location.reload(); }, 1000);
+        },
+        error: function(xhr) {
+          var msg = xhr.responseJSON ? xhr.responseJSON.error : 'Error saving';
+          statusEl.text(msg).addClass('text-danger');
+        }
+      });
+    });
   });
 </script>
 {% endblock %}
@@ -100,6 +122,36 @@
       <a href="#" class="editable-textfield" data-type="text" data-pk="{{service.id}}"
         data-title="Enter Points per successful check" data-name="points"
         data-url="{{url_for('api.admin_update_points')}}">{{service.points}}</a>
+    </td>
+    <td style="padding-left: 30px;">
+      <h4>Dependencies</h4>
+      <div class="form-group">
+        <label for="parent_service">Parent Service (if this fails, consider parent as root cause)</label>
+        <select id="parent_service" class="form-control" style="width: 200px;">
+          <option value=""{% if not service.parent %} selected{% endif %}>None</option>
+          {% for team_service in team_services %}
+          <option value="{{ team_service.id }}"{% if service.parent_id == team_service.id %} selected{% endif %}>{{ team_service.name }}</option>
+          {% endfor %}
+        </select>
+        <button type="button" id="save_dependency" class="btn btn-sm btn-primary" style="margin-top: 5px;">Save</button>
+        <span id="dependency_status" style="margin-left: 10px;"></span>
+      </div>
+      {% if service.parent %}
+      <p><small>Current parent: <strong>{{ service.parent.name }}</strong>
+        {% if service.parent.last_check_result() == False %}
+        <span class="label label-danger">DOWN</span>
+        {% elif service.parent.last_check_result() == True %}
+        <span class="label label-success">UP</span>
+        {% endif %}
+      </small></p>
+      {% endif %}
+      {% if service.children %}
+      <p><small>Dependent services:
+        {% for child in service.children %}
+        <a href="{{ url_for('admin.service', id=child.id) }}">{{ child.name }}</a>{% if not loop.last %}, {% endif %}
+        {% endfor %}
+      </small></p>
+      {% endif %}
     </td>
   </tr>
 </table>

--- a/scoring_engine/web/views/admin.py
+++ b/scoring_engine/web/views/admin.py
@@ -103,8 +103,20 @@ def service(id):
         if service is None:
             return redirect(url_for("auth.unauthorized"))
 
+        # Get all services for this team (excluding current service) for dependency dropdown
+        team_services = (
+            db.session.query(Service)
+            .filter(Service.team_id == service.team_id)
+            .filter(Service.id != service.id)
+            .order_by(Service.name)
+            .all()
+        )
+
         return render_template(
-            "admin/service.html", service=service, blue_teams=blue_teams
+            "admin/service.html",
+            service=service,
+            blue_teams=blue_teams,
+            team_services=team_services,
         )
     else:
         return redirect(url_for("auth.unauthorized"))

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1088,3 +1088,133 @@ def admin_get_queue_stats():
         return jsonify(data=queue_stats)
     else:
         return {"status": "Unauthorized"}, 403
+
+
+@mod.route("/api/admin/service/<int:service_id>/dependency")
+@login_required
+def admin_get_service_dependency(service_id):
+    """Get dependency info for a service."""
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    service = db.session.get(Service, service_id)
+    if not service:
+        return jsonify({"error": "Service not found"}), 404
+
+    return jsonify({
+        "service_id": service.id,
+        "service_name": service.name,
+        "parent_id": service.parent_id,
+        "parent_name": service.parent.name if service.parent else None,
+        "children": [
+            {"id": child.id, "name": child.name}
+            for child in service.children
+        ],
+        "dependency_chain": [
+            {"id": s.id, "name": s.name}
+            for s in service.get_dependency_chain()
+        ],
+        "dependency_status": service.dependency_status,
+    })
+
+
+@mod.route("/api/admin/service/<int:service_id>/dependency", methods=["POST"])
+@login_required
+def admin_set_service_dependency(service_id):
+    """Set parent service for a service."""
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    service = db.session.get(Service, service_id)
+    if not service:
+        return jsonify({"error": "Service not found"}), 404
+
+    data = request.get_json() if request.is_json else request.form
+    parent_id = data.get("parent_id")
+
+    if parent_id is None or parent_id == "":
+        # Clear parent
+        service.parent_id = None
+        db.session.commit()
+        return jsonify({"status": "Parent dependency cleared"})
+
+    parent_id = int(parent_id)
+
+    # Validate parent service exists
+    parent = db.session.get(Service, parent_id)
+    if not parent:
+        return jsonify({"error": "Parent service not found"}), 404
+
+    # Prevent self-reference
+    if parent_id == service_id:
+        return jsonify({"error": "Service cannot be its own parent"}), 400
+
+    # Prevent circular dependencies - check if this would create a loop
+    visited = set()
+    current = parent
+    while current and current.id not in visited:
+        visited.add(current.id)
+        if current.parent_id == service_id:
+            return jsonify({"error": "Would create circular dependency"}), 400
+        current = current.parent
+
+    # Ensure parent is from same team
+    if parent.team_id != service.team_id:
+        return jsonify({"error": "Parent must be from same team"}), 400
+
+    service.parent_id = parent_id
+    db.session.commit()
+
+    return jsonify({
+        "status": "Parent dependency set",
+        "parent_id": parent_id,
+        "parent_name": parent.name,
+    })
+
+
+@mod.route("/api/admin/service/<int:service_id>/dependency", methods=["DELETE"])
+@login_required
+def admin_remove_service_dependency(service_id):
+    """Remove parent service dependency."""
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    service = db.session.get(Service, service_id)
+    if not service:
+        return jsonify({"error": "Service not found"}), 404
+
+    service.parent_id = None
+    db.session.commit()
+
+    return jsonify({"status": "Parent dependency removed"})
+
+
+@mod.route("/api/admin/team/<int:team_id>/services/dependencies")
+@login_required
+def admin_get_team_service_dependencies(team_id):
+    """Get all service dependencies for a team."""
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    team = db.session.get(Team, team_id)
+    if not team:
+        return jsonify({"error": "Team not found"}), 404
+
+    services = db.session.query(Service).filter(Service.team_id == team_id).all()
+
+    return jsonify({
+        "team_id": team_id,
+        "team_name": team.name,
+        "services": [
+            {
+                "id": s.id,
+                "name": s.name,
+                "parent_id": s.parent_id,
+                "parent_name": s.parent.name if s.parent else None,
+                "children_ids": [child.id for child in s.children],
+                "last_check_result": s.last_check_result(),
+                "dependency_status": s.dependency_status,
+            }
+            for s in services
+        ],
+    })

--- a/tests/scoring_engine/web/views/api/test_service_dependencies.py
+++ b/tests/scoring_engine/web/views/api/test_service_dependencies.py
@@ -1,0 +1,252 @@
+"""Tests for service dependency API endpoints."""
+import json
+from scoring_engine.models.service import Service
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+from scoring_engine.models.check import Check
+from scoring_engine.models.round import Round
+from scoring_engine.web import create_app
+from tests.scoring_engine.unit_test import UnitTest
+
+
+class TestServiceDependencies(UnitTest):
+
+    def setup_method(self):
+        super().setup_method()
+        self.app.config["TESTING"] = True
+        self.app.config["WTF_CSRF_ENABLED"] = False
+        self.client = self.app.test_client()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+        # Create white team and user for auth
+        self.white_team = Team(name="White Team", color="White")
+        self.session.add(self.white_team)
+        self.white_user = User(username="admin", password="testpass", team=self.white_team)
+        self.session.add(self.white_user)
+
+        # Create blue team and services
+        self.blue_team = Team(name="Blue Team 1", color="Blue")
+        self.session.add(self.blue_team)
+        self.dns_service = Service(
+            name="DNS", team=self.blue_team, check_name="DNS Check", host="10.0.0.1"
+        )
+        self.http_service = Service(
+            name="HTTP", team=self.blue_team, check_name="HTTP Check", host="10.0.0.2"
+        )
+        self.smtp_service = Service(
+            name="SMTP", team=self.blue_team, check_name="SMTP Check", host="10.0.0.3"
+        )
+        self.session.add(self.dns_service)
+        self.session.add(self.http_service)
+        self.session.add(self.smtp_service)
+        self.session.commit()
+
+    def teardown_method(self):
+        self.ctx.pop()
+        super().teardown_method()
+
+    def login(self, username, password):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def test_get_dependency_requires_auth(self):
+        """Test that getting dependency info requires authentication."""
+        response = self.client.get(f"/api/admin/service/{self.http_service.id}/dependency")
+        assert response.status_code == 302  # Redirect to login
+
+    def test_get_dependency_no_parent(self):
+        """Test getting dependency info for service with no parent."""
+        self.login("admin", "testpass")
+        response = self.client.get(f"/api/admin/service/{self.http_service.id}/dependency")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["service_id"] == self.http_service.id
+        assert data["parent_id"] is None
+        assert data["parent_name"] is None
+        assert data["children"] == []
+        assert data["dependency_chain"] == []
+
+    def test_get_dependency_with_parent(self):
+        """Test getting dependency info for service with parent."""
+        self.http_service.parent = self.dns_service
+        self.session.commit()
+
+        self.login("admin", "testpass")
+        response = self.client.get(f"/api/admin/service/{self.http_service.id}/dependency")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["parent_id"] == self.dns_service.id
+        assert data["parent_name"] == "DNS"
+        assert len(data["dependency_chain"]) == 1
+
+    def test_get_dependency_service_not_found(self):
+        """Test getting dependency for non-existent service."""
+        self.login("admin", "testpass")
+        response = self.client.get("/api/admin/service/99999/dependency")
+        assert response.status_code == 404
+
+    def test_set_dependency(self):
+        """Test setting a parent dependency."""
+        self.login("admin", "testpass")
+        response = self.client.post(
+            f"/api/admin/service/{self.http_service.id}/dependency",
+            json={"parent_id": self.dns_service.id},
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["parent_id"] == self.dns_service.id
+
+        # Verify in database
+        self.session.refresh(self.http_service)
+        assert self.http_service.parent_id == self.dns_service.id
+
+    def test_set_dependency_requires_auth(self):
+        """Test that setting dependency requires authentication."""
+        response = self.client.post(
+            f"/api/admin/service/{self.http_service.id}/dependency",
+            json={"parent_id": self.dns_service.id},
+        )
+        assert response.status_code == 302
+
+    def test_set_dependency_clear_parent(self):
+        """Test clearing parent dependency with empty value."""
+        self.http_service.parent = self.dns_service
+        self.session.commit()
+
+        self.login("admin", "testpass")
+        response = self.client.post(
+            f"/api/admin/service/{self.http_service.id}/dependency",
+            json={"parent_id": ""},
+        )
+        assert response.status_code == 200
+
+        self.session.refresh(self.http_service)
+        assert self.http_service.parent_id is None
+
+    def test_set_dependency_prevents_self_reference(self):
+        """Test that service cannot be its own parent."""
+        self.login("admin", "testpass")
+        response = self.client.post(
+            f"/api/admin/service/{self.http_service.id}/dependency",
+            json={"parent_id": self.http_service.id},
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert "own parent" in data["error"]
+
+    def test_set_dependency_prevents_circular(self):
+        """Test that circular dependencies are prevented."""
+        # Set DNS → HTTP
+        self.dns_service.parent = self.http_service
+        self.session.commit()
+
+        # Try to set HTTP → DNS (would create circular)
+        self.login("admin", "testpass")
+        response = self.client.post(
+            f"/api/admin/service/{self.http_service.id}/dependency",
+            json={"parent_id": self.dns_service.id},
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert "circular" in data["error"].lower()
+
+    def test_set_dependency_requires_same_team(self):
+        """Test that parent must be from same team."""
+        other_team = Team(name="Blue Team 2", color="Blue")
+        self.session.add(other_team)
+        other_service = Service(
+            name="Other DNS", team=other_team, check_name="DNS Check", host="10.0.1.1"
+        )
+        self.session.add(other_service)
+        self.session.commit()
+
+        self.login("admin", "testpass")
+        response = self.client.post(
+            f"/api/admin/service/{self.http_service.id}/dependency",
+            json={"parent_id": other_service.id},
+        )
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert "same team" in data["error"].lower()
+
+    def test_set_dependency_parent_not_found(self):
+        """Test setting non-existent parent."""
+        self.login("admin", "testpass")
+        response = self.client.post(
+            f"/api/admin/service/{self.http_service.id}/dependency",
+            json={"parent_id": 99999},
+        )
+        assert response.status_code == 404
+
+    def test_remove_dependency(self):
+        """Test removing parent dependency."""
+        self.http_service.parent = self.dns_service
+        self.session.commit()
+
+        self.login("admin", "testpass")
+        response = self.client.delete(
+            f"/api/admin/service/{self.http_service.id}/dependency"
+        )
+        assert response.status_code == 200
+
+        self.session.refresh(self.http_service)
+        assert self.http_service.parent_id is None
+
+    def test_get_team_dependencies(self):
+        """Test getting all service dependencies for a team."""
+        # Set up some dependencies
+        self.http_service.parent = self.dns_service
+        self.smtp_service.parent = self.dns_service
+        self.session.commit()
+
+        self.login("admin", "testpass")
+        response = self.client.get(
+            f"/api/admin/team/{self.blue_team.id}/services/dependencies"
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)
+
+        assert data["team_id"] == self.blue_team.id
+        assert len(data["services"]) == 3
+
+        # Find HTTP service in response
+        http_data = next(s for s in data["services"] if s["name"] == "HTTP")
+        assert http_data["parent_id"] == self.dns_service.id
+        assert http_data["parent_name"] == "DNS"
+
+        # Find DNS service - should have 2 children
+        dns_data = next(s for s in data["services"] if s["name"] == "DNS")
+        assert len(dns_data["children_ids"]) == 2
+
+    def test_get_team_dependencies_team_not_found(self):
+        """Test getting dependencies for non-existent team."""
+        self.login("admin", "testpass")
+        response = self.client.get("/api/admin/team/99999/services/dependencies")
+        assert response.status_code == 404
+
+    def test_dependency_status_with_failing_parent(self):
+        """Test dependency status shows root cause when parent fails."""
+        # Set up dependency
+        self.http_service.parent = self.dns_service
+        self.session.commit()
+
+        # Create failing check for DNS
+        round_obj = Round(number=1)
+        self.session.add(round_obj)
+        check = Check(round=round_obj, service=self.dns_service, result=False, output="Failed")
+        self.session.add(check)
+        self.session.commit()
+
+        self.login("admin", "testpass")
+        response = self.client.get(f"/api/admin/service/{self.http_service.id}/dependency")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+
+        status = data["dependency_status"]
+        assert status["parent_is_down"] is True
+        assert status["root_cause"]["id"] == self.dns_service.id
+        assert status["root_cause"]["name"] == "DNS"


### PR DESCRIPTION
## Summary
- Allow defining parent-child relationships between services (e.g., DNS → HTTP, Network → DNS → HTTP)
- When a parent service fails, child services show root cause information to identify cascading failures
- Admin UI to configure dependencies and visualize dependent services
- API endpoints for programmatic dependency management

## Features
- **Service Model**: Added `parent_id` column and self-referential relationship
- **Model Methods**:
  - `parent_is_down()` - check if parent service's last check failed
  - `get_root_cause()` - traverse parent chain to find topmost failing service
  - `get_dependency_chain()` - get all parent services in order
  - `dependency_status` property - comprehensive status for API/UI
- **API Endpoints**:
  - `GET /api/admin/service/<id>/dependency` - get dependency info
  - `POST /api/admin/service/<id>/dependency` - set parent service
  - `DELETE /api/admin/service/<id>/dependency` - remove parent
  - `GET /api/admin/team/<id>/services/dependencies` - all team dependencies
- **Admin UI**: Dropdown to select parent service, shows current parent status, lists dependent services
- **Safety**: Prevents circular dependencies, self-references, and cross-team parent assignments

## Use Case
With 40+ services per team in qualifiers, when a critical service (DNS, LDAP, etc.) fails, many dependent services also fail. This feature helps organizers and teams quickly identify the root cause of cascading failures rather than investigating each service individually.

## Test plan
- [x] Unit tests for Service model dependency methods (11 new tests)
- [x] API endpoint tests for all dependency operations (15 new tests)
- [x] Full test suite passes (548 tests)
- [ ] Manual testing: configure DNS → HTTP dependency, fail DNS, verify HTTP shows root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)