### PR TITLE
Add attack logging and correlation with service failures

### DIFF
--- a/scoring_engine/models/flag.py
+++ b/scoring_engine/models/flag.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
     ForeignKey,
+    func,
 )
 
 # from sqlalchemy.dialects.postgresql import UUID
@@ -95,5 +96,15 @@ class Solve(Base):
     host = Column(String(260), nullable=False)
     flag_id = Column(String(36), ForeignKey("flags.id"))
     team_id = Column(Integer, ForeignKey("teams.id"))
+    captured_at = Column(DateTime(timezone=True), default=func.now(), nullable=True)
     flag = relationship("Flag", backref="solves", lazy="joined")
     team = relationship("Team", backref="flag_solves", lazy="joined")
+
+    @property
+    def localize_captured_at(self):
+        """Get captured_at timestamp in configured timezone."""
+        if self.captured_at is None:
+            return None
+        return _ensure_utc_aware(self.captured_at).astimezone(
+            pytz.timezone(config.timezone)
+        ).strftime("%Y-%m-%d %H:%M:%S %Z")

--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -56,6 +56,17 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="panel-title">
+            <span>Red Team <b class="pull-right glyphicon glyphicon-fire"></b></span>
+          </div>
+        </div>
+        <div class="list-group">
+          <a class="list-group-item {% if request.path == '/admin/attacks' %}active{% endif %}"
+            href="/admin/attacks">Attack Log</a>
+        </div>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div class="panel-title">
             <span>Services <b class="pull-right glyphicon glyphicon-tasks"></b></span>
           </div>
         </div>

