### PR TITLE
Add service-type check failure breakdown to stats page

### DIFF
--- a/scoring_engine/cache_helper.py
+++ b/scoring_engine/cache_helper.py
@@ -102,8 +102,14 @@ def update_inject_data(inject_id, team_id=None):
             cache.delete(key.decode("utf-8").removeprefix(cache.cache.key_prefix))
 
 
-# TODO - Break this into an API cache expiration
 def update_stats():
-    from scoring_engine.web.views.stats import home
-
-    cache.delete_memoized(home)
+    # Clear cached /api/stats responses (keyed per-team/role)
+    if not isinstance(cache.cache, NullCache):
+        for key in cache.cache._write_client.scan_iter(
+            match="*/api/stats_*"
+        ):
+            cache.delete(
+                key.decode("utf-8").removeprefix(
+                    cache.cache.key_prefix
+                )
+            )

--- a/scoring_engine/web/templates/stats.html
+++ b/scoring_engine/web/templates/stats.html
@@ -9,6 +9,23 @@
 {% block content %}
 <div class="container-fluid md-page">
     <div class="row">
+        <h2 class="text-center">All-Time Service Statistics</h2>
+    </div>
+    <div class="row">
+        <table id="service-summary" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+            <thead>
+                <tr>
+                    <th>Service</th>
+                    <th>Up</th>
+                    <th>Down</th>
+                    <th>Total</th>
+                    <th>Uptime %</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <div class="row">
         <h2 class="text-center">Round Stats</h2>
     </div>
     <div class="row">
@@ -20,28 +37,54 @@
                     <th>End Time</th>
                     <th>Duration (Seconds)</th>
                     <th>Service Ratio</th>
+                    <th>Failures by Service</th>
                 </tr>
             </thead>
+            <tbody></tbody>
         </table>
     </div>
 </div>
 <script>
-    $('#stats').DataTable( {
-        ajax: '/api/stats',
-        order: [[0, 'desc']],
-        columns: [
-            { data: 'round_id' },
-            { data: 'start_time' },
-            { data: 'end_time' },
-            { data: 'total_seconds' },
-        ],
-        "columnDefs": [{
-            "targets": 4,
-            "data": null,
-            "render": function ( data, type, row, meta ) {
-                return row.num_up_services + ' <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> / ' + row.num_down_services + ' <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>';
-            }
-        }]
-    } );
+    $.ajax({
+        url: '/api/stats',
+        dataType: 'json',
+        success: function(response) {
+            // Populate all-time summary table
+            var summaryRows = [];
+            var summary = response.summary || {};
+            $.each(summary, function(serviceName, counts) {
+                var pct = counts.total > 0 ? ((counts.up / counts.total) * 100).toFixed(1) : '0.0';
+                summaryRows.push([serviceName, counts.up, counts.down, counts.total, pct + '%']);
+            });
+            var summaryTable = $('#service-summary').DataTable({
+                data: summaryRows,
+                paging: false,
+                searching: false,
+                order: [[0, 'asc']]
+            });
+
+            // Populate per-round stats table
+            var roundRows = [];
+            var data = response.data || [];
+            $.each(data, function(i, row) {
+                var ratio = row.num_up_services + ' <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span> / ' + row.num_down_services + ' <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>';
+
+                var failures = [];
+                var breakdown = row.service_breakdown || {};
+                $.each(breakdown, function(svc, counts) {
+                    if (counts.down > 0) {
+                        failures.push('<span style="color:red;">' + svc + ' x' + counts.down + '</span>');
+                    }
+                });
+                var failureText = failures.length > 0 ? failures.join(', ') : '<span style="color:green;">All passing</span>';
+
+                roundRows.push([row.round_id, row.start_time, row.end_time, row.total_seconds, ratio, failureText]);
+            });
+            var roundTable = $('#stats').DataTable({
+                data: roundRows,
+                order: [[0, 'desc']]
+            });
+        }
+    });
 </script>
 {% endblock %}

--- a/scoring_engine/web/views/api/stats.py
+++ b/scoring_engine/web/views/api/stats.py
@@ -35,6 +35,116 @@ from scoring_engine.models.team import Team
 from . import make_cache_key, mod
 
 
