### PR TITLE
Add persistence tracking for red team sessions

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,31 +1,24 @@
 #!/usr/bin/env python
+import optparse
+import os
 from datetime import datetime, timedelta
 from random import choice, randint, sample
 
-import optparse
-import os
-
-from scoring_engine.models.inject import Template, Inject
-from scoring_engine.models.team import Team
-from scoring_engine.models.service import Service
-from scoring_engine.models.round import Round
-from scoring_engine.models.check import Check
-from scoring_engine.models.flag import Flag, Solve, Platform, FlagTypeEnum, Perm
-
-from scoring_engine.models.notifications import Notification
-from scoring_engine.models.setting import Setting
-from scoring_engine.db import db, init_db, delete_db, verify_db_ready
-from scoring_engine.config import config
 from scoring_engine.competition import Competition
+from scoring_engine.config import config
+from scoring_engine.db import db, delete_db, init_db, verify_db_ready
+from scoring_engine.engine.basic_check import CHECK_FAILURE_TEXT, CHECK_SUCCESS_TEXT, CHECK_TIMED_OUT_TEXT
 from scoring_engine.logger import logger
+from scoring_engine.models.check import Check
+from scoring_engine.models.flag import Flag, FlagTypeEnum, Perm, Platform, Solve
+from scoring_engine.models.inject import Inject, Template
+from scoring_engine.models.notifications import Notification
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
 from scoring_engine.version import version
 from scoring_engine.web import create_app
-from scoring_engine.engine.basic_check import (
-    CHECK_SUCCESS_TEXT,
-    CHECK_FAILURE_TEXT,
-    CHECK_TIMED_OUT_TEXT,
-)
-
 
 parser = optparse.OptionParser()
 parser.add_option("--overwrite-db", action="store_true", default=False)
@@ -159,6 +152,11 @@ with app.app_context():
     db.session.add(Setting(name="agent_show_flag_early_mins", value=config.agent_show_flag_early_mins))
     db.session.add(Setting(name="agent_psk", value=config.agent_psk))
 
+    # Persistence Tracking Settings
+    logger.info("Creating the Persistence Tracking Settings")
+    db.session.add(Setting(name="persistence_timeout_seconds", value=str(config.persistence_timeout_seconds)))
+    db.session.add(Setting(name="persistence_beacon_psk", value=config.persistence_beacon_psk))
+
     # SLA Penalty Settings
     logger.info("Creating the SLA Penalty Settings")
     db.session.add(Setting(name="sla_enabled", value=config.sla_enabled))
@@ -290,7 +288,7 @@ with app.app_context():
             )
             flag.platform = choice([Platform.nix, Platform.windows])
             # Most flags should be non-dummy so they show up (only ~20% dummy)
-            flag.dummy = (i % 5 == 0)
+            flag.dummy = i % 5 == 0
             flag.type = choice([FlagTypeEnum.file, FlagTypeEnum.pipe, FlagTypeEnum.net, FlagTypeEnum.reg])
             flag.perm = choice([Perm.user, Perm.root])
             flag.data = {"path": f"/tmp/flag_{i}.txt", "content": f"FLAG_{i}_CONTENT"}

--- a/engine.conf.inc
+++ b/engine.conf.inc
@@ -57,6 +57,13 @@ sla_penalty_mode = additive
 # Allow scores to go negative from penalties
 sla_allow_negative = False
 
+# Persistence Tracking Configuration
+# Timeout in seconds before a session is considered stale (no recent checkin)
+persistence_timeout_seconds = 300
+# PSK for external C2 beacon integration (Cobalt Strike, etc.)
+# Leave empty to disable external beacon API
+persistence_beacon_psk =
+
 # Dynamic Scoring (Time-Based) Configuration
 # Enable/disable dynamic scoring multipliers
 dynamic_scoring_enabled = False

