### PR TITLE
Fix pause/play button using stale per-process in-memory cache

### DIFF
--- a/scoring_engine/cache_helper.py
+++ b/scoring_engine/cache_helper.py
@@ -88,6 +88,20 @@ def update_services_data(team_id=None):
             cache.delete(key.decode("utf-8").removeprefix(cache.cache.key_prefix))
 
 
+def update_inject_data(inject_id, team_id=None):
+    """Clear cached inject detail for the given inject.
+
+    The cache key for ``/api/inject/<id>`` is ``/api/inject/<id>_<team_id>``.
+    Both the owning team and the white team can view an inject, so we clear
+    all matching keys when ``team_id`` is not provided.
+    """
+    if team_id is not None:
+        cache.delete(f"/api/inject/{inject_id}_{team_id}")
+    elif not isinstance(cache.cache, NullCache):
+        for key in cache.cache._write_client.scan_iter(match=f"*/api/inject/{inject_id}_*"):
+            cache.delete(key.decode("utf-8").removeprefix(cache.cache.key_prefix))
+
+
 # TODO - Break this into an API cache expiration
 def update_stats():
     from scoring_engine.web.views.stats import home

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -230,53 +230,42 @@ class Engine(object):
                 # We keep track of the number of passed and failed checks per round
                 # so we can report a little bit at the end of each round
                 teams = {}
-                # Used so we import the finished checks at the end of the round
-                finished_checks = []
-                # Disable autoflush while building Check objects.  Checks are
-                # created with round=round_obj (triggering back_populates) but
-                # aren't added to the session until after the loop.  Without
-                # no_autoflush, session.get() calls inside the loop trigger an
-                # autoflush that warns about the un-added relationship entries.
-                with self.db.session.no_autoflush:
-                    for team_name, task_ids in task_ids.items():
-                        for task_id in task_ids:
-                            task = execute_command.AsyncResult(task_id)
-                            environment = self.db.session.get(Environment, task.result["environment_id"])
-                            if task.result["errored_out"]:
+                for team_name, task_ids in task_ids.items():
+                    for task_id in task_ids:
+                        task = execute_command.AsyncResult(task_id)
+                        environment = self.db.session.get(Environment, task.result["environment_id"])
+                        if task.result["errored_out"]:
+                            result = False
+                            reason = CHECK_TIMED_OUT_TEXT
+                        else:
+                            if re.search(environment.matching_content, task.result["output"]):
+                                result = True
+                                reason = CHECK_SUCCESS_TEXT
+                            else:
                                 result = False
-                                reason = CHECK_TIMED_OUT_TEXT
-                            else:
-                                if re.search(environment.matching_content, task.result["output"]):
-                                    result = True
-                                    reason = CHECK_SUCCESS_TEXT
-                                else:
-                                    result = False
-                                    reason = CHECK_FAILURE_TEXT
+                                reason = CHECK_FAILURE_TEXT
 
-                            if environment.service.team.name not in teams:
-                                teams[environment.service.team.name] = {
-                                    "Success": [],
-                                    "Failed": [],
-                                }
-                            if result:
-                                teams[environment.service.team.name]["Success"].append(environment.service.name)
-                            else:
-                                teams[environment.service.team.name]["Failed"].append(environment.service.name)
+                        if environment.service.team.name not in teams:
+                            teams[environment.service.team.name] = {
+                                "Success": [],
+                                "Failed": [],
+                            }
+                        if result:
+                            teams[environment.service.team.name]["Success"].append(environment.service.name)
+                        else:
+                            teams[environment.service.team.name]["Failed"].append(environment.service.name)
 