+def _build_stats_query(team_id=None):
+    """Build the stats query with service-type breakdown.
+
+    Parameters
+    ----------
+    team_id : int, optional
+        If provided, filter checks to only this team's services.
+        If None, include all teams (white team view).
+
+    Returns
+    -------
+    list
+        Query results with columns: round_id, round_start, round_end,
+        service_name, num_successful_checks, num_unsuccessful_checks.
+    """
+    last_round = Round.get_last_round_num()
+    query = (
+        db.session.query(
+            Round.id.label("round_id"),
+            Round.round_start,
+            Round.round_end,
+            Service.name.label("service_name"),
+            func.sum(case((Check.result == True, 1), else_=0)).label(
+                "num_successful_checks"
+            ),
+            func.sum(case((Check.result == False, 1), else_=0)).label(
+                "num_unsuccessful_checks"
+            ),
+        )
+        .outerjoin(Check, Round.id == Check.round_id)
+        .join(Service, Check.service_id == Service.id)
+        .filter(Round.id <= last_round)
+    )
+
+    if team_id is not None:
+        query = query.filter(Service.team_id == team_id)
+
+    return (
+        query.group_by(
+            Round.id, Round.round_start, Round.round_end, Service.name
+        )
+        .order_by(Round.id.desc(), Service.name)
+        .all()
+    )
+
+
+def _build_response(rows):
+    """Aggregate query rows into per-round stats with service breakdown
+    and all-time summary.
+
+    Parameters
+    ----------
+    rows : list
+        Query results from _build_stats_query.
+
+    Returns
+    -------
+    dict
+        Response with 'data' (per-round) and 'summary' (all-time) keys.
+    """
+    tz = pytz.timezone(config.timezone)
+
+    # Group rows by round
+    rounds = {}
+    summary = defaultdict(lambda: {"up": 0, "down": 0, "total": 0})
+
+    for row in rows:
+        round_id = row[0]
+        round_start = row[1]
+        round_end = row[2]
+        service_name = row[3]
+        up = row[4]
+        down = row[5]
+
+        if round_id not in rounds:
+            rounds[round_id] = {
+                "round_id": round_id,
+                "start_time": _ensure_utc_aware(round_start)
+                .astimezone(tz)
+                .strftime("%Y-%m-%d %H:%M:%S %Z"),
+                "end_time": _ensure_utc_aware(round_end)
+                .astimezone(tz)
+                .strftime("%Y-%m-%d %H:%M:%S %Z"),
+                "total_seconds": (round_end - round_start).seconds,
+                "num_up_services": 0,
+                "num_down_services": 0,
+                "service_breakdown": {},
+            }
+
+        entry = rounds[round_id]
+        entry["num_up_services"] += up
+        entry["num_down_services"] += down
+        entry["service_breakdown"][service_name] = {
+            "up": up,
+            "down": down,
+        }
+
+        # Accumulate all-time summary
+        summary[service_name]["up"] += up
+        summary[service_name]["down"] += down
+        summary[service_name]["total"] += up + down
+
+    # Sort by round_id descending
+    stats = sorted(
+        rounds.values(), key=lambda r: r["round_id"], reverse=True
+    )
+
+    return {"data": stats, "summary": dict(summary)}
+
+
 @mod.route("/api/stats")
 @login_required
 @cache.cached(make_cache_key=make_cache_key)
@@ -48,89 +158,11 @@ def api_stats():
         return jsonify({"status": "Unauthorized"}), 403
 
     if current_user.is_blue_team:
-        stats = []
-        # TODO - There has to be a better way to subquery this...
-        last_round = Round.get_last_round_num()
-        res = (
-            db.session.query(
-                Round.id.label("round_id"),
-                Round.round_start,
-                Round.round_end,
-                func.sum(case((Check.result == True, 1), else_=0)).label(
-                    "num_successful_checks"
-                ),
-                func.sum(case((Check.result == False, 1), else_=0)).label(
-                    "num_unsuccessful_checks"
-                ),
-            )
-            .outerjoin(Check, Round.id == Check.round_id)
-            .join(
-                Service, Check.service_id == Service.id
-            )  # Ensure checks are linked to services
-            .filter(Round.id <= last_round)
-            .filter(Service.team_id == team.id)  # Limit results to the specified team
-            .group_by(Round.id, Round.round_start, Round.round_end)
-            .order_by(Round.id.desc())
-            .all()
-        )
-        for row in res:
-            stats.append(
-                {
-                    "round_id": row[0],
-                    "start_time": _ensure_utc_aware(row[1])
-                    .astimezone(pytz.timezone(config.timezone))
-                    .strftime("%Y-%m-%d %H:%M:%S %Z"),
-                    "end_time": _ensure_utc_aware(row[2])
-                    .astimezone(pytz.timezone(config.timezone))
-                    .strftime("%Y-%m-%d %H:%M:%S %Z"),
-                    "total_seconds": (row[2] - row[1]).seconds,
-                    "num_up_services": row[3],
-                    "num_down_services": row[4],
-                }
-            )
-        return jsonify(data=stats)
+        rows = _build_stats_query(team_id=team.id)
+        return jsonify(_build_response(rows))
 
     if current_user.is_white_team:
-        stats = []
-        # TODO - There's probably a better way to do this.
-        # db.session.query(Round.id, func.count(Check.result)).join(Check).join(Service).filter(Check.result.is_(False)).group_by(Round.id).all()
-        last_round = Round.get_last_round_num()
-        res = (
-            db.session.query(
-                Round.id.label("round_id"),
-                Round.round_start,
-                Round.round_end,
-                func.sum(case((Check.result == True, 1), else_=0)).label(
-                    "num_successful_checks"
-                ),
-                func.sum(case((Check.result == False, 1), else_=0)).label(
-                    "num_unsuccessful_checks"
-                ),
-            )
-            .outerjoin(
-                Check, Round.id == Check.round_id
-            )  # Include all rounds even if no checks are present
-            .filter(Round.id <= last_round)
-            .group_by(Round.id, Round.round_start, Round.round_end)
-            .order_by(desc(Round.id))
-            .all()
-        )
-
-        for row in res:
-            stats.append(
-                {
-                    "round_id": row[0],
-                    "start_time": _ensure_utc_aware(row[1])
-                    .astimezone(pytz.timezone(config.timezone))
-                    .strftime("%Y-%m-%d %H:%M:%S %Z"),
-                    "end_time": _ensure_utc_aware(row[2])
-                    .astimezone(pytz.timezone(config.timezone))
-                    .strftime("%Y-%m-%d %H:%M:%S %Z"),
-                    "total_seconds": (row[2] - row[1]).seconds,
-                    "num_up_services": row[3],
-                    "num_down_services": row[4],
-                }
-            )
-        return jsonify(data=stats)
+        rows = _build_stats_query(team_id=None)
+        return jsonify(_build_response(rows))
 
     return {"status": "Unauthorized"}, 403