--- a/scoring_engine/config_loader.py
+++ b/scoring_engine/config_loader.py
@@ -22,9 +22,7 @@ class ConfigLoader(object):
             Path to the configuration file relative to this module. Defaults to
             ``"../engine.conf"``.
         """
-        config_location = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), location
-        )
+        config_location = os.path.join(os.path.dirname(os.path.abspath(__file__)), location)
 
         self.parser = configparser.ConfigParser()
         # Attempt to read the supplied configuration file.  In the test
@@ -50,9 +48,7 @@ class ConfigLoader(object):
         if not self.parser.has_section("OPTIONS"):
             self.parser.add_section("OPTIONS")
 
-        self.debug = self.parse_sources(
-            "debug", self.parser["OPTIONS"]["debug"].lower() == "true", "bool"
-        )
+        self.debug = self.parse_sources("debug", self.parser["OPTIONS"]["debug"].lower() == "true", "bool")
 
         self.checks_location = self.parse_sources(
             "checks_location",
@@ -131,31 +127,19 @@ class ConfigLoader(object):
             self.parser["OPTIONS"]["worker_queue"],
         )
 
-        self.timezone = self.parse_sources(
-            "timezone", self.parser["OPTIONS"]["timezone"]
-        )
+        self.timezone = self.parse_sources("timezone", self.parser["OPTIONS"]["timezone"])
 
-        self.upload_folder = self.parse_sources(
-            "upload_folder", self.parser["OPTIONS"]["upload_folder"]
-        )
+        self.upload_folder = self.parse_sources("upload_folder", self.parser["OPTIONS"]["upload_folder"])
 
         self.db_uri = self.parse_sources("db_uri", self.parser["OPTIONS"]["db_uri"])
 
-        self.cache_type = self.parse_sources(
-            "cache_type", self.parser["OPTIONS"]["cache_type"]
-        )
+        self.cache_type = self.parse_sources("cache_type", self.parser["OPTIONS"]["cache_type"])
 
-        self.redis_host = self.parse_sources(
-            "redis_host", self.parser["OPTIONS"]["redis_host"]
-        )
+        self.redis_host = self.parse_sources("redis_host", self.parser["OPTIONS"]["redis_host"])
 
-        self.redis_port = self.parse_sources(
-            "redis_port", int(self.parser["OPTIONS"]["redis_port"]), "int"
-        )
+        self.redis_port = self.parse_sources("redis_port", int(self.parser["OPTIONS"]["redis_port"]), "int")
 
-        self.redis_password = self.parse_sources(
-            "redis_password", self.parser["OPTIONS"]["redis_password"]
-        )
+        self.redis_password = self.parse_sources("redis_password", self.parser["OPTIONS"]["redis_password"])
 
         # SLA Penalty Configuration
         self.sla_enabled = self.parse_sources(
@@ -191,6 +175,18 @@ class ConfigLoader(object):
             "sla_allow_negative",
             self.parser["OPTIONS"].get("sla_allow_negative", "false").lower() == "true",
             "bool",
+        )
+
+        # Persistence Tracking Configuration
+        self.persistence_timeout_seconds = self.parse_sources(
+            "persistence_timeout_seconds",
+            int(self.parser["OPTIONS"].get("persistence_timeout_seconds", "300")),
+            "int",
+        )
+
+        self.persistence_beacon_psk = self.parse_sources(
+            "persistence_beacon_psk",
+            self.parser["OPTIONS"].get("persistence_beacon_psk", ""),
         )
 
         # Dynamic Scoring Configuration

--- a/scoring_engine/models/flag.py
+++ b/scoring_engine/models/flag.py
@@ -1,21 +1,10 @@
-from sqlalchemy import (
-    Column,
-    Enum,
-    Integer,
-    Boolean,
-    PickleType,
-    DateTime,
-    String,
-    UniqueConstraint,
-    ForeignKey,
-)
+import html
+
+import pytz
+from sqlalchemy import Boolean, Column, DateTime, Enum, ForeignKey, Integer, PickleType, String, UniqueConstraint, func
 
 # from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
-
-import pytz
-
-import html
 
 
 def _ensure_utc_aware(dt):
@@ -28,14 +17,13 @@ def _ensure_utc_aware(dt):
     # Already aware - convert to UTC
     return dt.astimezone(pytz.utc)
 
-import uuid
-
-from scoring_engine.models.base import Base
-from scoring_engine.models.team import Team
-from scoring_engine.config import config
-
 
 import enum
+import uuid
+
+from scoring_engine.config import config
+from scoring_engine.models.base import Base
+from scoring_engine.models.team import Team
 
 
 class FlagTypeEnum(enum.Enum):
@@ -81,11 +69,17 @@ class Flag(Base):
 
     @property
     def localize_start_time(self):
-        return _ensure_utc_aware(self.start_time).astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z")
+        return (
+            _ensure_utc_aware(self.start_time)
+            .astimezone(pytz.timezone(config.timezone))
+            .strftime("%Y-%m-%d %H:%M:%S %Z")
+        )
 
     @property
     def localize_end_time(self):
-        return _ensure_utc_aware(self.end_time).astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z")
+        return (
+            _ensure_utc_aware(self.end_time).astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z")
+        )
 
 
 class Solve(Base):
@@ -95,5 +89,104 @@ class Solve(Base):
     host = Column(String(260), nullable=False)
     flag_id = Column(String(36), ForeignKey("flags.id"))
     team_id = Column(Integer, ForeignKey("teams.id"))
+    captured_at = Column(DateTime(timezone=True), default=func.now(), nullable=True)
     flag = relationship("Flag", backref="solves", lazy="joined")
     team = relationship("Team", backref="flag_solves", lazy="joined")
+
+    @property
+    def localize_captured_at(self):
+        """Get captured_at timestamp in configured timezone."""
+        if self.captured_at is None:
+            return None
+        return (
+            _ensure_utc_aware(self.captured_at)
+            .astimezone(pytz.timezone(config.timezone))
+            .strftime("%Y-%m-%d %H:%M:%S %Z")
+        )
+
+
+class PersistenceSession(Base):
+    """
+    Tracks a red team persistence session on a blue team host.
+
+    A session starts when the agent first checks in from a compromised host
+    and ends when:
+    - The agent stops checking in (timeout - blue team remediated)
+    - Manually marked as ended by admin
+    """
+
+    __tablename__ = "persistence_sessions"
+    __table_args__ = (UniqueConstraint("host", "team_id", "ended_at", name="_host_team_active_uc"),)
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    host = Column(String(260), nullable=False)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=False)
+    platform = Column(Enum(Platform), nullable=False)
+
+    # Timestamps
+    started_at = Column(DateTime(timezone=True), default=func.now(), nullable=False)
+    last_checkin = Column(DateTime(timezone=True), default=func.now(), nullable=False)
+    ended_at = Column(DateTime(timezone=True), nullable=True)  # Null = still active
+
+    # End reason
+    end_reason = Column(String(50), nullable=True)  # timeout, manual, competition_end
+
+    # Relationships
+    team = relationship("Team", backref="persistence_sessions")
+
+    @property
+    def is_active(self):
+        """Check if this session is still active."""
+        return self.ended_at is None
+
+    @property
+    def duration_seconds(self):
+        """Calculate session duration in seconds."""
+        from datetime import datetime, timezone
+
+        if self.ended_at is None:
+            end = datetime.now(timezone.utc)
+        else:
+            end = _ensure_utc_aware(self.ended_at)
+        start = _ensure_utc_aware(self.started_at)
+        return int((end - start).total_seconds())
+
+    @property
+    def duration_formatted(self):
+        """Get human-readable duration."""
+        seconds = self.duration_seconds
+        hours, remainder = divmod(seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        if hours > 0:
+            return f"{hours}h {minutes}m {seconds}s"
+        elif minutes > 0:
+            return f"{minutes}m {seconds}s"
+        else:
+            return f"{seconds}s"
+
+    @property
+    def localize_started_at(self):
+        """Get started_at in configured timezone."""
+        return (
+            _ensure_utc_aware(self.started_at)
+            .astimezone(pytz.timezone(config.timezone))
+            .strftime("%Y-%m-%d %H:%M:%S %Z")
+        )
+
+    @property
+    def localize_last_checkin(self):
+        """Get last_checkin in configured timezone."""
+        return (
+            _ensure_utc_aware(self.last_checkin)
+            .astimezone(pytz.timezone(config.timezone))
+            .strftime("%Y-%m-%d %H:%M:%S %Z")
+        )
+
+    @property
+    def localize_ended_at(self):
+        """Get ended_at in configured timezone."""
+        if self.ended_at is None:
+            return None
+        return (
+            _ensure_utc_aware(self.ended_at).astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z")
+        )

--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -43,6 +43,17 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="panel-title">
+            <span>Red Team <b class="pull-right glyphicon glyphicon-fire"></b></span>
+          </div>
+        </div>
+        <div class="list-group">
+          <a class="list-group-item {% if request.path == '/admin/persistence' %}active{% endif %}"
+            href="/admin/persistence">Persistence</a>
+        </div>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div class="panel-title">
             <span>Injects <b class="pull-right glyphicon glyphicon-file"></b></span>
           </div>
         </div>

--- a/scoring_engine/web/templates/admin/persistence.html
+++ b/scoring_engine/web/templates/admin/persistence.html
@@ -1,0 +1,348 @@
+{% extends 'admin/adminbase.html' %}
+{% block title %}Admin - Persistence Tracking{% endblock %}
+
+{% block head %}
+{{ super() }}
+<style>
+  .session-active { color: #5cb85c; font-weight: bold; }
+  .session-stale { color: #f0ad4e; }
+  .session-ended { color: #999; }
+  .stats-card { text-align: center; padding: 15px; margin-bottom: 15px; }
+  .stats-card h2 { margin: 0; font-size: 2.5em; }
+  .stats-card small { color: #777; }
+  .beacon-example { background: #f5f5f5; padding: 10px; border-radius: 4px; font-family: monospace; font-size: 12px; overflow-x: auto; }
+</style>
+{% endblock %}
+
+{% block header %}
+Persistence Tracking
+{% endblock %}
+
+{% block admincontent %}
+<!-- Summary Stats -->
+<div class="row">
+  <div class="col-md-3">
+    <div class="panel panel-success stats-card">
+      <h2 id="active-count">-</h2>
+      <small>Active Sessions</small>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="panel panel-warning stats-card">
+      <h2 id="stale-count">-</h2>
+      <small>Stale Sessions</small>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="panel panel-default stats-card">
+      <h2 id="ended-count">-</h2>
+      <small>Ended Sessions</small>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="panel panel-info stats-card">
+      <h2 id="total-count">-</h2>
+      <small>Total Sessions</small>
+    </div>
+  </div>
+</div>
+
+<!-- Actions -->
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h4>Actions</h4>
+  </div>
+  <div class="panel-body">
+    <button class="btn btn-warning" id="detect-stale-btn">
+      <span class="glyphicon glyphicon-time"></span> Detect & End Stale Sessions
+    </button>
+    <button class="btn btn-default" id="refresh-btn">
+      <span class="glyphicon glyphicon-refresh"></span> Refresh
+    </button>
+    <span id="action-result" class="text-muted" style="margin-left: 15px;"></span>
+  </div>
+</div>
+
+<!-- Settings -->
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h4>Settings</h4>
+  </div>
+  <div class="panel-body">
+    <form id="persistence-settings-form">
+      <div class="form-group">
+        <label for="timeout">Session Timeout (seconds)</label>
+        <input type="number" class="form-control" id="timeout" name="persistence_timeout_seconds"
+               value="{{ persistence_timeout_seconds }}" min="60" max="3600">
+        <p class="help-block">Sessions with no check-in for this long are considered stale (default: 300 = 5 minutes)</p>
+      </div>
+      <div class="form-group">
+        <label for="beacon-psk">External Beacon API PSK</label>
+        <div class="input-group">
+          <input type="text" class="form-control" id="beacon-psk" name="persistence_beacon_psk"
+                 value="{{ persistence_beacon_psk }}" placeholder="Leave empty to disable">
+          <span class="input-group-btn">
+            <button class="btn btn-default" type="button" id="generate-psk-btn">Generate</button>
+          </span>
+        </div>
+        <p class="help-block">PSK for Cobalt Strike / external C2 beacon integration. Leave empty to disable.</p>
+      </div>
+      <button type="submit" class="btn btn-primary">Save Settings</button>
+    </form>
+  </div>
+</div>
+
+<!-- External Beacon API Info -->
+{% if persistence_beacon_psk %}
+<div class="panel panel-info">
+  <div class="panel-heading">
+    <h4>External C2 Integration (Cobalt Strike, etc.)</h4>
+  </div>
+  <div class="panel-body">
+    <p>Send beacon check-ins from external C2 frameworks using the following API:</p>
+
+    <h5>Beacon Check-in (POST /api/persistence/beacon)</h5>
+    <div class="beacon-example">
+curl -X POST {{ request.url_root }}api/persistence/beacon \
+  -H "Authorization: Bearer YOUR_PSK" \
+  -H "Content-Type: application/json" \
+  -d '{"team": "Team 1", "host": "webserver.local", "platform": "win", "beacon_id": "abc123"}'
+    </div>
+
+    <h5 style="margin-top: 15px;">End Beacon Session (POST /api/persistence/beacon/end)</h5>
+    <div class="beacon-example">
+curl -X POST {{ request.url_root }}api/persistence/beacon/end \
+  -H "Authorization: Bearer YOUR_PSK" \
+  -H "Content-Type: application/json" \
+  -d '{"team": "Team 1", "host": "webserver.local", "beacon_id": "abc123", "reason": "exit"}'
+    </div>
+
+    <h5 style="margin-top: 15px;">Aggressor Script Example (Cobalt Strike)</h5>
+    <div class="beacon-example">
+on beacon_initial {
+    $bid = $1;
+    $host = beacon_info($bid, "computer");
+    $user = beacon_info($bid, "user");
+    # Extract team from host naming convention (e.g., web.team1.local -> Team 1)
+    # Customize this regex for your competition
+    $url = "{{ request.url_root }}api/persistence/beacon";
+    $body = '{"team": "Team 1", "host": "' . $host . '", "platform": "win", "beacon_id": "' . $bid . '"}';
+    # Use Cobalt Strike's web client or external script to POST
+}
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<!-- Active Sessions Table -->
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h4>Active Persistence Sessions</h4>
+  </div>
+  <div class="panel-body">
+    <table class="table table-striped table-bordered" id="sessions-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Host</th>
+          <th>Team (Victim)</th>
+          <th>Platform</th>
+          <th>Started</th>
+          <th>Last Check-in</th>
+          <th>Duration</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody id="sessions-body">
+        <tr><td colspan="9" class="text-center">Loading...</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Sessions by Team -->
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h4>Sessions by Team</h4>
+  </div>
+  <div class="panel-body">
+    <table class="table table-striped table-bordered" id="team-summary-table">
+      <thead>
+        <tr>
+          <th>Team</th>
+          <th>Total Sessions</th>
+          <th>Active Now</th>
+        </tr>
+      </thead>
+      <tbody id="team-summary-body">
+        <tr><td colspan="3" class="text-center">Loading...</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+function loadSummary() {
+  $.getJSON('/api/persistence/summary', function(data) {
+    $('#active-count').text(data.active_sessions);
+    $('#stale-count').text(data.stale_sessions);
+    $('#ended-count').text(data.ended_sessions);
+    $('#total-count').text(data.total_sessions);
+
+    // Team summary
+    var teamHtml = '';
+    var activeByTeam = {};
+    data.active_by_team.forEach(function(t) {
+      activeByTeam[t.team] = t.count;
+    });
+
+    data.by_team.forEach(function(t) {
+      teamHtml += '<tr><td>' + escapeHtml(t.team) + '</td><td>' + t.count + '</td><td>' + (activeByTeam[t.team] || 0) + '</td></tr>';
+    });
+
+    if (teamHtml === '') {
+      teamHtml = '<tr><td colspan="3" class="text-center text-muted">No sessions yet</td></tr>';
+    }
+    $('#team-summary-body').html(teamHtml);
+  });
+}
+
+function loadSessions() {
+  $.getJSON('/api/persistence/sessions?limit=50', function(data) {
+    var html = '';
+    data.data.forEach(function(s) {
+      var statusClass = s.is_active ? (s.is_stale ? 'session-stale' : 'session-active') : 'session-ended';
+      var statusText = s.is_active ? (s.is_stale ? 'Stale' : 'Active') : 'Ended';
+      if (s.end_reason) {
+        statusText += ' (' + s.end_reason + ')';
+      }
+
+      html += '<tr class="' + statusClass + '">';
+      html += '<td>' + s.id + '</td>';
+      html += '<td>' + escapeHtml(s.host) + '</td>';
+      html += '<td>' + escapeHtml(s.team_name || '-') + '</td>';
+      html += '<td>' + (s.platform || '-') + '</td>';
+      html += '<td>' + escapeHtml(s.started_at_local) + '</td>';
+      html += '<td>' + escapeHtml(s.last_checkin_local) + '</td>';
+      html += '<td>' + escapeHtml(s.duration_formatted) + '</td>';
+      html += '<td>' + statusText + '</td>';
+      html += '<td>';
+      if (s.is_active) {
+        html += '<button class="btn btn-xs btn-danger end-session-btn" data-id="' + s.id + '">End</button>';
+      }
+      html += '</td>';
+      html += '</tr>';
+    });
+
+    if (html === '') {
+      html = '<tr><td colspan="9" class="text-center text-muted">No persistence sessions</td></tr>';
+    }
+    $('#sessions-body').html(html);
+
+    // Bind end buttons
+    $('.end-session-btn').click(function() {
+      var sessionId = $(this).data('id');
+      endSession(sessionId);
+    });
+  });
+}
+
+function endSession(sessionId) {
+  $.ajax({
+    url: '/api/persistence/session/' + sessionId + '/end',
+    method: 'POST',
+    success: function(data) {
+      $('#action-result').text('Session ' + sessionId + ' ended (' + data.duration_formatted + ')');
+      loadSessions();
+      loadSummary();
+    },
+    error: function(xhr) {
+      $('#action-result').text('Error: ' + (xhr.responseJSON?.error || 'Unknown error'));
+    }
+  });
+}
+
+function detectStale() {
+  $.ajax({
+    url: '/api/persistence/detect_stale',
+    method: 'POST',
+    success: function(data) {
+      $('#action-result').text('Ended ' + data.sessions_ended + ' stale sessions');
+      loadSessions();
+      loadSummary();
+    },
+    error: function(xhr) {
+      $('#action-result').text('Error: ' + (xhr.responseJSON?.error || 'Unknown error'));
+    }
+  });
+}
+
+function escapeHtml(text) {
+  if (!text) return '';
+  var div = document.createElement('div');
+  div.appendChild(document.createTextNode(text));
+  return div.innerHTML;
+}
+
+function generatePSK() {
+  var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  var psk = '';
+  for (var i = 0; i < 32; i++) {
+    psk += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  $('#beacon-psk').val(psk);
+}
+
+$(document).ready(function() {
+  loadSummary();
+  loadSessions();
+
+  // Auto-refresh every 10 seconds
+  setInterval(function() {
+    loadSummary();
+    loadSessions();
+  }, 10000);
+
+  $('#refresh-btn').click(function() {
+    loadSummary();
+    loadSessions();
+    $('#action-result').text('Refreshed');
+  });
+
+  $('#detect-stale-btn').click(function() {
+    detectStale();
+  });
+
+  $('#generate-psk-btn').click(function() {
+    generatePSK();
+  });
+
+  $('#persistence-settings-form').submit(function(e) {
+    e.preventDefault();
+    var timeout = $('#timeout').val();
+    var psk = $('#beacon-psk').val();
+
+    $.ajax({
+      url: '/api/admin/update_settings',
+      method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        persistence_timeout_seconds: timeout,
+        persistence_beacon_psk: psk
+      }),
+      success: function() {
+        $('#action-result').text('Settings saved');
+        // Reload page to update the API documentation
+        if (psk && !{{ 'true' if persistence_beacon_psk else 'false' }}) {
+          location.reload();
+        }
+      },
+      error: function(xhr) {
+        $('#action-result').text('Error saving: ' + (xhr.responseJSON?.error || 'Unknown error'));
+      }
+    });
+  });
+});
+</script>
+{% endblock %}

--- a/scoring_engine/web/views/admin.py
+++ b/scoring_engine/web/views/admin.py
@@ -1,14 +1,14 @@
-from flask import Blueprint, redirect, render_template, url_for
-from flask_login import current_user, login_required
 from operator import itemgetter
 
-from scoring_engine.models.user import User
-from scoring_engine.models.team import Team
+from flask import Blueprint, redirect, render_template, url_for
+from flask_login import current_user, login_required
+
+from scoring_engine.db import db
 from scoring_engine.models.inject import Inject
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
-from scoring_engine.db import db
-
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
 
 mod = Blueprint("admin", __name__)
 
@@ -67,9 +67,7 @@ def inject_templates():
     if current_user.is_white_team:
         blue_teams = Team.get_all_blue_teams()
         red_teams = Team.get_all_red_teams()
-        return render_template(
-            "admin/templates.html", blue_teams=blue_teams, red_teams=red_teams
-        )
+        return render_template("admin/templates.html", blue_teams=blue_teams, red_teams=red_teams)
     else:
         return redirect(url_for("auth.unauthorized"))
 
@@ -103,9 +101,7 @@ def service(id):
         if service is None:
             return redirect(url_for("auth.unauthorized"))
 
-        return render_template(
-            "admin/service.html", service=service, blue_teams=blue_teams
-        )
+        return render_template("admin/service.html", service=service, blue_teams=blue_teams)
     else:
         return redirect(url_for("auth.unauthorized"))
 
@@ -139,19 +135,32 @@ def permissions():
         return render_template(
             "admin/permissions.html",
             blue_teams=blue_teams,
-            blue_team_update_hostname=Setting.get_setting(
-                "blue_team_update_hostname"
-            ).value,
+            blue_team_update_hostname=Setting.get_setting("blue_team_update_hostname").value,
             blue_team_update_port=Setting.get_setting("blue_team_update_port").value,
-            blue_team_update_account_usernames=Setting.get_setting(
-                "blue_team_update_account_usernames"
-            ).value,
-            blue_team_update_account_passwords=Setting.get_setting(
-                "blue_team_update_account_passwords"
-            ).value,
-            blue_team_view_check_output=Setting.get_setting(
-                "blue_team_view_check_output"
-            ).value,
+            blue_team_update_account_usernames=Setting.get_setting("blue_team_update_account_usernames").value,
+            blue_team_update_account_passwords=Setting.get_setting("blue_team_update_account_passwords").value,
+            blue_team_view_check_output=Setting.get_setting("blue_team_view_check_output").value,
+        )
+    else:
+        return redirect(url_for("auth.unauthorized"))
+
+
+@mod.route("/admin/persistence")
+@login_required
+def persistence():
+    if current_user.is_white_team:
+        blue_teams = Team.get_all_blue_teams()
+
+        # Get persistence settings
+        def get_setting_value(name, default):
+            setting = Setting.get_setting(name)
+            return setting.value if setting else default
+
+        return render_template(
+            "admin/persistence.html",
+            blue_teams=blue_teams,
+            persistence_timeout_seconds=get_setting_value("persistence_timeout_seconds", "300"),
+            persistence_beacon_psk=get_setting_value("persistence_beacon_psk", ""),
         )
     else:
         return redirect(url_for("auth.unauthorized"))

--- a/scoring_engine/web/views/api/__init__.py
+++ b/scoring_engine/web/views/api/__init__.py
@@ -1,5 +1,6 @@
-from flask import Blueprint, g, request
 from functools import wraps
+
+from flask import Blueprint, g, request
 
 from scoring_engine.cache import cache
 from scoring_engine.models.notifications import Notification
@@ -17,15 +18,18 @@ def make_cache_key(*args, **kwargs):
 mod = Blueprint("api", __name__)
 
 
-from . import admin
-from . import agent
-from . import flags
-from . import injects
-from . import notifications
-from . import overview
-from . import profile
-from . import scoreboard
-from . import service
-from . import sla
-from . import stats
-from . import team
+from . import (
+    admin,
+    agent,
+    flags,
+    injects,
+    notifications,
+    overview,
+    persistence,
+    profile,
+    scoreboard,
+    service,
+    sla,
+    stats,
+    team,
+)

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1,14 +1,12 @@
+import html
 import json
-import pytz
-
+from datetime import datetime, timezone
 from tempfile import template
 
-from datetime import datetime, timezone
+import pytz
 from dateutil.parser import parse
-from flask import flash, redirect, request, url_for, jsonify
+from flask import flash, jsonify, redirect, request, url_for
 from flask_login import current_user, login_required
-
-import html
 
 
 def _ensure_utc_aware(dt):
@@ -21,34 +19,33 @@ def _ensure_utc_aware(dt):
     # Already aware - convert to UTC
     return dt.astimezone(pytz.utc)
 
-from scoring_engine.config import config
-from scoring_engine.db import db
-from scoring_engine.models.inject import Template, Inject
-from scoring_engine.models.service import Service
-from scoring_engine.models.check import Check
-from scoring_engine.models.environment import Environment
-from scoring_engine.models.property import Property
-from scoring_engine.models.kb import KB
-from scoring_engine.models.round import Round
-from scoring_engine.models.team import Team
-from scoring_engine.models.user import User
-from scoring_engine.models.setting import Setting
-from scoring_engine.engine.execute_command import execute_command
-from scoring_engine.cache_helper import (
-    update_scoreboard_data,
-    update_overview_data,
-    update_services_navbar,
-    update_service_data,
-    update_team_stats,
-    update_services_data,
-)
-from scoring_engine.celery_stats import CeleryStats
 
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func
 
-
+from scoring_engine.cache_helper import (
+    update_overview_data,
+    update_scoreboard_data,
+    update_service_data,
+    update_services_data,
+    update_services_navbar,
+    update_team_stats,
+)
+from scoring_engine.celery_stats import CeleryStats
+from scoring_engine.config import config
+from scoring_engine.db import db
+from scoring_engine.engine.execute_command import execute_command
+from scoring_engine.models.check import Check
+from scoring_engine.models.environment import Environment
+from scoring_engine.models.inject import Inject, Template
+from scoring_engine.models.kb import KB
+from scoring_engine.models.property import Property
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
 
 from . import mod
 
@@ -344,12 +341,7 @@ def admin_update_blueteam_view_check_output():
 @login_required
 def get_check_progress_total():
     if current_user.is_white_team:
-        task_id_settings = (
-            db.session.query(KB)
-            .filter_by(name="task_ids")
-            .order_by(KB.round_num.desc())
-            .first()
-        )
+        task_id_settings = db.session.query(KB).filter_by(name="task_ids").order_by(KB.round_num.desc()).first()
         total_stats = {}
         total_stats["finished"] = 0
         total_stats["pending"] = 0
@@ -390,9 +382,7 @@ def get_check_progress_total():
             elif team_total_tasks == 0:
                 team_total_percentage = 100
             elif team_stat and team_stat["finished"]:
-                team_total_percentage = int(
-                    (team_stat["finished"] / team_total_tasks) * 100
-                )
+                team_total_percentage = int((team_stat["finished"] / team_total_tasks) * 100)
             output_dict[team_name] = team_total_percentage
 
         return json.dumps(output_dict)
@@ -411,12 +401,8 @@ def admin_get_inject_templates_id(template_id):
             scenario=template.scenario,
             deliverable=template.deliverable,
             score=template.score,
-            start_time=_ensure_utc_aware(template.start_time).astimezone(
-                pytz.timezone(config.timezone)
-            ).isoformat(),
-            end_time=_ensure_utc_aware(template.end_time).astimezone(
-                pytz.timezone(config.timezone)
-            ).isoformat(),
+            start_time=_ensure_utc_aware(template.start_time).astimezone(pytz.timezone(config.timezone)).isoformat(),
+            end_time=_ensure_utc_aware(template.end_time).astimezone(pytz.timezone(config.timezone)).isoformat(),
             enabled=template.enabled,
             # rubric=[
             #     {"id": x.id, "value": x.value, "deliverable": x.deliverable}
@@ -443,13 +429,9 @@ def admin_put_inject_templates_id(template_id):
             if data.get("deliverable"):
                 template.deliverable = data["deliverable"]
             if data.get("start_time"):
-                template.start_time = (
-                    parse(data["start_time"]).astimezone(pytz.utc).replace(tzinfo=None)
-                )
+                template.start_time = parse(data["start_time"]).astimezone(pytz.utc).replace(tzinfo=None)
             if data.get("end_time"):
-                template.end_time = (
-                    parse(data["end_time"]).astimezone(pytz.utc).replace(tzinfo=None)
-                )
+                template.end_time = parse(data["end_time"]).astimezone(pytz.utc).replace(tzinfo=None)
             # TODO - Fix this to not be string values from javascript select
             if data.get("status") == "Enabled":
                 template.enabled = True
@@ -472,9 +454,7 @@ def admin_put_inject_templates_id(template_id):
                         inject.enabled = True
                     # Otherwise, create the inject
                     else:
-                        team = (
-                            db.session.query(Team).filter(Team.name == team_name).first()
-                        )
+                        team = db.session.query(Team).filter(Team.name == team_name).first()
                         inject = Inject(
                             team=team,
                             template=template,
@@ -530,24 +510,14 @@ def admin_get_inject_templates():
                     scenario=template.scenario,
                     deliverable=template.deliverable,
                     score=template.score,
-                    start_time=template.start_time.astimezone(
-                        pytz.timezone(config.timezone)
-                    ).isoformat(),
-                    end_time=template.end_time.astimezone(
-                        pytz.timezone(config.timezone)
-                    ).isoformat(),
+                    start_time=template.start_time.astimezone(pytz.timezone(config.timezone)).isoformat(),
+                    end_time=template.end_time.astimezone(pytz.timezone(config.timezone)).isoformat(),
                     enabled=template.enabled,
                     # rubric=[
                     #     {"id": x.id, "value": x.value, "deliverable": x.deliverable}
                     #     for x in template.rubric
                     # ],
-                    teams=[
-                        inject.team.name
-                        for inject in template.inject
-                        if inject
-                        if inject.enabled
-                        if inject.team
-                    ],
+                    teams=[inject.team.name for inject in template.inject if inject if inject.enabled if inject.team],
                 )
             )
         return jsonify(data=data)
@@ -595,16 +565,8 @@ def admin_post_inject_templates():
                 scenario=data["scenario"],
                 deliverable=data["deliverable"],
                 score=data["score"],
-                start_time=(
-                    parse(data["start_time"])
-                    .astimezone(pytz.timezone(config.timezone))
-                    .replace(tzinfo=None)
-                ),
-                end_time=(
-                    parse(data["end_time"])
-                    .astimezone(pytz.timezone(config.timezone))
-                    .replace(tzinfo=None)
-                ),
+                start_time=(parse(data["start_time"]).astimezone(pytz.timezone(config.timezone)).replace(tzinfo=None)),
+                end_time=(parse(data["end_time"]).astimezone(pytz.timezone(config.timezone)).replace(tzinfo=None)),
             )
             db.session.add(template)
             db.session.commit()
@@ -628,9 +590,7 @@ def admin_post_inject_templates():
                         inject.enabled = True
                     # Otherwise, create the inject
                     else:
-                        team = (
-                            db.session.query(Team).filter(Team.name == team_name).first()
-                        )
+                        team = db.session.query(Team).filter(Team.name == team_name).first()
                         inject = Inject(
                             team=team,
                             template=template,
@@ -703,17 +663,9 @@ def admin_import_inject_templates():
                         if d.get("deliverable"):
                             t.deliverable = d["deliverable"]
                         if d.get("start_time"):
-                            t.start_time = (
-                                parse(d["start_time"])
-                                .astimezone(pytz.utc)
-                                .replace(tzinfo=None)
-                            )
+                            t.start_time = parse(d["start_time"]).astimezone(pytz.utc).replace(tzinfo=None)
                         if d.get("end_time"):
-                            t.end_time = (
-                                parse(d["start_time"])
-                                .astimezone(pytz.utc)
-                                .replace(tzinfo=None)
-                            )
+                            t.end_time = parse(d["start_time"]).astimezone(pytz.utc).replace(tzinfo=None)
                         if d.get("enabled"):
                             t.enabled = True
                         else:
@@ -752,11 +704,7 @@ def admin_import_inject_templates():
                                     inject.enabled = True
                                 # Otherwise, create the inject
                                 else:
-                                    team = (
-                                        db.session.query(Team)
-                                        .filter(Team.name == team_name)
-                                        .first()
-                                    )
+                                    team = db.session.query(Team).filter(Team.name == team_name).first()
                                     inject = Inject(
                                         team=team,
                                         template=template,
@@ -776,9 +724,7 @@ def admin_import_inject_templates():
 
                     else:
                         return (
-                            jsonify(
-                                {"status": "Error", "message": "Invalid Template ID"}
-                            ),
+                            jsonify({"status": "Error", "message": "Invalid Template ID"}),
                             400,
                         )
                 # Otherwise, create the template
@@ -788,12 +734,8 @@ def admin_import_inject_templates():
                         scenario=d["scenario"],
                         deliverable=d["deliverable"],
                         score=d["score"],
-                        start_time=parse(d["start_time"])
-                        .astimezone(pytz.utc)
-                        .replace(tzinfo=None),
-                        end_time=parse(d["end_time"])
-                        .astimezone(pytz.utc)
-                        .replace(tzinfo=None),
+                        start_time=parse(d["start_time"]).astimezone(pytz.utc).replace(tzinfo=None),
+                        end_time=parse(d["end_time"]).astimezone(pytz.utc).replace(tzinfo=None),
                         enabled=d["enabled"],
                     )
                     db.session.add(t)
@@ -818,11 +760,7 @@ def admin_import_inject_templates():
                             inject.enabled = True
                         # Otherwise, create the inject
                         else:
-                            team = (
-                                db.session.query(Team)
-                                .filter(Team.name == team_name)
-                                .first()
-                            )
+                            team = db.session.query(Team).filter(Team.name == team_name).first()
                             inject = Inject(
                                 team=team,
                                 template=t,
@@ -889,9 +827,7 @@ def admin_injects_bar():
         team_data = {}
         team_labels = []
         team_inject_scores = []
-        blue_teams = (
-            db.session.query(Team).filter(Team.color == "Blue").order_by(Team.name).all()
-        )
+        blue_teams = db.session.query(Team).filter(Team.color == "Blue").order_by(Team.name).all()
         for blue_team in blue_teams:
             team_labels.append(blue_team.name)
             team_inject_scores.append(str(inject_scores.get(blue_team.id, 0)))
@@ -964,9 +900,7 @@ def admin_update_password():
     if current_user.is_white_team:
         if "user_id" in request.form and "password" in request.form:
             try:
-                user_obj = (
-                    db.session.query(User).filter(User.id == request.form["user_id"]).one()
-                )
+                user_obj = db.session.query(User).filter(User.id == request.form["user_id"]).one()
             except NoResultFound:
                 return redirect(url_for("auth.login"))
             user_obj.update_password(html.escape(request.form["password"]))
@@ -986,14 +920,8 @@ def admin_update_password():
 @login_required
 def admin_add_user():
     if current_user.is_white_team:
-        if (
-            "username" in request.form
-            and "password" in request.form
-            and "team_id" in request.form
-        ):
-            team_obj = (
-                db.session.query(Team).filter(Team.id == request.form["team_id"]).one()
-            )
+        if "username" in request.form and "password" in request.form and "team_id" in request.form:
+            team_obj = db.session.query(Team).filter(Team.id == request.form["team_id"]).one()
             user_obj = User(
                 username=html.escape(request.form["username"]),
                 password=html.escape(request.form["password"]),
@@ -1015,9 +943,7 @@ def admin_add_user():
 def admin_add_team():
     if current_user.is_white_team:
         if "name" in request.form and "color" in request.form:
-            team_obj = Team(
-                html.escape(request.form["name"]), html.escape(request.form["color"])
-            )
+            team_obj = Team(html.escape(request.form["name"]), html.escape(request.form["color"]))
             db.session.add(team_obj)
             db.session.commit()
             flash("Team successfully added.", "success")
@@ -1038,7 +964,7 @@ def admin_toggle_engine():
         db.session.add(setting)
         db.session.commit()
         Setting.clear_cache("engine_paused")
-        return {'status': "Success"}
+        return {"status": "Success"}
     else:
         return {"status": "Unauthorized"}, 403
 
@@ -1049,12 +975,8 @@ def admin_get_engine_stats():
     if current_user.is_white_team:
         engine_stats = {}
         engine_stats["round_number"] = Round.get_last_round_num()
-        engine_stats["num_passed_checks"] = (
-            db.session.query(Check).filter_by(result=True).count()
-        )
-        engine_stats["num_failed_checks"] = (
-            db.session.query(Check).filter_by(result=False).count()
-        )
+        engine_stats["num_passed_checks"] = db.session.query(Check).filter_by(result=True).count()
+        engine_stats["num_failed_checks"] = db.session.query(Check).filter_by(result=False).count()
         engine_stats["total_checks"] = db.session.query(Check).count()
         return jsonify(engine_stats)
     else:
@@ -1088,3 +1010,69 @@ def admin_get_queue_stats():
         return jsonify(data=queue_stats)
     else:
         return {"status": "Unauthorized"}, 403
+
+
+@mod.route("/api/admin/update_settings", methods=["POST"])
+@login_required
+def admin_update_settings():
+    """
+    Generic endpoint to update multiple settings at once.
+
+    Request body (JSON):
+        {
+            "setting_name": "setting_value",
+            ...
+        }
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Missing JSON body"}), 400
+
+    # List of allowed settings that can be updated via this endpoint
+    allowed_settings = {
+        "persistence_timeout_seconds",
+        "persistence_beacon_psk",
+        "sla_enabled",
+        "sla_penalty_threshold",
+        "sla_penalty_percent",
+        "sla_penalty_max_percent",
+        "sla_penalty_mode",
+        "sla_allow_negative",
+        "dynamic_scoring_enabled",
+        "dynamic_scoring_early_rounds",
+        "dynamic_scoring_early_multiplier",
+        "dynamic_scoring_late_start_round",
+        "dynamic_scoring_late_multiplier",
+    }
+
+    updated = []
+    for key, value in data.items():
+        if key not in allowed_settings:
+            return jsonify({"error": f"Setting '{key}' is not allowed to be updated via this endpoint"}), 400
+
+        setting = Setting.get_setting(key)
+        if not setting:
+            # Create the setting if it doesn't exist
+            setting = Setting(name=key, value=value)
+            db.session.add(setting)
+        else:
+            setting.value = value
+            db.session.add(setting)
+
+        updated.append(key)
+
+    db.session.commit()
+
+    # Clear cache for all updated settings
+    for key in updated:
+        Setting.clear_cache(key)
+
+    return jsonify(
+        {
+            "status": "success",
+            "updated": updated,
+        }
+    )