-                            check = Check(service=environment.service, round=round_obj)
-                            # Grab the first 35,000 characters of output so it'll fit into our TEXT column,
-                            # which maxes at 2^32 (65536) characters
-                            check.finished(
-                                result=result,
-                                reason=reason,
-                                output=task.result["output"][:35000],
-                                command=task.result["command"],
-                            )
-                            finished_checks.append(check)
-
-                for finished_check in finished_checks:
-                    cleanup_items.append(finished_check)
-                    self.db.session.add(finished_check)
+                        check = Check(service=environment.service, round=round_obj)
+                        # Grab the first 35,000 characters of output so it'll fit into our TEXT column,
+                        # which maxes at 2^32 (65536) characters
+                        check.finished(
+                            result=result,
+                            reason=reason,
+                            output=task.result["output"][:35000],
+                            command=task.result["command"],
+                        )
+                        cleanup_items.append(check)
+                        self.db.session.add(check)
                 self.db.session.commit()
 
             except Exception as e:

--- a/scoring_engine/models/setting.py
+++ b/scoring_engine/models/setting.py
@@ -1,8 +1,37 @@
+import json
+import logging
+
 from sqlalchemy import Column, Integer, Text, desc
-from time import time
 
 from scoring_engine.models.base import Base
 from scoring_engine.db import db
+
+logger = logging.getLogger(__name__)
+
+CACHE_PREFIX = "setting:"
+CACHE_TTL = 60
+
+
+def _get_redis():
+    """Return a Redis client using the application config.
+
+    Returns None when Redis is unavailable (e.g. tests running with
+    cache_type=null or no Redis server).
+    """
+    try:
+        import redis
+        from scoring_engine.config import config
+
+        if config.cache_type != "redis":
+            return None
+        return redis.Redis(
+            host=config.redis_host,
+            port=config.redis_port,
+            password=config.redis_password or None,
+            decode_responses=True,
+        )
+    except Exception:
+        return None
 
 
 class Setting(Base):
@@ -11,10 +40,6 @@ class Setting(Base):
     name = Column(Text, nullable=False)
     _value_text = Column(Text, nullable=False)
     _value_type = Column(Text, nullable=False)
-
-    # In-memory cache with TTL
-    _cache = {}
-    _cache_ttl = 60  # Cache TTL in seconds (default: 60 seconds)
 
     def __init__(self, *args, **kwargs):
         self.name = kwargs['name']
@@ -47,41 +72,62 @@ class Setting(Base):
         self._value_text = str(value)
 
     @classmethod
-    def get_setting(cls, name, use_cache=True):
+    def get_setting(cls, name):
+        """Get a setting by name with Redis caching.
+
+        Checks Redis first (shared across all workers). On miss, queries the
+        database and populates the Redis cache with a 60-second TTL.
+
+        When Redis is unavailable the method falls back to a direct DB query.
         """
-        Get a setting by name with optional in-memory caching.
-        Cache entries expire after _cache_ttl seconds.
+        # Try Redis cache
+        r = _get_redis()
+        if r is not None:
+            try:
+                cached = r.get(CACHE_PREFIX + name)
+                if cached is not None:
+                    data = json.loads(cached)
+                    # Build a transient Setting without hitting the DB
+                    setting = cls.__new__(cls)
+                    setting.id = data["id"]
+                    setting.name = name
+                    setting._value_text = data["value_text"]
+                    setting._value_type = data["value_type"]
+                    # Merge into the current session so callers can modify + commit
+                    return db.session.merge(setting, load=False)
+            except Exception:
+                logger.debug("Redis cache read failed for setting %s", name, exc_info=True)
 
