### PR TITLE
Add configurable secret_key for stable dev sessions

### DIFF
--- a/engine.conf.inc
+++ b/engine.conf.inc
@@ -16,6 +16,10 @@ upload_folder = /var/uploads
 
 debug = False
 
+# Secret key for Flask sessions. If empty, a random key is generated on each
+# startup (sessions won't survive restarts). Set a fixed value for development.
+secret_key =
+
 # SQLite
 db_uri = sqlite:////tmp/engine.db?check_same_thread=False
 # MySQL

--- a/scoring_engine/config_loader.py
+++ b/scoring_engine/config_loader.py
@@ -54,6 +54,10 @@ class ConfigLoader(object):
             "debug", self.parser["OPTIONS"]["debug"].lower() == "true", "bool"
         )
 
+        self.secret_key = self.parse_sources(
+            "secret_key", self.parser["OPTIONS"].get("secret_key", "")
+        )
+
         self.checks_location = self.parse_sources(
             "checks_location",
             self.parser["OPTIONS"]["checks_location"],

--- a/scoring_engine/web/__init__.py
+++ b/scoring_engine/web/__init__.py
@@ -9,15 +9,12 @@ from scoring_engine.config import config
 from scoring_engine.db import db
 
 
-SECRET_KEY = os.urandom(128)
-
-
 def create_app():
     app = Flask(__name__)
 
     app.config.update(DEBUG=config.debug)
     app.config.update(UPLOAD_FOLDER=config.upload_folder)
-    app.secret_key = SECRET_KEY
+    app.secret_key = config.secret_key if config.secret_key else os.urandom(128)
 
     # Configure Flask-SQLAlchemy
     app.config['SQLALCHEMY_DATABASE_URI'] = config.db_uri


### PR DESCRIPTION
## Summary
- `SECRET_KEY = os.urandom(128)` at module level regenerated on every server restart, invalidating all Flask sessions and CSRF tokens
- During development with the auto-reloader, any file change kills all active sessions — making it impossible to stay logged in while iterating on code
- The secret key is now configurable via `secret_key` in `engine.conf` or `SCORINGENGINE_SECRET_KEY` env var
- When unset/empty, falls back to `os.urandom(128)` (existing production behavior preserved)

## Test plan
- [ ] Verify `secret_key =` (empty) in config still generates random key on startup
- [ ] Verify setting `secret_key = some-fixed-value` keeps sessions alive across dev server reloads
- [ ] Verify `SCORINGENGINE_SECRET_KEY` env var overrides the config file value
- [ ] Verify existing tests pass (`make run-tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)