--- a/scoring_engine/web/views/api/persistence.py
+++ b/scoring_engine/web/views/api/persistence.py
@@ -1,0 +1,609 @@
+"""API endpoints for tracking red team persistence on compromised hosts."""
+from datetime import datetime, timedelta, timezone
+
+from flask import jsonify, request
+from flask_login import current_user, login_required
+from sqlalchemy import and_, desc, func
+from sqlalchemy.orm import joinedload
+
+from scoring_engine.db import db
+from scoring_engine.models.flag import PersistenceSession, Platform
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+
+from . import mod
+
+
+def get_persistence_timeout_seconds():
+    """Get the persistence timeout from settings, defaulting to 5 minutes."""
+    try:
+        timeout = Setting.get_setting("persistence_timeout_seconds")
+        return int(timeout.value) if timeout else 300
+    except Exception:
+        return 300  # 5 minutes default
+
+
+@mod.route("/api/persistence/sessions")
+@login_required
+def persistence_sessions():
+    """
+    Get all persistence sessions.
+
+    Query params:
+        active_only: if 'true', only show active sessions
+        team_id: filter by blue team (victim)
+        limit: max results (default 100)
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    active_only = request.args.get("active_only", "false").lower() == "true"
+    team_id = request.args.get("team_id", type=int)
+    limit = request.args.get("limit", 100, type=int)
+
+    query = (
+        db.session.query(PersistenceSession)
+        .options(joinedload(PersistenceSession.team))
+    )
+
+    if active_only:
+        query = query.filter(PersistenceSession.ended_at.is_(None))
+
+    if team_id:
+        query = query.filter(PersistenceSession.team_id == team_id)
+
+    sessions = (
+        query.order_by(desc(PersistenceSession.last_checkin))
+        .limit(limit)
+        .all()
+    )
+
+    timeout_seconds = get_persistence_timeout_seconds()
+    now = datetime.now(timezone.utc)
+
+    data = []
+    for session in sessions:
+        # Check if session is stale (no recent checkin)
+        last_checkin_utc = session.last_checkin
+        if last_checkin_utc.tzinfo is None:
+            last_checkin_utc = last_checkin_utc.replace(tzinfo=timezone.utc)
+
+        seconds_since_checkin = (now - last_checkin_utc).total_seconds()
+        is_stale = session.is_active and seconds_since_checkin > timeout_seconds
+
+        data.append({
+            "id": session.id,
+            "host": session.host,
+            "team_id": session.team_id,
+            "team_name": session.team.name if session.team else None,
+            "platform": session.platform.value if session.platform else None,
+            "started_at": session.started_at.isoformat() if session.started_at else None,
+            "started_at_local": session.localize_started_at,
+            "last_checkin": session.last_checkin.isoformat() if session.last_checkin else None,
+            "last_checkin_local": session.localize_last_checkin,
+            "ended_at": session.ended_at.isoformat() if session.ended_at else None,
+            "ended_at_local": session.localize_ended_at,
+            "end_reason": session.end_reason,
+            "is_active": session.is_active,
+            "is_stale": is_stale,
+            "seconds_since_checkin": int(seconds_since_checkin),
+            "duration_seconds": session.duration_seconds,
+            "duration_formatted": session.duration_formatted,
+        })
+
+    return jsonify({
+        "data": data,
+        "count": len(data),
+        "timeout_seconds": timeout_seconds,
+    })
+
+
+@mod.route("/api/persistence/active")
+@login_required
+def persistence_active():
+    """
+    Get currently active persistence sessions.
+    Convenience endpoint that filters to active sessions only.
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    timeout_seconds = get_persistence_timeout_seconds()
+    now = datetime.now(timezone.utc)
+    timeout_threshold = now - timedelta(seconds=timeout_seconds)
+
+    # Active sessions with recent checkin
+    sessions = (
+        db.session.query(PersistenceSession)
+        .options(joinedload(PersistenceSession.team))
+        .filter(PersistenceSession.ended_at.is_(None))
+        .filter(PersistenceSession.last_checkin >= timeout_threshold.replace(tzinfo=None))
+        .order_by(desc(PersistenceSession.last_checkin))
+        .all()
+    )
+
+    data = []
+    for session in sessions:
+        last_checkin_utc = session.last_checkin
+        if last_checkin_utc.tzinfo is None:
+            last_checkin_utc = last_checkin_utc.replace(tzinfo=timezone.utc)
+
+        data.append({
+            "id": session.id,
+            "host": session.host,
+            "team_id": session.team_id,
+            "team_name": session.team.name if session.team else None,
+            "platform": session.platform.value if session.platform else None,
+            "started_at_local": session.localize_started_at,
+            "last_checkin_local": session.localize_last_checkin,
+            "duration_formatted": session.duration_formatted,
+            "seconds_since_checkin": int((now - last_checkin_utc).total_seconds()),
+        })
+
+    return jsonify({
+        "data": data,
+        "count": len(data),
+        "timeout_seconds": timeout_seconds,
+    })
+
+
+@mod.route("/api/persistence/detect_stale", methods=["POST"])
+@login_required
+def persistence_detect_stale():
+    """
+    Detect and end stale persistence sessions.
+    Sessions that haven't checked in within the timeout are marked as ended.
+
+    Returns the number of sessions that were ended.
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    timeout_seconds = get_persistence_timeout_seconds()
+    now = datetime.now(timezone.utc)
+    timeout_threshold = now - timedelta(seconds=timeout_seconds)
+
+    # Find stale active sessions
+    stale_sessions = (
+        db.session.query(PersistenceSession)
+        .filter(PersistenceSession.ended_at.is_(None))
+        .filter(PersistenceSession.last_checkin < timeout_threshold.replace(tzinfo=None))
+        .all()
+    )
+
+    ended_count = 0
+    for session in stale_sessions:
+        session.ended_at = session.last_checkin  # End time is last known checkin
+        session.end_reason = "timeout"
+        ended_count += 1
+
+    db.session.commit()
+
+    return jsonify({
+        "status": "success",
+        "sessions_ended": ended_count,
+        "timeout_seconds": timeout_seconds,
+    })
+
+
+@mod.route("/api/persistence/session/<int:session_id>/end", methods=["POST"])
+@login_required
+def persistence_end_session(session_id):
+    """Manually end a persistence session."""
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    session = db.session.get(PersistenceSession, session_id)
+    if not session:
+        return jsonify({"error": "Session not found"}), 404
+
+    if session.ended_at:
+        return jsonify({"error": "Session already ended"}), 400
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    session.ended_at = now
+    session.end_reason = "manual"
+    db.session.commit()
+
+    return jsonify({
+        "status": "success",
+        "session_id": session_id,
+        "duration_seconds": session.duration_seconds,
+        "duration_formatted": session.duration_formatted,
+    })
+
+
+@mod.route("/api/persistence/summary")
+@login_required
+def persistence_summary():
+    """
+    Get persistence summary statistics.
+    Shows total persistence time by team, active sessions, etc.
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    timeout_seconds = get_persistence_timeout_seconds()
+    now = datetime.now(timezone.utc)
+    timeout_threshold = now - timedelta(seconds=timeout_seconds)
+
+    # Total sessions
+    total_sessions = db.session.query(func.count(PersistenceSession.id)).scalar()
+
+    # Active sessions (not ended and recently checked in)
+    active_sessions = (
+        db.session.query(func.count(PersistenceSession.id))
+        .filter(PersistenceSession.ended_at.is_(None))
+        .filter(PersistenceSession.last_checkin >= timeout_threshold.replace(tzinfo=None))
+        .scalar()
+    )
+
+    # Stale sessions (not ended but no recent checkin)
+    stale_sessions = (
+        db.session.query(func.count(PersistenceSession.id))
+        .filter(PersistenceSession.ended_at.is_(None))
+        .filter(PersistenceSession.last_checkin < timeout_threshold.replace(tzinfo=None))
+        .scalar()
+    )
+
+    # Ended sessions
+    ended_sessions = (
+        db.session.query(func.count(PersistenceSession.id))
+        .filter(PersistenceSession.ended_at.isnot(None))
+        .scalar()
+    )
+
+    # Sessions by team (victim)
+    sessions_by_team = (
+        db.session.query(
+            Team.name,
+            func.count(PersistenceSession.id).label("count"),
+        )
+        .join(PersistenceSession, PersistenceSession.team_id == Team.id)
+        .group_by(Team.id, Team.name)
+        .order_by(desc("count"))
+        .all()
+    )
+
+    # Active sessions by team
+    active_by_team = (
+        db.session.query(
+            Team.name,
+            func.count(PersistenceSession.id).label("count"),
+        )
+        .join(PersistenceSession, PersistenceSession.team_id == Team.id)
+        .filter(PersistenceSession.ended_at.is_(None))
+        .filter(PersistenceSession.last_checkin >= timeout_threshold.replace(tzinfo=None))
+        .group_by(Team.id, Team.name)
+        .order_by(desc("count"))
+        .all()
+    )
+
+    # Sessions by platform
+    sessions_by_platform = (
+        db.session.query(
+            PersistenceSession.platform,
+            func.count(PersistenceSession.id).label("count"),
+        )
+        .group_by(PersistenceSession.platform)
+        .all()
+    )
+
+    # Calculate average persistence duration for ended sessions
+    ended = (
+        db.session.query(PersistenceSession)
+        .filter(PersistenceSession.ended_at.isnot(None))
+        .all()
+    )
+    total_duration = sum(s.duration_seconds for s in ended)
+    avg_duration = total_duration // len(ended) if ended else 0
+
+    # Longest persistence session
+    longest_session = None
+    all_sessions = db.session.query(PersistenceSession).all()
+    if all_sessions:
+        longest = max(all_sessions, key=lambda s: s.duration_seconds)
+        longest_session = {
+            "id": longest.id,
+            "host": longest.host,
+            "team_name": longest.team.name if longest.team else None,
+            "duration_formatted": longest.duration_formatted,
+            "duration_seconds": longest.duration_seconds,
+        }
+
+    return jsonify({
+        "total_sessions": total_sessions,
+        "active_sessions": active_sessions,
+        "stale_sessions": stale_sessions,
+        "ended_sessions": ended_sessions,
+        "by_team": [{"team": t, "count": c} for t, c in sessions_by_team],
+        "active_by_team": [{"team": t, "count": c} for t, c in active_by_team],
+        "by_platform": [
+            {"platform": p.value if p else "unknown", "count": c}
+            for p, c in sessions_by_platform
+        ],
+        "average_duration_seconds": avg_duration,
+        "average_duration_formatted": format_duration(avg_duration),
+        "longest_session": longest_session,
+        "timeout_seconds": timeout_seconds,
+    })
+
+
+@mod.route("/api/persistence/team/<int:team_id>")
+@login_required
+def persistence_by_team(team_id):
+    """Get persistence history for a specific team."""
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    team = db.session.get(Team, team_id)
+    if not team:
+        return jsonify({"error": "Team not found"}), 404
+
+    sessions = (
+        db.session.query(PersistenceSession)
+        .filter(PersistenceSession.team_id == team_id)
+        .order_by(desc(PersistenceSession.started_at))
+        .all()
+    )
+
+    timeout_seconds = get_persistence_timeout_seconds()
+    now = datetime.now(timezone.utc)
+
+    # Calculate total persistence time
+    total_duration = sum(s.duration_seconds for s in sessions)
+
+    # Active sessions count
+    active_count = sum(1 for s in sessions if s.is_active)
+
+    # Unique hosts compromised
+    unique_hosts = len(set(s.host for s in sessions))
+
+    data = []
+    for session in sessions:
+        last_checkin_utc = session.last_checkin
+        if last_checkin_utc.tzinfo is None:
+            last_checkin_utc = last_checkin_utc.replace(tzinfo=timezone.utc)
+
+        seconds_since_checkin = (now - last_checkin_utc).total_seconds()
+        is_stale = session.is_active and seconds_since_checkin > timeout_seconds
+
+        data.append({
+            "id": session.id,
+            "host": session.host,
+            "platform": session.platform.value if session.platform else None,
+            "started_at_local": session.localize_started_at,
+            "last_checkin_local": session.localize_last_checkin,
+            "ended_at_local": session.localize_ended_at,
+            "end_reason": session.end_reason,
+            "is_active": session.is_active,
+            "is_stale": is_stale,
+            "duration_formatted": session.duration_formatted,
+        })
+
+    return jsonify({
+        "team_id": team_id,
+        "team_name": team.name,
+        "sessions": data,
+        "total_sessions": len(sessions),
+        "active_sessions": active_count,
+        "unique_hosts": unique_hosts,
+        "total_duration_seconds": total_duration,
+        "total_duration_formatted": format_duration(total_duration),
+    })
+
+
+def format_duration(seconds):
+    """Format seconds into human-readable duration."""
+    if seconds < 60:
+        return f"{seconds}s"
+    hours, remainder = divmod(seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours > 0:
+        return f"{hours}h {minutes}m {secs}s"
+    return f"{minutes}m {secs}s"
+
+
+# =============================================================================
+# External C2 Beacon Integration (Cobalt Strike, etc.)
+# =============================================================================
+
+@mod.route("/api/persistence/beacon", methods=["POST"])
+def persistence_beacon():
+    """
+    External C2 beacon check-in endpoint.
+
+    Allows external C2 frameworks (Cobalt Strike, Mythic, etc.) to report
+    their beacons to the persistence tracking system via webhook/API.
+
+    Authentication: PSK in Authorization header
+        Authorization: Bearer <persistence_beacon_psk>
+
+    Request body (JSON):
+        {
+            "team": "Team 1",           # Blue team name (victim)
+            "host": "webserver.local",  # Compromised host
+            "platform": "win" | "nix",  # Platform (win/nix)
+            "beacon_id": "abc123",      # Optional: external beacon ID
+            "user": "DOMAIN\\user",     # Optional: compromised user
+            "metadata": {}              # Optional: additional metadata
+        }
+
+    Returns:
+        {
+            "status": "success",
+            "session_id": 123,
+            "action": "created" | "updated"
+        }
+    """
+    # Check if beacon PSK is configured
+    psk_setting = Setting.get_setting("persistence_beacon_psk")
+    if not psk_setting or not psk_setting.value:
+        return jsonify({"error": "Beacon API not configured"}), 503
+
+    # Validate PSK
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return jsonify({"error": "Missing or invalid Authorization header"}), 401
+
+    provided_psk = auth_header[7:]  # Remove "Bearer " prefix
+    if provided_psk != psk_setting.value:
+        return jsonify({"error": "Invalid PSK"}), 401
+
+    # Parse request body
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Missing JSON body"}), 400
+
+    team_name = data.get("team")
+    host = data.get("host")
+    platform_str = data.get("platform")
+
+    if not team_name or not host or not platform_str:
+        return jsonify({"error": "Missing required fields: team, host, platform"}), 400
+
+    # Validate platform
+    try:
+        platform = Platform(platform_str)
+    except ValueError:
+        return jsonify({"error": f"Invalid platform: {platform_str}. Use 'win' or 'nix'"}), 400
+
+    # Find team
+    team = db.session.query(Team).filter_by(name=team_name).first()
+    if not team:
+        return jsonify({"error": f"Team not found: {team_name}"}), 404
+
+    if not team.is_blue_team:
+        return jsonify({"error": "Target must be a blue team"}), 400
+
+    # Include optional metadata in host identifier for beacon tracking
+    beacon_id = data.get("beacon_id")
+    if beacon_id:
+        # Use beacon_id in host to track individual beacons separately
+        host = f"{host}:{beacon_id}"
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    # Find or create session
+    active_session = (
+        db.session.query(PersistenceSession)
+        .filter(
+            and_(
+                PersistenceSession.host == host,
+                PersistenceSession.team_id == team.id,
+                PersistenceSession.ended_at.is_(None),
+            )
+        )
+        .first()
+    )
+
+    if active_session:
+        # Update existing session
+        active_session.last_checkin = now
+        active_session.platform = platform
+        action = "updated"
+        session_id = active_session.id
+    else:
+        # Create new session
+        session = PersistenceSession(
+            host=host,
+            team_id=team.id,
+            platform=platform,
+            started_at=now,
+            last_checkin=now,
+        )
+        db.session.add(session)
+        db.session.flush()  # Get ID before commit
+        action = "created"
+        session_id = session.id
+
+    db.session.commit()
+
+    return jsonify({
+        "status": "success",
+        "session_id": session_id,
+        "action": action,
+        "host": host,
+        "team": team_name,
+    })
+
+
+@mod.route("/api/persistence/beacon/end", methods=["POST"])
+def persistence_beacon_end():
+    """
+    End a beacon session from external C2.
+
+    Use when a beacon exits cleanly or is killed.
+
+    Authentication: PSK in Authorization header
+
+    Request body (JSON):
+        {
+            "team": "Team 1",
+            "host": "webserver.local",
+            "beacon_id": "abc123",      # Optional
+            "reason": "exit"            # Optional: exit, killed, lost
+        }
+    """
+    # Check if beacon PSK is configured
+    psk_setting = Setting.get_setting("persistence_beacon_psk")
+    if not psk_setting or not psk_setting.value:
+        return jsonify({"error": "Beacon API not configured"}), 503
+
+    # Validate PSK
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return jsonify({"error": "Missing or invalid Authorization header"}), 401
+
+    provided_psk = auth_header[7:]
+    if provided_psk != psk_setting.value:
+        return jsonify({"error": "Invalid PSK"}), 401
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Missing JSON body"}), 400
+
+    team_name = data.get("team")
+    host = data.get("host")
+    beacon_id = data.get("beacon_id")
+    reason = data.get("reason", "external")
+
+    if not team_name or not host:
+        return jsonify({"error": "Missing required fields: team, host"}), 400
+
+    # Find team
+    team = db.session.query(Team).filter_by(name=team_name).first()
+    if not team:
+        return jsonify({"error": f"Team not found: {team_name}"}), 404
+
+    # Construct host with beacon_id if provided
+    if beacon_id:
+        host = f"{host}:{beacon_id}"
+
+    # Find active session
+    active_session = (
+        db.session.query(PersistenceSession)
+        .filter(
+            and_(
+                PersistenceSession.host == host,
+                PersistenceSession.team_id == team.id,
+                PersistenceSession.ended_at.is_(None),
+            )
+        )
+        .first()
+    )
+
+    if not active_session:
+        return jsonify({"error": "No active session found"}), 404
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    active_session.ended_at = now
+    active_session.end_reason = reason
+    db.session.commit()
+
+    return jsonify({
+        "status": "success",
+        "session_id": active_session.id,
+        "duration_seconds": active_session.duration_seconds,
+        "duration_formatted": active_session.duration_formatted,
+    })

--- a/tests/scoring_engine/web/views/test_api_persistence.py
+++ b/tests/scoring_engine/web/views/test_api_persistence.py
@@ -1,0 +1,394 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+from scoring_engine.models.flag import PersistenceSession, Platform
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+from tests.scoring_engine.unit_test import UnitTest
+
+
+class TestAPIPersistence(UnitTest):
+    """Tests for the persistence tracking API endpoints."""
+
+    def setup_method(self):
+        super(TestAPIPersistence, self).setup_method()
+        self.app.config["WTF_CSRF_ENABLED"] = False
+        self.client = self.app.test_client()
+
+    def create_white_team_user(self):
+        """Create a white team user for admin access."""
+        team = Team(name="White Team", color="White")
+        self.session.add(team)
+        user = User(username="whiteuser", password="testpass", team=team)
+        self.session.add(user)
+        self.session.commit()
+        return user
+
+    def create_blue_team_user(self):
+        """Create a blue team user."""
+        team = Team(name="Blue Team 1", color="Blue")
+        self.session.add(team)
+        user = User(username="blueuser", password="testpass", team=team)
+        self.session.add(user)
+        self.session.commit()
+        return user
+
+    def create_blue_team(self, name="Team 1"):
+        """Create a blue team."""
+        team = Team(name=name, color="Blue")
+        self.session.add(team)
+        self.session.commit()
+        return team
+
+    def login(self, username, password):
+        """Login helper."""
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def create_persistence_session(self, team, host="webserver.local", platform=Platform.nix, active=True):
+        """Create a persistence session for testing."""
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        session = PersistenceSession(
+            host=host,
+            team_id=team.id,
+            platform=platform,
+            started_at=now - timedelta(hours=1),
+            last_checkin=now if active else now - timedelta(hours=2),
+            ended_at=None if active else now - timedelta(hours=1),
+            end_reason=None if active else "timeout",
+        )
+        self.session.add(session)
+        self.session.commit()
+        return session
+
+    # =========================================================================
+    # Authentication Tests
+    # =========================================================================
+
+    def test_persistence_sessions_requires_auth(self):
+        """Test that /api/persistence/sessions requires authentication."""
+        resp = self.client.get("/api/persistence/sessions")
+        assert resp.status_code == 302
+        assert "/login" in resp.location
+
+    def test_persistence_sessions_requires_white_team(self):
+        """Test that /api/persistence/sessions requires white team."""
+        self.create_blue_team_user()
+        self.login("blueuser", "testpass")
+        resp = self.client.get("/api/persistence/sessions")
+        assert resp.status_code == 403
+
+    # =========================================================================
+    # Sessions Endpoint Tests
+    # =========================================================================
+
+    def test_persistence_sessions_empty(self):
+        """Test getting sessions when none exist."""
+        self.create_white_team_user()
+        self.login("whiteuser", "testpass")
+        resp = self.client.get("/api/persistence/sessions")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["count"] == 0
+        assert data["data"] == []
+
+    def test_persistence_sessions_with_data(self):
+        """Test getting sessions with existing data."""
+        self.create_white_team_user()
+        blue_team = self.create_blue_team()
+        self.create_persistence_session(blue_team)
+        self.login("whiteuser", "testpass")
+
+        resp = self.client.get("/api/persistence/sessions")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["count"] == 1
+        assert data["data"][0]["host"] == "webserver.local"
+        assert data["data"][0]["team_name"] == "Team 1"
+
+    def test_persistence_sessions_filter_active_only(self):
+        """Test filtering to active sessions only."""
+        self.create_white_team_user()
+        blue_team = self.create_blue_team()
+        self.create_persistence_session(blue_team, host="active.local", active=True)
+        self.create_persistence_session(blue_team, host="ended.local", active=False)
+        self.login("whiteuser", "testpass")
+
+        resp = self.client.get("/api/persistence/sessions?active_only=true")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["count"] == 1
+        assert data["data"][0]["host"] == "active.local"
+
+    # =========================================================================
+    # Summary Endpoint Tests
+    # =========================================================================
+
+    def test_persistence_summary(self):
+        """Test the persistence summary endpoint."""
+        self.create_white_team_user()
+        blue_team = self.create_blue_team()
+        self.create_persistence_session(blue_team, active=True)
+        self.create_persistence_session(blue_team, host="other.local", active=False)
+        self.login("whiteuser", "testpass")
+
+        resp = self.client.get("/api/persistence/summary")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["total_sessions"] == 2
+        assert data["ended_sessions"] == 1
+
+    # =========================================================================
+    # End Session Tests
+    # =========================================================================
+
+    def test_persistence_end_session(self):
+        """Test manually ending a session."""
+        self.create_white_team_user()
+        blue_team = self.create_blue_team()
+        session = self.create_persistence_session(blue_team)
+        self.login("whiteuser", "testpass")
+
+        resp = self.client.post(f"/api/persistence/session/{session.id}/end")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "success"
+        assert data["session_id"] == session.id
+
+        # Verify session is ended
+        self.session.refresh(session)
+        assert session.ended_at is not None
+        assert session.end_reason == "manual"
+
+    def test_persistence_end_session_not_found(self):
+        """Test ending a non-existent session."""
+        self.create_white_team_user()
+        self.login("whiteuser", "testpass")
+
+        resp = self.client.post("/api/persistence/session/999/end")
+        assert resp.status_code == 404
+
+    def test_persistence_end_session_already_ended(self):
+        """Test ending an already ended session."""
+        self.create_white_team_user()
+        blue_team = self.create_blue_team()
+        session = self.create_persistence_session(blue_team, active=False)
+        self.login("whiteuser", "testpass")
+
+        resp = self.client.post(f"/api/persistence/session/{session.id}/end")
+        assert resp.status_code == 400
+
+    # =========================================================================
+    # Detect Stale Tests
+    # =========================================================================
+
+    def test_persistence_detect_stale(self):
+        """Test detecting and ending stale sessions."""
+        self.create_white_team_user()
+        blue_team = self.create_blue_team()
+
+        # Create a stale session (last_checkin > timeout ago)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        stale_session = PersistenceSession(
+            host="stale.local",
+            team_id=blue_team.id,
+            platform=Platform.nix,
+            started_at=now - timedelta(hours=2),
+            last_checkin=now - timedelta(minutes=10),  # 10 mins ago, > 5 min default timeout
+        )
+        self.session.add(stale_session)
+        self.session.commit()
+
+        # Add timeout setting (5 minutes = 300 seconds)
+        self.session.add(Setting(name="persistence_timeout_seconds", value="300"))
+        self.session.commit()
+        Setting.clear_cache()
+
+        self.login("whiteuser", "testpass")
+
+        resp = self.client.post("/api/persistence/detect_stale")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "success"
+        assert data["sessions_ended"] == 1
+
+        # Verify session was ended
+        self.session.refresh(stale_session)
+        assert stale_session.ended_at is not None
+        assert stale_session.end_reason == "timeout"
+
+    # =========================================================================
+    # External Beacon API Tests
+    # =========================================================================
+
+    def test_beacon_api_disabled_without_psk(self):
+        """Test that beacon API returns 503 when PSK not configured."""
+        self.create_blue_team("Team 1")
+
+        resp = self.client.post(
+            "/api/persistence/beacon",
+            json={"team": "Team 1", "host": "test.local", "platform": "nix"},
+            headers={"Authorization": "Bearer somepsk"},
+        )
+        assert resp.status_code == 503
+
+    def test_beacon_api_invalid_psk(self):
+        """Test that beacon API rejects invalid PSK."""
+        self.create_blue_team("Team 1")
+        self.session.add(Setting(name="persistence_beacon_psk", value="correctpsk"))
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.post(
+            "/api/persistence/beacon",
+            json={"team": "Team 1", "host": "test.local", "platform": "nix"},
+            headers={"Authorization": "Bearer wrongpsk"},
+        )
+        assert resp.status_code == 401
+
+    def test_beacon_api_missing_auth(self):
+        """Test that beacon API requires Authorization header."""
+        self.create_blue_team("Team 1")
+        self.session.add(Setting(name="persistence_beacon_psk", value="testpsk"))
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.post(
+            "/api/persistence/beacon",
+            json={"team": "Team 1", "host": "test.local", "platform": "nix"},
+        )
+        assert resp.status_code == 401
+
+    def test_beacon_api_creates_session(self):
+        """Test that beacon API creates a new session."""
+        blue_team = self.create_blue_team("Team 1")
+        self.session.add(Setting(name="persistence_beacon_psk", value="testpsk"))
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.post(
+            "/api/persistence/beacon",
+            json={"team": "Team 1", "host": "test.local", "platform": "nix"},
+            headers={"Authorization": "Bearer testpsk"},
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "success"
+        assert data["action"] == "created"
+        assert data["host"] == "test.local"
+
+        # Verify session was created
+        session = self.session.query(PersistenceSession).filter_by(host="test.local").first()
+        assert session is not None
+        assert session.team_id == blue_team.id
+        assert session.platform == Platform.nix
+
+    def test_beacon_api_updates_existing_session(self):
+        """Test that beacon API updates existing session."""
+        blue_team = self.create_blue_team("Team 1")
+        existing_session = self.create_persistence_session(blue_team, host="test.local")
+        original_checkin = existing_session.last_checkin
+
+        self.session.add(Setting(name="persistence_beacon_psk", value="testpsk"))
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.post(
+            "/api/persistence/beacon",
+            json={"team": "Team 1", "host": "test.local", "platform": "win"},
+            headers={"Authorization": "Bearer testpsk"},
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "success"
+        assert data["action"] == "updated"
+
+        # Verify session was updated
+        self.session.refresh(existing_session)
+        assert existing_session.last_checkin > original_checkin
+        assert existing_session.platform == Platform.windows
+
+    def test_beacon_api_with_beacon_id(self):
+        """Test that beacon_id creates separate sessions."""
+        blue_team = self.create_blue_team("Team 1")
+        self.session.add(Setting(name="persistence_beacon_psk", value="testpsk"))
+        self.session.commit()
+        Setting.clear_cache()
+
+        # Create first beacon
+        resp1 = self.client.post(
+            "/api/persistence/beacon",
+            json={"team": "Team 1", "host": "test.local", "platform": "win", "beacon_id": "beacon1"},
+            headers={"Authorization": "Bearer testpsk"},
+        )
+        assert resp1.status_code == 200
+
+        # Create second beacon on same host
+        resp2 = self.client.post(
+            "/api/persistence/beacon",
+            json={"team": "Team 1", "host": "test.local", "platform": "win", "beacon_id": "beacon2"},
+            headers={"Authorization": "Bearer testpsk"},
+        )
+        assert resp2.status_code == 200
+
+        # Should have two separate sessions
+        sessions = self.session.query(PersistenceSession).filter(
+            PersistenceSession.team_id == blue_team.id
+        ).all()
+        assert len(sessions) == 2
+        hosts = [s.host for s in sessions]
+        assert "test.local:beacon1" in hosts
+        assert "test.local:beacon2" in hosts
+
+    def test_beacon_end_api(self):
+        """Test that beacon end API ends a session."""
+        blue_team = self.create_blue_team("Team 1")
+        session = self.create_persistence_session(blue_team, host="test.local")
+        self.session.add(Setting(name="persistence_beacon_psk", value="testpsk"))
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.post(
+            "/api/persistence/beacon/end",
+            json={"team": "Team 1", "host": "test.local", "reason": "exit"},
+            headers={"Authorization": "Bearer testpsk"},
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "success"
+
+        # Verify session was ended
+        self.session.refresh(session)
+        assert session.ended_at is not None
+        assert session.end_reason == "exit"
+
+    def test_beacon_api_invalid_team(self):
+        """Test that beacon API rejects invalid team."""
+        self.session.add(Setting(name="persistence_beacon_psk", value="testpsk"))
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.post(
+            "/api/persistence/beacon",
+            json={"team": "Nonexistent Team", "host": "test.local", "platform": "nix"},
+            headers={"Authorization": "Bearer testpsk"},
+        )
+        assert resp.status_code == 404
+
+    def test_beacon_api_invalid_platform(self):
+        """Test that beacon API rejects invalid platform."""
+        self.create_blue_team("Team 1")
+        self.session.add(Setting(name="persistence_beacon_psk", value="testpsk"))
+        self.session.commit()
+        Setting.clear_cache()
+
+        resp = self.client.post(
+            "/api/persistence/beacon",
+            json={"team": "Team 1", "host": "test.local", "platform": "invalid"},
+            headers={"Authorization": "Bearer testpsk"},
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

This PR implements **attacker persistence tracking** (#3 from the Tier 2 features). It tracks how long red team maintains access on compromised hosts before remediation.

**Key features:**
- `PersistenceSession` model tracks start/end times, platform, and host
- Sessions created/updated on agent check-in
- External C2 integration (Cobalt Strike, Mythic, etc.) via public beacon API
- Admin dashboard at `/admin/persistence` with real-time session monitoring
- Stale session detection (auto-end sessions without recent check-ins)

## Changes

### New Files
- `scoring_engine/models/flag.py` - Added `PersistenceSession` model
- `scoring_engine/web/views/api/persistence.py` - Persistence API endpoints
- `scoring_engine/web/templates/admin/persistence.html` - Admin dashboard
- `tests/scoring_engine/web/views/test_api_persistence.py` - 19 tests

### Modified Files
- `scoring_engine/web/views/api/agent.py` - Track persistence on check-in
- `scoring_engine/web/views/api/__init__.py` - Register persistence module
- `scoring_engine/web/views/api/admin.py` - Generic settings update endpoint
- `scoring_engine/web/views/admin.py` - Admin persistence view
- `scoring_engine/web/templates/admin/adminbase.html` - Navigation link
- `scoring_engine/config_loader.py` - Persistence config options
- `bin/setup` - Create default persistence settings
- `engine.conf.inc` - Persistence configuration

## API Endpoints

### Admin Endpoints (White Team)
- `GET /api/persistence/sessions` - List all sessions
- `GET /api/persistence/active` - List active sessions
- `GET /api/persistence/summary` - Statistics
- `GET /api/persistence/team/<id>` - Per-team history
- `POST /api/persistence/detect_stale` - End stale sessions
- `POST /api/persistence/session/<id>/end` - Manually end session

### External C2 Integration (Public, PSK auth)
- `POST /api/persistence/beacon` - Create/update beacon check-in
- `POST /api/persistence/beacon/end` - End beacon session

## Configuration

```ini
# Timeout before session is considered stale (5 minutes default)
persistence_timeout_seconds = 300
# PSK for external C2 beacon API (leave empty to disable)
persistence_beacon_psk =
```

## Test plan
- [x] Unit tests pass (19 new tests)
- [x] Existing tests pass
- [ ] Manual testing of admin dashboard
- [ ] Test external beacon API with curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)