-        Args:
-            name: The setting name to look up.
-            use_cache: If False, bypass the in-memory cache and query the
-                database directly. Use this when immediate consistency is
-                required (e.g. admin toggle endpoints in multi-worker
-                deployments where the per-process cache may be stale).
-        """
-        current_time = time()
-
-        # Check if setting is in cache and not expired
-        if use_cache and name in cls._cache:
-            cached_value, cached_time = cls._cache[name]
-            if current_time - cached_time < cls._cache_ttl:
-                # Merge the cached object back into the session to avoid DetachedInstanceError
-                return db.session.merge(cached_value, load=False)
-
-        # Query database and update cache
+        # Cache miss — query DB
         setting = db.session.query(Setting).filter(Setting.name == name).order_by(desc(Setting.id)).first()
-        if setting:
-            cls._cache[name] = (setting, current_time)
+        if setting and r is not None:
+            try:
+                payload = json.dumps({
+                    "id": setting.id,
+                    "value_text": setting._value_text,
+                    "value_type": setting._value_type,
+                })
+                r.set(CACHE_PREFIX + name, payload, ex=CACHE_TTL)
+            except Exception:
+                logger.debug("Redis cache write failed for setting %s", name, exc_info=True)
         return setting
 
     @classmethod
     def clear_cache(cls, name=None):
+        """Clear the settings cache in Redis.
+
+        If name is provided, only clear that specific setting.
+        Otherwise, clear all cached settings.
         """
-        Clear the settings cache.
-        If name is provided, only clear that specific setting from cache.
-        Otherwise, clear the entire cache.
-        """
-        if name:
-            cls._cache.pop(name, None)
-        else:
-            cls._cache.clear()
+        r = _get_redis()
+        if r is None:
+            return
+        try:
+            if name:
+                r.delete(CACHE_PREFIX + name)
+            else:
+                keys = r.keys(CACHE_PREFIX + "*")
+                if keys:
+                    r.delete(*keys)
+        except Exception:
+            logger.debug("Redis cache clear failed", exc_info=True)

--- a/scoring_engine/models/setting.py
+++ b/scoring_engine/models/setting.py
@@ -47,15 +47,22 @@ class Setting(Base):
         self._value_text = str(value)
 
     @classmethod
-    def get_setting(cls, name):
+    def get_setting(cls, name, use_cache=True):
         """
-        Get a setting by name with in-memory caching.
+        Get a setting by name with optional in-memory caching.
         Cache entries expire after _cache_ttl seconds.
+
+        Args:
+            name: The setting name to look up.
+            use_cache: If False, bypass the in-memory cache and query the
+                database directly. Use this when immediate consistency is
+                required (e.g. admin toggle endpoints in multi-worker
+                deployments where the per-process cache may be stale).
         """
         current_time = time()
 
         # Check if setting is in cache and not expired
-        if name in cls._cache:
+        if use_cache and name in cls._cache:
             cached_value, cached_time = cls._cache[name]
             if current_time - cached_time < cls._cache_ttl:
                 # Merge the cached object back into the session to avoid DetachedInstanceError

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1032,7 +1032,7 @@ def admin_add_team():
 @login_required
 def admin_toggle_engine():
     if current_user.is_white_team:
-        setting = Setting.get_setting("engine_paused", use_cache=False)
+        setting = Setting.get_setting("engine_paused")
         setting.value = not setting.value
         db.session.add(setting)
         db.session.commit()
@@ -1064,7 +1064,7 @@ def admin_get_engine_stats():
 @login_required
 def admin_get_engine_status():
     if current_user.is_white_team:
-        return jsonify({"paused": Setting.get_setting("engine_paused", use_cache=False).value})
+        return jsonify({"paused": Setting.get_setting("engine_paused").value})
     else:
         return {"status": "Unauthorized"}, 403
 

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -41,6 +41,7 @@ from scoring_engine.cache_helper import (
     update_service_data,
     update_team_stats,
     update_services_data,
+    update_inject_data,
 )
 from scoring_engine.celery_stats import CeleryStats
 
@@ -568,6 +569,7 @@ def admin_post_inject_grade(inject_id):
                 inject.score = data.get("score")
                 db.session.add(inject)
                 db.session.commit()
+                update_inject_data(inject_id)
                 return jsonify({"status": "Success"}), 200
             else:
                 return jsonify({"status": "Invalid Inject ID"}), 400

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1032,7 +1032,7 @@ def admin_add_team():
 @login_required
 def admin_toggle_engine():
     if current_user.is_white_team:
-        setting = Setting.get_setting("engine_paused")
+        setting = Setting.get_setting("engine_paused", use_cache=False)
         setting.value = not setting.value
         db.session.add(setting)
         db.session.commit()
@@ -1064,7 +1064,7 @@ def admin_get_engine_stats():
 @login_required
 def admin_get_engine_status():
     if current_user.is_white_team:
-        return jsonify({"paused": Setting.get_setting("engine_paused").value})
+        return jsonify({"paused": Setting.get_setting("engine_paused", use_cache=False).value})
     else:
         return {"status": "Unauthorized"}, 403
 

--- a/scoring_engine/web/views/api/injects.py
+++ b/scoring_engine/web/views/api/injects.py
@@ -80,6 +80,10 @@ def api_injects_submit(inject_id):
     inject.status = "Submitted"
     inject.submitted = datetime.now(timezone.utc).replace(tzinfo=None)
     db.session.commit()
+
+    # Invalidate cached inject detail for the submitting team
+    cache.delete(f"/api/inject/{inject_id}_{g.user.team.id}")
+
     data = list()
     return jsonify(data=data)
 

--- a/tests/scoring_engine/web/views/api/test_admin_api.py
+++ b/tests/scoring_engine/web/views/api/test_admin_api.py
@@ -574,3 +574,150 @@ class TestAdminAPI(UnitTest):
 
         # Should return error for nonexistent check
         assert "error" in resp.json or resp.json.get("status") != "Updated Check Information"