--- a/tests/scoring_engine/web/views/api/test_stats_api.py
+++ b/tests/scoring_engine/web/views/api/test_stats_api.py
@@ -1,0 +1,308 @@
+"""Tests for Stats API endpoint"""
+from datetime import datetime, timedelta, timezone
+
+from scoring_engine.models.check import Check
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+from tests.scoring_engine.unit_test import UnitTest
+
+
+class TestStatsAPI(UnitTest):
+    def setup_method(self):
+        super(TestStatsAPI, self).setup_method()
+        self.app.config["WTF_CSRF_ENABLED"] = False
+        self.client = self.app.test_client()
+
+        # Create teams
+        self.white_team = Team(name="White Team", color="White")
+        self.blue_team = Team(name="Blue Team", color="Blue")
+        self.blue_team2 = Team(name="Blue Team 2", color="Blue")
+        self.red_team = Team(name="Red Team", color="Red")
+        self.session.add_all(
+            [
+                self.white_team,
+                self.blue_team,
+                self.blue_team2,
+                self.red_team,
+            ]
+        )
+        self.session.commit()
+
+        # Create users
+        self.white_user = User(
+            username="whiteuser",
+            password="pass",
+            team=self.white_team,
+        )
+        self.blue_user = User(
+            username="blueuser",
+            password="pass",
+            team=self.blue_team,
+        )
+        self.blue_user2 = User(
+            username="blueuser2",
+            password="pass",
+            team=self.blue_team2,
+        )
+        self.red_user = User(
+            username="reduser",
+            password="pass",
+            team=self.red_team,
+        )
+        self.session.add_all(
+            [
+                self.white_user,
+                self.blue_user,
+                self.blue_user2,
+                self.red_user,
+            ]
+        )
+        self.session.commit()
+
+    def login(self, username, password):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def logout(self):
+        return self.client.get(
+            "/logout", follow_redirects=True
+        )
+
+    def _create_round_with_checks(
+        self, round_number, services, results
+    ):
+        """Helper to create a round with checks for given services.
+
+        Parameters
+        ----------
+        round_number : int
+        services : list of Service
+        results : list of bool, one per service
+        """
+        now = datetime.now(timezone.utc)
+        round_obj = Round(
+            number=round_number,
+            round_start=now - timedelta(seconds=60),
+            round_end=now,
+        )
+        self.session.add(round_obj)
+        self.session.flush()
+        for svc, result in zip(services, results):
+            check = Check(
+                service=svc,
+                round=round_obj,
+                result=result,
+                output="",
+            )
+            self.session.add(check)
+        self.session.commit()
+        return round_obj
+
+    # --- Auth / Authorization Tests ---
+
+    def test_stats_api_requires_auth(self):
+        """Unauthenticated request returns 302 redirect to login"""
+        resp = self.client.get("/api/stats")
+        assert resp.status_code == 302
+        assert "/login?" in resp.location
+
+    def test_stats_api_red_team_unauthorized(self):
+        """Red team gets 403"""
+        self.login("reduser", "pass")
+        resp = self.client.get("/api/stats")
+        assert resp.status_code == 403
+        assert resp.json["status"] == "Unauthorized"
+
+    # --- Response Structure Tests ---
+
+    def test_stats_api_blue_team_response_structure(self):
+        """Blue team response has data and summary keys
+        with service_breakdown"""
+        svc = Service(
+            name="SSH",
+            check_name="SSH Check",
+            host="10.0.0.1",
+            team=self.blue_team,
+        )
+        self.session.add(svc)
+        self.session.commit()
+        self._create_round_with_checks(1, [svc], [True])
+
+        self.login("blueuser", "pass")
+        resp = self.client.get("/api/stats")
+        assert resp.status_code == 200
+
+        data = resp.json
+        assert "data" in data
+        assert "summary" in data
+        assert len(data["data"]) == 1
+
+        round_entry = data["data"][0]
+        assert "round_id" in round_entry
+        assert "start_time" in round_entry
+        assert "end_time" in round_entry
+        assert "total_seconds" in round_entry
+        assert "num_up_services" in round_entry
+        assert "num_down_services" in round_entry
+        assert "service_breakdown" in round_entry
+        assert "SSH" in round_entry["service_breakdown"]
+
+    # --- Filtering Tests ---
+
+    def test_stats_api_blue_team_sees_own_services(self):
+        """Blue team only sees their own team's services"""
+        svc1 = Service(
+            name="SSH",
+            check_name="SSH Check",
+            host="10.0.0.1",
+            team=self.blue_team,
+        )
+        svc2 = Service(
+            name="DNS",
+            check_name="DNS Check",
+            host="10.0.0.2",
+            team=self.blue_team2,
+        )
+        self.session.add_all([svc1, svc2])
+        self.session.commit()
+        self._create_round_with_checks(
+            1, [svc1, svc2], [True, False]
+        )
+
+        self.login("blueuser", "pass")
+        resp = self.client.get("/api/stats")
+        data = resp.json
+
+        # Blue team 1 should only see SSH
+        assert "SSH" in data["summary"]
+        assert "DNS" not in data["summary"]
+        assert (
+            data["data"][0]["service_breakdown"].get("DNS")
+            is None
+        )
+
+    def test_stats_api_white_team_sees_all(self):
+        """White team sees all teams' services"""
+        svc1 = Service(
+            name="SSH",
+            check_name="SSH Check",
+            host="10.0.0.1",
+            team=self.blue_team,
+        )
+        svc2 = Service(
+            name="DNS",
+            check_name="DNS Check",
+            host="10.0.0.2",
+            team=self.blue_team2,
+        )
+        self.session.add_all([svc1, svc2])
+        self.session.commit()
+        self._create_round_with_checks(
+            1, [svc1, svc2], [True, False]
+        )
+
+        self.login("whiteuser", "pass")
+        resp = self.client.get("/api/stats")
+        data = resp.json
+
+        assert "SSH" in data["summary"]
+        assert "DNS" in data["summary"]
+
+    # --- Per-Round Breakdown Tests ---
+
+    def test_stats_api_per_round_breakdown(self):
+        """Verify correct up/down counts per service per round"""
+        svc_ssh = Service(
+            name="SSH",
+            check_name="SSH Check",
+            host="10.0.0.1",
+            team=self.blue_team,
+        )
+        svc_dns = Service(
+            name="DNS",
+            check_name="DNS Check",
+            host="10.0.0.2",
+            team=self.blue_team,
+        )
+        self.session.add_all([svc_ssh, svc_dns])
+        self.session.commit()
+
+        # Round 1: SSH up, DNS down
+        self._create_round_with_checks(
+            1, [svc_ssh, svc_dns], [True, False]
+        )
+        # Round 2: SSH down, DNS up
+        self._create_round_with_checks(
+            2, [svc_ssh, svc_dns], [False, True]
+        )
+
+        self.login("blueuser", "pass")
+        resp = self.client.get("/api/stats")
+        data = resp.json
+
+        # data is sorted descending by round_id
+        round2 = data["data"][0]
+        round1 = data["data"][1]
+
+        assert round1["round_id"] < round2["round_id"]
+
+        assert round1["service_breakdown"]["SSH"] == {
+            "up": 1,
+            "down": 0,
+        }
+        assert round1["service_breakdown"]["DNS"] == {
+            "up": 0,
+            "down": 1,
+        }
+
+        assert round2["service_breakdown"]["SSH"] == {
+            "up": 0,
+            "down": 1,
+        }
+        assert round2["service_breakdown"]["DNS"] == {
+            "up": 1,
+            "down": 0,
+        }
+
+    # --- Summary Totals Test ---
+
+    def test_stats_api_summary_totals(self):
+        """Verify all-time aggregation in summary"""
+        svc = Service(
+            name="HTTP",
+            check_name="HTTP Check",
+            host="10.0.0.1",
+            team=self.blue_team,
+        )
+        self.session.add(svc)
+        self.session.commit()
+
+        # 3 rounds: pass, fail, pass
+        self._create_round_with_checks(1, [svc], [True])
+        self._create_round_with_checks(2, [svc], [False])
+        self._create_round_with_checks(3, [svc], [True])
+
+        self.login("blueuser", "pass")
+        resp = self.client.get("/api/stats")
+        data = resp.json
+
+        assert data["summary"]["HTTP"]["up"] == 2
+        assert data["summary"]["HTTP"]["down"] == 1
+        assert data["summary"]["HTTP"]["total"] == 3
+
+    # --- Empty State Test ---
+
+    def test_stats_api_no_rounds(self):
+        """Empty data and summary when no rounds exist"""
+        self.login("blueuser", "pass")
+        resp = self.client.get("/api/stats")
+        assert resp.status_code == 200
+
+        data = resp.json
+        assert data["data"] == []
+        assert data["summary"] == {}


### PR DESCRIPTION
## Summary
- Enriches `/api/stats` to include per-round `service_breakdown` (e.g., `{"SSH": {"up": 3, "down": 1}}`) and an all-time `summary` with up/down/total per service type
- Adds "All-Time Service Statistics" table (Service, Up, Down, Total, Uptime %) and "Failures by Service" column to the round stats table on the stats page
- Fixes `update_stats()` in `cache_helper.py` to properly invalidate API cache keys using `scan_iter` pattern matching instead of the broken `delete_memoized(home)` call
- DRYs the blue/white team query branches into shared `_build_stats_query()` and `_build_response()` helpers

## Test plan
- [x] 8 new tests in `test_stats_api.py` covering auth, authorization, response structure, team filtering, per-round breakdown, summary totals, and empty state
- [ ] Manual: login as Blue team → stats page shows only own services
- [ ] Manual: login as White team → stats page shows all teams' services
- [ ] Verify backward compat: existing `num_up_services`/`num_down_services` keys still present in per-round data

🤖 Generated with [Claude Code](https://claude.com/claude-code)