### PR TITLE
Fix regex validation for environment matching_content

### DIFF
--- a/scoring_engine/competition.py
+++ b/scoring_engine/competition.py
@@ -1,3 +1,4 @@
+import re
 import yaml
 import datetime
 
@@ -165,6 +166,10 @@ class Competition(dict):
         # Verify environment matching_content
         assert 'matching_content' in environment, "{0} {1} environment must have a 'matching_content' field".format(team_name, service_name)
         assert type(environment['matching_content']) is str, "{0} {1} environment 'matching_content' field must be a string".format(team_name, service_name)
+        try:
+            re.compile(environment['matching_content'])
+        except re.error as e:
+            assert False, "{0} {1} environment 'matching_content' field must be a valid regex pattern: {2}".format(team_name, service_name, e)
 
         # Verify environment properties
         if 'properties' in environment:

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -240,7 +240,16 @@ class Engine(object):
                             result = False
                             reason = CHECK_TIMED_OUT_TEXT
                         else:
-                            if re.search(environment.matching_content, task.result["output"]):
+                            try:
+                                matched = re.search(environment.matching_content, task.result["output"])
+                            except re.error:
+                                logger.warning(
+                                    "Invalid regex pattern for environment %s: %r, falling back to literal match",
+                                    environment.id,
+                                    environment.matching_content,
+                                )
+                                matched = environment.matching_content in task.result["output"]
+                            if matched:
                                 result = True
                                 reason = CHECK_SUCCESS_TEXT
                             else:

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -9,6 +9,7 @@ from flask import flash, redirect, request, url_for, jsonify
 from flask_login import current_user, login_required
 
 import html
+import re
 
 
 def _ensure_utc_aware(dt):
@@ -61,7 +62,12 @@ def admin_update_environment():
             environment = db.session.get(Environment, int(request.form["pk"]))
             if environment:
                 if request.form["name"] == "matching_content":
-                    environment.matching_content = html.escape(request.form["value"])
+                    value = html.escape(request.form["value"])
+                    try:
+                        re.compile(value)
+                    except re.error as e:
+                        return jsonify({"error": "Invalid regex pattern: " + str(e)}), 400
+                    environment.matching_content = value
                 db.session.add(environment)
                 db.session.commit()
                 return jsonify({"status": "Updated Environment Information"})

--- a/tests/scoring_engine/test_competition.py
+++ b/tests/scoring_engine/test_competition.py
@@ -307,6 +307,10 @@ class TestEnvironmentData(CompetitionDataTest):
         self.setup['teams'][0]['services'][0]['environments'][0]['matching_content'] = []
         self.verify_error("Team1 SSH environment 'matching_content' field must be a string")
 
+    def test_bad_matching_content_regex(self):
+        self.setup['teams'][0]['services'][0]['environments'][0]['matching_content'] = 'foo(bar'
+        self.verify_error("Team1 SSH environment 'matching_content' field must be a valid regex pattern: missing ), unterminated subpattern at position 3")
+
     def test_bad_properties_type(self):
         self.setup['teams'][0]['services'][0]['environments'][0]['properties'] = 'a string'
         self.verify_error("Team1 SSH environment 'properties' field must be an array")


### PR DESCRIPTION
The engine crashed with `re.PatternError: unbalanced parenthesis` when
`matching_content` contained invalid regex patterns, killing the entire
round. This adds three layers of defense:

1. Engine (runtime): catch re.error and fall back to literal string match
2. Competition YAML: validate regex at config parse time
3. Admin API: reject invalid regex when updating matching_content

https://claude.ai/code/session_01QUyHoTpYuo6Yw6fWkR9V2n