--- a/scoring_engine/web/templates/admin/attacks.html
+++ b/scoring_engine/web/templates/admin/attacks.html
@@ -1,0 +1,310 @@
+{% extends 'admin/adminbase.html' %}
+{% block title %}Admin - Attack Log{% endblock %}
+
+{% block head %}
+{{ super() }}
+<script src="{{ url_for('static', filename='vendor/js/jquery.dataTables.min.js') }}"></script>
+<script src="{{ url_for('static', filename='vendor/js/dataTables.bootstrap.min.js') }}"></script>
+<link href="{{ url_for('static', filename='vendor/css/dataTables.bootstrap.min.css') }}" rel="stylesheet" />
+<style>
+  .stat-box {
+    padding: 15px;
+    margin-bottom: 15px;
+    background: #f9f9f9;
+    border-radius: 4px;
+    text-align: center;
+  }
+  .stat-box h3 {
+    margin: 0 0 5px 0;
+    font-size: 28px;
+  }
+  .stat-box small {
+    color: #666;
+  }
+  .correlation-card {
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    margin-bottom: 10px;
+    padding: 10px;
+  }
+  .correlation-card.has-failures {
+    border-left: 4px solid #d9534f;
+  }
+  .correlation-card.no-failures {
+    border-left: 4px solid #5cb85c;
+  }
+  .failure-item {
+    background: #fcf8e3;
+    padding: 5px 10px;
+    margin: 5px 0;
+    border-radius: 3px;
+    font-size: 12px;
+  }
+  .failure-item.after-capture {
+    background: #f2dede;
+  }
+  .timestamp {
+    font-family: monospace;
+    font-size: 11px;
+    color: #666;
+  }
+</style>
+{% endblock %}
+
+{% block header %}Attack Log & Correlation{% endblock %}
+
+{% block admincontent %}
+<div style="padding-top: 20px;">
+
+  <!-- Summary Stats -->
+  <h4>Attack Summary</h4>
+  <div class="row" id="summary-stats">
+    <div class="col-md-3">
+      <div class="stat-box">
+        <h3 id="stat-total">-</h3>
+        <small>Total Captures</small>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="stat-box">
+        <h3 id="stat-nix">-</h3>
+        <small>Linux Captures</small>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="stat-box">
+        <h3 id="stat-win">-</h3>
+        <small>Windows Captures</small>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="stat-box">
+        <h3 id="stat-root">-</h3>
+        <small>Root/Admin Captures</small>
+      </div>
+    </div>
+  </div>
+
+  <!-- Captures by Team -->
+  <div class="row">
+    <div class="col-md-6">
+      <h5>Top Red Teams (Attackers)</h5>
+      <table class="table table-condensed" id="red-team-table">
+        <thead>
+          <tr><th>Team</th><th>Captures</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div class="col-md-6">
+      <h5>Most Targeted (Victims)</h5>
+      <table class="table table-condensed" id="victim-table">
+        <thead>
+          <tr><th>Team</th><th>Captures Against</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+
+  <hr>
+
+  <!-- Attack Timeline -->
+  <h4>Recent Captures</h4>
+  <div class="form-inline" style="margin-bottom: 15px;">
+    <div class="form-group">
+      <label for="filter-team">Filter by Victim Team:</label>
+      <select id="filter-team" class="form-control input-sm">
+        <option value="">All Teams</option>
+        {% for team in blue_teams %}
+        <option value="{{ team.id }}">{{ team.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <button class="btn btn-sm btn-default" onclick="loadTimeline()">Refresh</button>
+  </div>
+
+  <table id="timeline" class="table table-striped table-bordered table-condensed">
+    <thead>
+      <tr>
+        <th>Time</th>
+        <th>Host</th>
+        <th>Red Team</th>
+        <th>Blue Team</th>
+        <th>Platform</th>
+        <th>Permission</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
+  <hr>
+
+  <!-- Attack/Failure Correlation -->
+  <h4>Attack/Failure Correlation</h4>
+  <p class="text-muted">Shows service check failures that occurred within a time window of flag captures,
+    helping identify if a failure was caused by red team activity or self-inflicted.</p>
+
+  <div class="form-inline" style="margin-bottom: 15px;">
+    <div class="form-group">
+      <label for="correlation-window">Time Window:</label>
+      <select id="correlation-window" class="form-control input-sm">
+        <option value="60">1 minute</option>
+        <option value="180">3 minutes</option>
+        <option value="300" selected>5 minutes</option>
+        <option value="600">10 minutes</option>
+      </select>
+    </div>
+    <div class="form-group" style="margin-left: 15px;">
+      <label for="correlation-team">Team:</label>
+      <select id="correlation-team" class="form-control input-sm">
+        <option value="">All Teams</option>
+        {% for team in blue_teams %}
+        <option value="{{ team.id }}">{{ team.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <button class="btn btn-sm btn-primary" onclick="loadCorrelation()">Analyze</button>
+  </div>
+
+  <div id="correlation-summary" class="alert alert-info" style="display: none;">
+    Analyzed <strong id="corr-total">0</strong> captures.
+    <strong id="corr-with-failures">0</strong> had nearby service failures.
+    <strong id="corr-likely-caused">0</strong> likely caused by attack (failure occurred after capture).
+  </div>
+
+  <div id="correlation-results"></div>
+
+</div>
+
+<script>
+$(document).ready(function() {
+  loadSummary();
+  loadTimeline();
+});
+
+function loadSummary() {
+  $.getJSON('/api/attacks/summary', function(data) {
+    $('#stat-total').text(data.total_captures);
+
+    // Platform stats
+    var nixCount = 0, winCount = 0;
+    data.by_platform.forEach(function(p) {
+      if (p.platform === 'nix') nixCount = p.count;
+      if (p.platform === 'win') winCount = p.count;
+    });
+    $('#stat-nix').text(nixCount);
+    $('#stat-win').text(winCount);
+
+    // Root/admin stats
+    var rootCount = 0;
+    data.by_permission.forEach(function(p) {
+      if (p.perm === 'root') rootCount = p.count;
+    });
+    $('#stat-root').text(rootCount);
+
+    // Red team table
+    var redHtml = '';
+    data.by_red_team.forEach(function(t) {
+      redHtml += '<tr><td>' + t.team + '</td><td>' + t.count + '</td></tr>';
+    });
+    $('#red-team-table tbody').html(redHtml || '<tr><td colspan="2">No data</td></tr>');
+
+    // Victim table
+    var victimHtml = '';
+    data.by_victim.forEach(function(t) {
+      victimHtml += '<tr><td>' + t.team + '</td><td>' + t.count + '</td></tr>';
+    });
+    $('#victim-table tbody').html(victimHtml || '<tr><td colspan="2">No data</td></tr>');
+  });
+}
+
+function loadTimeline() {
+  var teamId = $('#filter-team').val();
+  var url = '/api/attacks/timeline?limit=50';
+  if (teamId) url += '&team_id=' + teamId;
+
+  $.getJSON(url, function(data) {
+    var html = '';
+    data.data.forEach(function(capture) {
+      var time = capture.captured_at_local || 'Unknown';
+      var redTeam = capture.red_team ? capture.red_team.name : 'Unknown';
+      var blueTeam = capture.blue_team ? capture.blue_team.name : 'Unknown';
+      var platform = capture.flag ? capture.flag.platform : '-';
+      var perm = capture.flag ? capture.flag.perm : '-';
+
+      var permClass = perm === 'root' ? 'danger' : 'warning';
+
+      html += '<tr>';
+      html += '<td class="timestamp">' + time + '</td>';
+      html += '<td>' + capture.host + '</td>';
+      html += '<td><span class="label label-danger">' + redTeam + '</span></td>';
+      html += '<td><span class="label label-primary">' + blueTeam + '</span></td>';
+      html += '<td>' + platform + '</td>';
+      html += '<td><span class="label label-' + permClass + '">' + perm + '</span></td>';
+      html += '</tr>';
+    });
+
+    $('#timeline tbody').html(html || '<tr><td colspan="6">No captures recorded</td></tr>');
+  });
+}
+
+function loadCorrelation() {
+  var window = $('#correlation-window').val();
+  var teamId = $('#correlation-team').val();
+  var url = '/api/attacks/correlation?window_seconds=' + window + '&limit=30';
+  if (teamId) url += '&team_id=' + teamId;
+
+  $('#correlation-results').html('<p>Loading...</p>');
+
+  $.getJSON(url, function(data) {
+    // Update summary
+    $('#correlation-summary').show();
+    $('#corr-total').text(data.summary.total_captures);
+    $('#corr-with-failures').text(data.summary.captures_with_nearby_failures);
+    $('#corr-likely-caused').text(data.summary.likely_attack_caused_failures);
+
+    // Build results
+    var html = '';
+    data.correlations.forEach(function(corr) {
+      var cardClass = corr.failure_count > 0 ? 'has-failures' : 'no-failures';
+      var capture = corr.capture;
+
+      html += '<div class="correlation-card ' + cardClass + '">';
+      html += '<div class="row">';
+      html += '<div class="col-md-6">';
+      html += '<strong>Capture:</strong> ' + capture.host + ' ';
+      html += '<span class="label label-danger">' + (capture.red_team || 'Unknown') + '</span> ';
+      html += '<span class="label label-default">' + capture.flag_platform + '/' + capture.flag_perm + '</span>';
+      html += '<br><span class="timestamp">' + capture.captured_at + '</span>';
+      html += '</div>';
+      html += '<div class="col-md-6">';
+
+      if (corr.failure_count === 0) {
+        html += '<span class="text-success">No nearby service failures</span>';
+      } else {
+        html += '<strong>' + corr.failure_count + ' failures nearby:</strong>';
+        corr.related_failures.forEach(function(f) {
+          var failClass = f.before_or_after === 'after' ? 'after-capture' : '';
+          var timeLabel = f.seconds_from_capture > 0 ?
+            '+' + f.seconds_from_capture + 's after' :
+            Math.abs(f.seconds_from_capture) + 's before';
+
+          html += '<div class="failure-item ' + failClass + '">';
+          html += '<strong>' + f.service_name + '</strong> (' + f.team_name + ') ';
+          html += '<span class="label label-' + (f.before_or_after === 'after' ? 'danger' : 'warning') + '">' + timeLabel + '</span>';
+          if (f.reason) html += '<br><small>' + f.reason.substring(0, 100) + '</small>';
+          html += '</div>';
+        });
+      }
+
+      html += '</div></div></div>';
+    });
+
+    $('#correlation-results').html(html || '<p class="text-muted">No captures with timestamps available for correlation.</p>');
+  }).fail(function() {
+    $('#correlation-results').html('<p class="text-danger">Error loading correlation data.</p>');
+  });
+}
+</script>
+{% endblock %}

--- a/scoring_engine/web/views/admin.py
+++ b/scoring_engine/web/views/admin.py
@@ -157,6 +157,22 @@ def permissions():
         return redirect(url_for("auth.unauthorized"))
 
 
+@mod.route("/admin/attacks")
+@login_required
+def attacks():
+    """Attack logging and correlation view."""
+    if current_user.is_white_team:
+        blue_teams = Team.get_all_blue_teams()
+        red_teams = db.session.query(Team).filter(Team.color == "Red").all()
+        return render_template(
+            "admin/attacks.html",
+            blue_teams=blue_teams,
+            red_teams=red_teams,
+        )
+    else:
+        return redirect(url_for("auth.unauthorized"))
+
+
 @mod.route("/admin/sla")
 @login_required
 def sla():

--- a/scoring_engine/web/views/api/__init__.py
+++ b/scoring_engine/web/views/api/__init__.py
@@ -19,6 +19,7 @@ mod = Blueprint("api", __name__)
 
 from . import admin
 from . import agent
+from . import attacks
 from . import flags
 from . import injects
 from . import notifications

--- a/scoring_engine/web/views/api/attacks.py
+++ b/scoring_engine/web/views/api/attacks.py
@@ -1,0 +1,389 @@
+"""API endpoints for attack logging and correlation with service failures."""
+from datetime import timedelta
+
+from flask import jsonify, request
+from flask_login import current_user, login_required
+from sqlalchemy import and_, desc, func
+from sqlalchemy.orm import joinedload
+
+from scoring_engine.db import db
+from scoring_engine.models.check import Check
+from scoring_engine.models.flag import Flag, Solve, Platform, Perm
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.team import Team
+
+from . import mod
+
+
+@mod.route("/api/attacks/timeline")
+@login_required
+def attacks_timeline():
+    """
+    Get attack timeline showing flag captures with timestamps.
+    Returns captures ordered by time, most recent first.
+
+    Query params:
+        limit: max results (default 100)
+        team_id: filter by blue team (victim)
+        host: filter by host
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    limit = request.args.get("limit", 100, type=int)
+    team_id = request.args.get("team_id", type=int)
+    host = request.args.get("host")
+
+    query = (
+        db.session.query(Solve)
+        .options(joinedload(Solve.flag), joinedload(Solve.team))
+        .join(Flag)
+        .filter(Flag.dummy.is_(False))  # Exclude dummy flags
+    )
+
+    if team_id:
+        # Filter by blue team - need to match host to service
+        services = db.session.query(Service.host).filter(Service.team_id == team_id).all()
+        hosts = [s.host for s in services]
+        query = query.filter(Solve.host.in_(hosts))
+
+    if host:
+        query = query.filter(Solve.host == host)
+
+    # Order by captured_at if available, otherwise by id (creation order)
+    solves = (
+        query.order_by(desc(Solve.captured_at), desc(Solve.id))
+        .limit(limit)
+        .all()
+    )
+
+    # Get blue team info for each host
+    host_to_team = {}
+    all_hosts = set(s.host for s in solves)
+    if all_hosts:
+        services = (
+            db.session.query(Service.host, Team.id, Team.name)
+            .join(Team)
+            .filter(Service.host.in_(all_hosts))
+            .filter(Team.color == "Blue")
+            .all()
+        )
+        for service in services:
+            host_to_team[service.host] = {"id": service.id, "name": service.name}
+
+    data = []
+    for solve in solves:
+        blue_team = host_to_team.get(solve.host)
+        data.append({
+            "id": solve.id,
+            "flag_id": solve.flag_id,
+            "host": solve.host,
+            "red_team": {
+                "id": solve.team.id,
+                "name": solve.team.name,
+            } if solve.team else None,
+            "blue_team": blue_team,
+            "captured_at": solve.captured_at.isoformat() if solve.captured_at else None,
+            "captured_at_local": solve.localize_captured_at,
+            "flag": {
+                "type": solve.flag.type.value,
+                "platform": solve.flag.platform.value,
+                "perm": solve.flag.perm.value,
+            } if solve.flag else None,
+        })
+
+    return jsonify({"data": data, "count": len(data)})
+
+
+@mod.route("/api/attacks/correlation")
+@login_required
+def attacks_correlation():
+    """
+    Correlate flag captures with service check failures.
+    Shows which service failures occurred near the time of flag captures.
+
+    Query params:
+        window_seconds: time window around capture to look for failures (default 300 = 5 min)
+        team_id: filter by blue team
+        limit: max captures to analyze (default 50)
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    window_seconds = request.args.get("window_seconds", 300, type=int)
+    team_id = request.args.get("team_id", type=int)
+    limit = request.args.get("limit", 50, type=int)
+
+    # Get recent captures with timestamps
+    query = (
+        db.session.query(Solve)
+        .options(joinedload(Solve.flag), joinedload(Solve.team))
+        .join(Flag)
+        .filter(Flag.dummy.is_(False))
+        .filter(Solve.captured_at.isnot(None))  # Only captures with timestamps
+    )
+
+    if team_id:
+        services = db.session.query(Service.host).filter(Service.team_id == team_id).all()
+        hosts = [s.host for s in services]
+        query = query.filter(Solve.host.in_(hosts))
+
+    solves = (
+        query.order_by(desc(Solve.captured_at))
+        .limit(limit)
+        .all()
+    )
+
+    # Build host -> service/team mapping
+    all_hosts = set(s.host for s in solves)
+    host_to_service = {}
+    if all_hosts:
+        services = (
+            db.session.query(Service)
+            .options(joinedload(Service.team))
+            .filter(Service.host.in_(all_hosts))
+            .all()
+        )
+        for service in services:
+            if service.host not in host_to_service:
+                host_to_service[service.host] = []
+            host_to_service[service.host].append(service)
+
+    correlations = []
+    for solve in solves:
+        capture_time = solve.captured_at
+        window_start = capture_time - timedelta(seconds=window_seconds)
+        window_end = capture_time + timedelta(seconds=window_seconds)
+
+        # Find services on this host
+        services_on_host = host_to_service.get(solve.host, [])
+
+        # Find failed checks in the time window for services on this host
+        related_failures = []
+        for service in services_on_host:
+            failed_checks = (
+                db.session.query(Check)
+                .join(Round)
+                .filter(Check.service_id == service.id)
+                .filter(Check.result.is_(False))
+                .filter(Check.completed_timestamp.isnot(None))
+                .filter(Check.completed_timestamp >= window_start)
+                .filter(Check.completed_timestamp <= window_end)
+                .order_by(Check.completed_timestamp)
+                .all()
+            )
+
+            for check in failed_checks:
+                # Calculate time difference from capture
+                time_diff = (check.completed_timestamp - capture_time).total_seconds()
+                related_failures.append({
+                    "check_id": check.id,
+                    "service_id": service.id,
+                    "service_name": service.name,
+                    "team_id": service.team_id,
+                    "team_name": service.team.name if service.team else None,
+                    "check_time": check.completed_timestamp.isoformat() if check.completed_timestamp else None,
+                    "reason": check.reason,
+                    "seconds_from_capture": int(time_diff),
+                    "before_or_after": "before" if time_diff < 0 else "after",
+                })
+
+        correlations.append({
+            "capture": {
+                "id": solve.id,
+                "flag_id": solve.flag_id,
+                "host": solve.host,
+                "captured_at": capture_time.isoformat(),
+                "red_team": solve.team.name if solve.team else None,
+                "flag_type": solve.flag.type.value if solve.flag else None,
+                "flag_platform": solve.flag.platform.value if solve.flag else None,
+                "flag_perm": solve.flag.perm.value if solve.flag else None,
+            },
+            "related_failures": related_failures,
+            "failure_count": len(related_failures),
+            "likely_caused_by_attack": len([f for f in related_failures if f["seconds_from_capture"] >= 0]) > 0,
+        })
+
+    # Summary statistics
+    total_captures = len(correlations)
+    captures_with_failures = len([c for c in correlations if c["failure_count"] > 0])
+    likely_attack_caused = len([c for c in correlations if c["likely_caused_by_attack"]])
+
+    return jsonify({
+        "correlations": correlations,
+        "summary": {
+            "total_captures": total_captures,
+            "captures_with_nearby_failures": captures_with_failures,
+            "likely_attack_caused_failures": likely_attack_caused,
+            "window_seconds": window_seconds,
+        },
+    })
+
+
+@mod.route("/api/attacks/summary")
+@login_required
+def attacks_summary():
+    """
+    Get summary statistics of attack activity.
+    Shows capture counts by team, platform, permission level, and time.
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    # Total captures (excluding dummy flags)
+    total_captures = (
+        db.session.query(func.count(Solve.id))
+        .join(Flag)
+        .filter(Flag.dummy.is_(False))
+        .scalar()
+    )
+
+    # Captures by red team
+    captures_by_red_team = (
+        db.session.query(Team.name, func.count(Solve.id).label("count"))
+        .join(Solve, Solve.team_id == Team.id)
+        .join(Flag, Solve.flag_id == Flag.id)
+        .filter(Flag.dummy.is_(False))
+        .group_by(Team.id, Team.name)
+        .order_by(desc("count"))
+        .all()
+    )
+
+    # Captures by platform
+    captures_by_platform = (
+        db.session.query(Flag.platform, func.count(Solve.id).label("count"))
+        .join(Solve)
+        .filter(Flag.dummy.is_(False))
+        .group_by(Flag.platform)
+        .all()
+    )
+
+    # Captures by permission level
+    captures_by_perm = (
+        db.session.query(Flag.perm, func.count(Solve.id).label("count"))
+        .join(Solve)
+        .filter(Flag.dummy.is_(False))
+        .group_by(Flag.perm)
+        .all()
+    )
+
+    # Build host -> blue team mapping for victim stats
+    all_hosts = [r[0] for r in db.session.query(Solve.host).distinct().all()]
+    host_to_team = {}
+    if all_hosts:
+        services = (
+            db.session.query(Service.host, Team.id, Team.name)
+            .join(Team)
+            .filter(Service.host.in_(all_hosts))
+            .filter(Team.color == "Blue")
+            .distinct()
+            .all()
+        )
+        for service in services:
+            host_to_team[service.host] = {"id": service.id, "name": service.name}
+
+    # Captures targeting each blue team (victim stats)
+    solves_with_hosts = (
+        db.session.query(Solve.host)
+        .join(Flag)
+        .filter(Flag.dummy.is_(False))
+        .all()
+    )
+
+    victims = {}
+    for (host,) in solves_with_hosts:
+        team_info = host_to_team.get(host)
+        if team_info:
+            team_name = team_info["name"]
+            victims[team_name] = victims.get(team_name, 0) + 1
+
+    captures_by_victim = sorted(victims.items(), key=lambda x: -x[1])
+
+    return jsonify({
+        "total_captures": total_captures,
+        "by_red_team": [{"team": t, "count": c} for t, c in captures_by_red_team],
+        "by_platform": [{"platform": p.value if p else "unknown", "count": c} for p, c in captures_by_platform],
+        "by_permission": [{"perm": p.value if p else "unknown", "count": c} for p, c in captures_by_perm],
+        "by_victim": [{"team": t, "count": c} for t, c in captures_by_victim],
+    })
+
+
+@mod.route("/api/attacks/service/<int:service_id>/history")
+@login_required
+def attacks_service_history(service_id):
+    """
+    Get attack history for a specific service.
+    Shows captures and check failures together in timeline.
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    service = db.session.get(Service, service_id)
+    if not service:
+        return jsonify({"error": "Service not found"}), 404
+
+    # Get captures on this host
+    captures = (
+        db.session.query(Solve)
+        .options(joinedload(Solve.flag), joinedload(Solve.team))
+        .join(Flag)
+        .filter(Flag.dummy.is_(False))
+        .filter(Solve.host == service.host)
+        .order_by(desc(Solve.captured_at))
+        .limit(100)
+        .all()
+    )
+
+    # Get recent check failures for this service
+    failures = (
+        db.session.query(Check)
+        .join(Round)
+        .filter(Check.service_id == service_id)
+        .filter(Check.result.is_(False))
+        .order_by(desc(Check.completed_timestamp))
+        .limit(100)
+        .all()
+    )
+
+    # Build combined timeline
+    timeline = []
+
+    for capture in captures:
+        timeline.append({
+            "type": "capture",
+            "timestamp": capture.captured_at.isoformat() if capture.captured_at else None,
+            "data": {
+                "id": capture.id,
+                "flag_id": capture.flag_id,
+                "red_team": capture.team.name if capture.team else None,
+                "platform": capture.flag.platform.value if capture.flag else None,
+                "perm": capture.flag.perm.value if capture.flag else None,
+            },
+        })
+
+    for check in failures:
+        timeline.append({
+            "type": "failure",
+            "timestamp": check.completed_timestamp.isoformat() if check.completed_timestamp else None,
+            "data": {
+                "check_id": check.id,
+                "round": check.round.number if check.round else None,
+                "reason": check.reason,
+            },
+        })
+
+    # Sort by timestamp (None values at end)
+    timeline.sort(key=lambda x: x["timestamp"] or "9999", reverse=True)
+
+    return jsonify({
+        "service": {
+            "id": service.id,
+            "name": service.name,
+            "host": service.host,
+            "team": service.team.name if service.team else None,
+        },
+        "timeline": timeline[:100],
+        "total_captures": len(captures),
+        "total_failures": len(failures),
+    })

--- a/tests/scoring_engine/web/views/api/test_attacks_api.py
+++ b/tests/scoring_engine/web/views/api/test_attacks_api.py
@@ -1,0 +1,371 @@
+"""Tests for attack logging and correlation API endpoints."""
+import json
+from datetime import datetime, timedelta, timezone
+
+from scoring_engine.models.check import Check
+from scoring_engine.models.flag import Flag, FlagTypeEnum, Platform, Perm, Solve
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+from tests.scoring_engine.unit_test import UnitTest
+
+
+class TestAttacksAPI(UnitTest):
+
+    def setup_method(self):
+        super().setup_method()
+        self.app.config["TESTING"] = True
+        self.app.config["WTF_CSRF_ENABLED"] = False
+        self.client = self.app.test_client()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+        # Create teams
+        self.white_team = Team(name="White Team", color="White")
+        self.red_team = Team(name="Red Team", color="Red")
+        self.blue_team1 = Team(name="Blue Team 1", color="Blue")
+        self.blue_team2 = Team(name="Blue Team 2", color="Blue")
+        self.session.add_all([self.white_team, self.red_team, self.blue_team1, self.blue_team2])
+
+        # Create users
+        self.white_user = User(username="admin", password="testpass", team=self.white_team)
+        self.blue_user = User(username="blue1", password="testpass", team=self.blue_team1)
+        self.session.add_all([self.white_user, self.blue_user])
+
+        # Create services
+        self.service1 = Service(
+            name="HTTP",
+            team=self.blue_team1,
+            check_name="HTTP Check",
+            host="10.0.0.1",
+            port=80,
+        )
+        self.service2 = Service(
+            name="DNS",
+            team=self.blue_team1,
+            check_name="DNS Check",
+            host="10.0.0.2",
+            port=53,
+        )
+        self.session.add_all([self.service1, self.service2])
+        self.session.commit()
+
+    def teardown_method(self):
+        self.ctx.pop()
+        super().teardown_method()
+
+    def login(self, username, password):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def create_flag(self, platform=Platform.nix, perm=Perm.user, dummy=False):
+        """Helper to create a flag."""
+        now = datetime.now(timezone.utc)
+        flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=platform,
+            perm=perm,
+            data={"path": "/tmp/flag.txt"},
+            start_time=now - timedelta(hours=1),
+            end_time=now + timedelta(hours=1),
+            dummy=dummy,
+        )
+        self.session.add(flag)
+        self.session.commit()
+        return flag
+
+    def create_solve(self, flag, host, team, captured_at=None):
+        """Helper to create a solve."""
+        solve = Solve(
+            flag=flag,
+            host=host,
+            team=team,
+        )
+        self.session.add(solve)
+        self.session.commit()
+        # Set captured_at after commit if specified
+        if captured_at:
+            solve.captured_at = captured_at
+            self.session.commit()
+        return solve
+
+    # Authorization tests
+    def test_timeline_requires_auth(self):
+        """Test that timeline endpoint requires authentication."""
+        resp = self.client.get("/api/attacks/timeline")
+        assert resp.status_code == 302
+
+    def test_timeline_requires_white_team(self):
+        """Test that timeline endpoint requires white team."""
+        self.login("blue1", "testpass")
+        resp = self.client.get("/api/attacks/timeline")
+        assert resp.status_code == 403
+
+    def test_summary_requires_auth(self):
+        """Test that summary endpoint requires authentication."""
+        resp = self.client.get("/api/attacks/summary")
+        assert resp.status_code == 302
+
+    def test_correlation_requires_auth(self):
+        """Test that correlation endpoint requires authentication."""
+        resp = self.client.get("/api/attacks/correlation")
+        assert resp.status_code == 302
+
+    # Timeline tests
+    def test_timeline_empty(self):
+        """Test timeline with no captures."""
+        self.login("admin", "testpass")
+        resp = self.client.get("/api/attacks/timeline")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["count"] == 0
+        assert data["data"] == []
+
+    def test_timeline_with_captures(self):
+        """Test timeline with captures."""
+        flag = self.create_flag()
+        now = datetime.now(timezone.utc)
+        solve = self.create_solve(flag, "10.0.0.1", self.red_team, captured_at=now)
+
+        self.login("admin", "testpass")
+        resp = self.client.get("/api/attacks/timeline")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["count"] == 1
+        assert data["data"][0]["host"] == "10.0.0.1"
+        assert data["data"][0]["red_team"]["name"] == "Red Team"
+        assert data["data"][0]["flag"]["platform"] == "nix"
+
+    def test_timeline_excludes_dummy_flags(self):
+        """Test that dummy flags are excluded from timeline."""
+        real_flag = self.create_flag(dummy=False)
+        dummy_flag = self.create_flag(dummy=True)
+        self.create_solve(real_flag, "10.0.0.1", self.red_team)
+        self.create_solve(dummy_flag, "10.0.0.2", self.red_team)
+
+        self.login("admin", "testpass")
+        resp = self.client.get("/api/attacks/timeline")
+        data = json.loads(resp.data)
+        assert data["count"] == 1
+        assert data["data"][0]["host"] == "10.0.0.1"
+
+    def test_timeline_filter_by_team(self):
+        """Test timeline filtering by blue team."""
+        flag = self.create_flag()
+        self.create_solve(flag, "10.0.0.1", self.red_team)  # blue_team1's host
+        self.create_solve(flag, "10.0.0.99", self.red_team)  # unknown host
+
+        self.login("admin", "testpass")
+        resp = self.client.get(f"/api/attacks/timeline?team_id={self.blue_team1.id}")
+        data = json.loads(resp.data)
+        assert data["count"] == 1
+        assert data["data"][0]["host"] == "10.0.0.1"
+
+    # Summary tests
+    def test_summary_empty(self):
+        """Test summary with no captures."""
+        self.login("admin", "testpass")
+        resp = self.client.get("/api/attacks/summary")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["total_captures"] == 0
+
+    def test_summary_with_captures(self):
+        """Test summary with various captures."""
+        nix_flag = self.create_flag(platform=Platform.nix, perm=Perm.root)
+        win_flag = self.create_flag(platform=Platform.windows, perm=Perm.user)
+
+        self.create_solve(nix_flag, "10.0.0.1", self.red_team)
+        self.create_solve(win_flag, "10.0.0.1", self.red_team)
+
+        self.login("admin", "testpass")
+        resp = self.client.get("/api/attacks/summary")
+        data = json.loads(resp.data)
+
+        assert data["total_captures"] == 2
+        assert len(data["by_red_team"]) == 1
+        assert data["by_red_team"][0]["team"] == "Red Team"
+        assert data["by_red_team"][0]["count"] == 2
+
+    # Correlation tests
+    def test_correlation_empty(self):
+        """Test correlation with no captures."""
+        self.login("admin", "testpass")
+        resp = self.client.get("/api/attacks/correlation")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["summary"]["total_captures"] == 0
+
+    def test_correlation_capture_with_failure(self):
+        """Test correlation finds failures near captures."""
+        flag = self.create_flag()
+        now = datetime.now(timezone.utc)
+
+        # Create capture
+        solve = self.create_solve(flag, "10.0.0.1", self.red_team, captured_at=now)
+
+        # Create round and failing check shortly after capture
+        round_obj = Round(number=1)
+        self.session.add(round_obj)
+        self.session.commit()
+
+        check = Check(
+            round=round_obj,
+            service=self.service1,
+            result=False,
+            reason="Connection refused",
+            completed_timestamp=now + timedelta(seconds=60),
+            completed=True,
+        )
+        self.session.add(check)
+        self.session.commit()
+
+        self.login("admin", "testpass")
+        resp = self.client.get("/api/attacks/correlation?window_seconds=300")
+        data = json.loads(resp.data)
+
+        assert data["summary"]["total_captures"] == 1
+        assert data["summary"]["captures_with_nearby_failures"] == 1
+        assert len(data["correlations"]) == 1
+        assert data["correlations"][0]["failure_count"] == 1
+        assert data["correlations"][0]["likely_caused_by_attack"] is True
+
+    def test_correlation_no_failures_nearby(self):
+        """Test correlation when no failures are near capture."""
+        flag = self.create_flag()
+        now = datetime.now(timezone.utc)
+
+        # Create capture
+        solve = self.create_solve(flag, "10.0.0.1", self.red_team, captured_at=now)
+
+        # Create round and passing check
+        round_obj = Round(number=1)
+        self.session.add(round_obj)
+        self.session.commit()
+
+        check = Check(
+            round=round_obj,
+            service=self.service1,
+            result=True,
+            completed_timestamp=now + timedelta(seconds=60),
+            completed=True,
+        )
+        self.session.add(check)
+        self.session.commit()
+
+        self.login("admin", "testpass")
+        resp = self.client.get("/api/attacks/correlation")
+        data = json.loads(resp.data)
+
+        assert data["summary"]["total_captures"] == 1
+        assert data["summary"]["captures_with_nearby_failures"] == 0
+
+    # Service history tests
+    def test_service_history_not_found(self):
+        """Test service history for non-existent service."""
+        self.login("admin", "testpass")
+        resp = self.client.get("/api/attacks/service/99999/history")
+        assert resp.status_code == 404
+
+    def test_service_history(self):
+        """Test service history shows captures and failures."""
+        flag = self.create_flag()
+        now = datetime.now(timezone.utc)
+
+        # Create capture on service host
+        solve = self.create_solve(flag, "10.0.0.1", self.red_team, captured_at=now)
+
+        # Create failing check
+        round_obj = Round(number=1)
+        self.session.add(round_obj)
+        self.session.commit()
+
+        check = Check(
+            round=round_obj,
+            service=self.service1,
+            result=False,
+            reason="Failed",
+            completed_timestamp=now + timedelta(seconds=30),
+            completed=True,
+        )
+        self.session.add(check)
+        self.session.commit()
+
+        self.login("admin", "testpass")
+        resp = self.client.get(f"/api/attacks/service/{self.service1.id}/history")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        assert data["service"]["name"] == "HTTP"
+        assert data["total_captures"] == 1
+        assert data["total_failures"] == 1
+        assert len(data["timeline"]) == 2
+
+        # Check timeline has both capture and failure
+        types = [item["type"] for item in data["timeline"]]
+        assert "capture" in types
+        assert "failure" in types
+
+
+class TestSolveCapturedAt(UnitTest):
+    """Tests for the Solve.captured_at field."""
+
+    def test_solve_captured_at_default(self):
+        """Test that captured_at is set by default on new solves."""
+        team = Team(name="Red Team", color="Red")
+        self.session.add(team)
+
+        now = datetime.now(timezone.utc)
+        flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.nix,
+            perm=Perm.user,
+            data={"path": "/tmp/flag"},
+            start_time=now - timedelta(hours=1),
+            end_time=now + timedelta(hours=1),
+        )
+        self.session.add(flag)
+        self.session.commit()
+
+        solve = Solve(host="10.0.0.1", flag=flag, team=team)
+        self.session.add(solve)
+        self.session.commit()
+
+        # captured_at should be set automatically
+        assert solve.captured_at is not None
+        # Should be close to now (within 10 seconds)
+        time_diff = abs((solve.captured_at.replace(tzinfo=timezone.utc) - now).total_seconds())
+        assert time_diff < 10
+
+    def test_solve_localize_captured_at(self):
+        """Test localize_captured_at property."""
+        team = Team(name="Red Team", color="Red")
+        self.session.add(team)
+
+        now = datetime.now(timezone.utc)
+        flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.nix,
+            perm=Perm.user,
+            data={"path": "/tmp/flag"},
+            start_time=now - timedelta(hours=1),
+            end_time=now + timedelta(hours=1),
+        )
+        self.session.add(flag)
+        self.session.commit()
+
+        solve = Solve(host="10.0.0.1", flag=flag, team=team)
+        self.session.add(solve)
+        self.session.commit()
+
+        # localize_captured_at should return a formatted string
+        local_time = solve.localize_captured_at
+        assert local_time is not None
+        assert isinstance(local_time, str)
+        # Should contain date components
+        assert "-" in local_time  # Date separator
+        assert ":" in local_time  # Time separator


### PR DESCRIPTION
## Summary
- Track red team flag captures with timestamps for correlation analysis
- Correlate captures with service check failures to identify attack-caused vs self-inflicted failures
- Admin interface to visualize attack activity and correlation

## Features

### Solve Model Enhancement
- Added `captured_at` timestamp column (auto-set via `default=func.now()`)
- Added `localize_captured_at` property for timezone-aware display

### Attack API Endpoints
- `GET /api/attacks/timeline` - Recent captures with timestamp, team, host info
  - Filterable by blue team (victim) and host
  - Excludes dummy flags
- `GET /api/attacks/summary` - Aggregate stats:
  - Total captures
  - Captures by red team (attacker rankings)
  - Captures by platform (Linux/Windows)
  - Captures by permission level (user/root)
  - Captures by blue team (victim rankings)
- `GET /api/attacks/correlation` - Time-based correlation analysis:
  - Finds service check failures within configurable time window of captures
  - Identifies "likely attack-caused" (failure occurred after capture)
  - Summary statistics on correlation
- `GET /api/attacks/service/<id>/history` - Combined timeline of captures and failures for a service

### Admin Attack Log Page (`/admin/attacks`)
- Summary stats cards (total, by platform, by permission)
- Top red teams (attackers) and most targeted blue teams (victims)
- Filterable capture timeline table
- Correlation analysis tool with:
  - Configurable time window (1-10 minutes)
  - Visual indication of failures before/after capture
  - Summary of likely attack-caused failures

## Use Case
During active red team competitions, organizers can now:
1. See real-time attack activity across all teams
2. Identify which service failures are likely caused by red team activity
3. Distinguish "self-inflicted" failures (before capture) from attack-caused (after capture)
4. Track red team effectiveness and blue team vulnerability

## Test plan
- [x] Unit tests for Solve.captured_at timestamp
- [x] API tests for timeline, summary, correlation endpoints (17 new tests)
- [x] Full test suite passes (540 tests)
- [ ] Manual testing: create flag captures, verify timeline shows data
- [ ] Manual testing: create service failures near captures, verify correlation

🤖 Generated with [Claude Code](https://claude.com/claude-code)