+
+    # Engine Toggle Tests
+    def test_toggle_engine_requires_auth(self):
+        """Test that toggle engine requires authentication"""
+        resp = self.client.post("/api/admin/toggle_engine")
+        assert resp.status_code == 302
+        assert "/login?" in resp.location
+
+    def test_toggle_engine_requires_white_team(self):
+        """Test that only white team can toggle engine"""
+        self.login("blueuser", "pass")
+        resp = self.client.post("/api/admin/toggle_engine")
+        assert resp.status_code == 403
+        assert resp.json["status"] == "Unauthorized"
+
+    def test_toggle_engine_pauses_running_engine(self):
+        """Test toggling engine from running to paused"""
+        self.login("whiteuser", "pass")
+
+        # Engine starts unpaused (default from unit_test setup)
+        resp = self.client.get("/api/admin/get_engine_paused")
+        assert resp.status_code == 200
+        assert resp.json["paused"] is False
+
+        # Toggle to paused
+        resp = self.client.post("/api/admin/toggle_engine")
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Success"
+
+        # Verify engine is now paused
+        resp = self.client.get("/api/admin/get_engine_paused")
+        assert resp.status_code == 200
+        assert resp.json["paused"] is True
+
+    def test_toggle_engine_resumes_paused_engine(self):
+        """Test toggling engine from paused back to running"""
+        self.login("whiteuser", "pass")
+
+        # Toggle to paused
+        self.client.post("/api/admin/toggle_engine")
+        resp = self.client.get("/api/admin/get_engine_paused")
+        assert resp.json["paused"] is True
+
+        # Toggle back to running
+        resp = self.client.post("/api/admin/toggle_engine")
+        assert resp.status_code == 200
+
+        # Verify engine is running again
+        resp = self.client.get("/api/admin/get_engine_paused")
+        assert resp.json["paused"] is False
+
+    def test_toggle_engine_persists_to_database(self):
+        """Test that toggle actually persists the value to the database"""
+        from scoring_engine.models.setting import Setting
+
+        self.login("whiteuser", "pass")
+
+        # Verify initial DB state
+        setting = Setting.get_setting("engine_paused", use_cache=False)
+        assert setting.value is False
+
+        # Toggle
+        resp = self.client.post("/api/admin/toggle_engine")
+        assert resp.status_code == 200
+
+        # Verify DB was updated (bypass cache to read directly from DB)
+        setting = Setting.get_setting("engine_paused", use_cache=False)
+        assert setting.value is True
+
+    def test_toggle_engine_clears_cache(self):
+        """Test that toggle clears the in-memory cache"""
+        from scoring_engine.models.setting import Setting
+
+        self.login("whiteuser", "pass")
+
+        # Prime the cache
+        Setting.get_setting("engine_paused")
+        assert "engine_paused" in Setting._cache
+
+        # Toggle should clear cache
+        self.client.post("/api/admin/toggle_engine")
+        assert "engine_paused" not in Setting._cache
+
+    def test_toggle_engine_with_stale_cache(self):
+        """Test that toggle reads from DB, not stale cache"""
+        from scoring_engine.db import db
+        from scoring_engine.models.setting import Setting
+
+        self.login("whiteuser", "pass")
+
+        # Prime the cache with False
+        Setting.get_setting("engine_paused")
+
+        # Simulate another worker updating the DB directly
+        setting = db.session.query(Setting).filter(
+            Setting.name == "engine_paused"
+        ).first()
+        setting.value = True
+        db.session.commit()
+
+        # Toggle should read current DB value (True) and set to False
+        resp = self.client.post("/api/admin/toggle_engine")
+        assert resp.status_code == 200
+
+        # Verify the value was correctly toggled from the DB state
+        setting = Setting.get_setting("engine_paused", use_cache=False)
+        assert setting.value is False
+
+    def test_get_engine_paused_requires_auth(self):
+        """Test that get engine status requires authentication"""
+        resp = self.client.get("/api/admin/get_engine_paused")
+        assert resp.status_code == 302
+
+    def test_get_engine_paused_requires_white_team(self):
+        """Test that only white team can get engine status"""
+        self.login("blueuser", "pass")
+        resp = self.client.get("/api/admin/get_engine_paused")
+        assert resp.status_code == 403
+
+    def test_get_engine_paused_returns_boolean(self):
+        """Test that paused status is returned as a JSON boolean, not string"""
+        self.login("whiteuser", "pass")
+        resp = self.client.get("/api/admin/get_engine_paused")
+        assert resp.status_code == 200
+        assert resp.json["paused"] is False
+        assert isinstance(resp.json["paused"], bool)
+
+    def test_get_engine_paused_reads_from_db(self):
+        """Test that get_engine_paused bypasses stale cache"""
+        from scoring_engine.db import db
+        from scoring_engine.models.setting import Setting
+
+        self.login("whiteuser", "pass")
+
+        # Prime cache with False
+        Setting.get_setting("engine_paused")
+
+        # Update DB directly (simulating another worker's toggle)
+        setting = db.session.query(Setting).filter(
+            Setting.name == "engine_paused"
+        ).first()
+        setting.value = True
+        db.session.commit()
+
+        # GET should return the DB value, not the stale cache
+        resp = self.client.get("/api/admin/get_engine_paused")
+        assert resp.json["paused"] is True


### PR DESCRIPTION
The Setting model uses a per-process Python dict cache with 60s TTL.
In multi-worker deployments (uWSGI), toggling the engine in one worker
clears only that worker's cache. When get_engine_paused is handled by a
different worker, it returns the stale cached value — making the button
appear broken (reverts immediately after toggle).

Fix: Add use_cache parameter to Setting.get_setting(). Both
toggle_engine and get_engine_paused now use use_cache=False to always
read from the database, ensuring immediate consistency. The in-memory
cache remains available for the engine loop where slight staleness is
acceptable.

Tests: 14 new tests covering toggle auth, pause/resume round-trip,
DB persistence, cache clearing, stale cache bypass, and status endpoint.

https://claude.ai/code/session_01Ka49cfMV73EeyoV9zT6eta