### PR TITLE
Add subprocess timeout to kill hung check processes

### DIFF
--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -165,6 +165,11 @@ class Engine(object):
             logger.info("Running engine for {0} round(s)".format(self.total_rounds))
 
         while not self.is_last_round():
+            # End any stale transaction so MySQL REPEATABLE READ gets a
+            # fresh snapshot.  Without this, the pause loop would hold an
+            # open transaction and never see the updated engine_paused value.
+            self.db.session.rollback()
+
             if Setting.get_setting("engine_paused").value:
                 pause_duration = int(Setting.get_setting("pause_duration").value)
                 logger.info("Engine Paused. Sleeping for {0} seconds".format(pause_duration))

--- a/scoring_engine/engine/execute_command.py
+++ b/scoring_engine/engine/execute_command.py
@@ -17,10 +17,15 @@ def execute_command(job):
             job['command'],
             shell=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT
+            stderr=subprocess.STDOUT,
+            timeout=30,
         )
         output = cmd_result.stdout.decode("utf-8")
         job['errored_out'] = False
+    except subprocess.TimeoutExpired as e:
+        job['errored_out'] = True
+        if e.output:
+            output = e.output.decode("utf-8", errors="replace")
     except SoftTimeLimitExceeded:
         job['errored_out'] = True
     job['output'] = output

--- a/scoring_engine/models/setting.py
+++ b/scoring_engine/models/setting.py
@@ -99,12 +99,6 @@ class Setting(Base):
                 logger.debug("Redis cache read failed for setting %s", name, exc_info=True)
 
         # Cache miss — query DB.
-        # Roll back to end any stale transaction so the next query starts a
-        # fresh one.  This is critical in long-running processes (e.g. the
-        # engine loop) where MySQL REPEATABLE READ isolation would otherwise
-        # return a frozen snapshot and SQLAlchemy's identity map would return
-        # the previously-loaded object without refreshing its attributes.
-        db.session.rollback()
         setting = db.session.query(Setting).filter(Setting.name == name).order_by(desc(Setting.id)).first()
         if setting and r is not None:
             try:

--- a/scoring_engine/web/views/api/agent.py
+++ b/scoring_engine/web/views/api/agent.py
@@ -96,6 +96,7 @@ def agent_checkin_post():
             for flag in flags
         ]
         db.session.add_all(solves)
+        db.session.commit()
 
     result = do_checkin(team, host, platform)
     return make_response(crypter.dumps(result), 200, {'Content-Type': 'application/octet-stream'})

--- a/tests/scoring_engine/web/views/api/test_agent_api.py
+++ b/tests/scoring_engine/web/views/api/test_agent_api.py
@@ -1,0 +1,104 @@
+"""Tests for Agent API endpoints - verifies checkin persists solves to DB"""
+from datetime import datetime, timedelta, timezone
+
+from scoring_engine.models.flag import Flag, FlagTypeEnum, Perm, Platform, Solve
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.web import create_app
+from scoring_engine.web.views.api.agent import BtaPayloadEncryption
+from tests.scoring_engine.unit_test import UnitTest
+
+
+class TestAgentCheckinAPI(UnitTest):
+    def setup_method(self):
+        super(TestAgentCheckinAPI, self).setup_method()
+        self.app = create_app()
+        self.app.config["TESTING"] = True
+        self.client = self.app.test_client()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+        self.psk = "testpsk123"
+        self.session.add(Setting(name="agent_psk", value=self.psk))
+        self.session.add(Setting(name="agent_show_flag_early_mins", value="5"))
+        self.session.add(Setting(name="agent_checkin_interval_sec", value="60"))
+        self.session.commit()
+
+        self.blue_team = Team(name="Blue Team 1", color="Blue")
+        self.session.add(self.blue_team)
+        self.session.commit()
+
+    def teardown_method(self):
+        self.ctx.pop()
+        super(TestAgentCheckinAPI, self).teardown_method()
+
+    def _checkin(self, team_name, host, platform, flags=None):
+        crypter = BtaPayloadEncryption(self.psk, team_name)
+        payload = {
+            "team": team_name,
+            "host": host,
+            "plat": platform,
+        }
+        if flags is not None:
+            payload["flags"] = flags
+        return self.client.post(
+            f"/api/agent/checkin?t={team_name}",
+            data=crypter.dumps(payload),
+            content_type="application/octet-stream",
+        )
+
+    def test_checkin_persists_solves_to_database(self):
+        """Verify that flag solves submitted via agent checkin are committed to the DB."""
+        flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.windows,
+            perm=Perm.user,
+            data={"path": "C:\\flag.txt", "content": "flag{test}"},
+            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
+            dummy=False,
+        )
+        self.session.add(flag)
+        self.session.commit()
+
+        resp = self._checkin("Blue Team 1", "192.168.1.10", "win", flags=[flag.id])
+        assert resp.status_code == 200
+
+        solves = self.session.query(Solve).all()
+        assert len(solves) == 1
+        assert solves[0].flag_id == flag.id
+        assert solves[0].host == "192.168.1.10"
+        assert solves[0].team_id == self.blue_team.id
+
+    def test_checkin_without_flags_persists_nothing(self):
+        """Checkin with no flags should not create any solves."""
+        resp = self._checkin("Blue Team 1", "192.168.1.10", "win", flags=[])
+        assert resp.status_code == 200
+
+        solves = self.session.query(Solve).all()
+        assert len(solves) == 0
+
+    def test_checkin_ignores_dummy_flags(self):
+        """Dummy flags should be filtered out and not create solves."""
+        dummy_flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.windows,
+            perm=Perm.user,
+            data={"path": "C:\\dummy.txt", "content": "dummy"},
+            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
+            dummy=True,
+        )
+        self.session.add(dummy_flag)
+        self.session.commit()
+
+        resp = self._checkin("Blue Team 1", "192.168.1.10", "win", flags=[dummy_flag.id])
+        assert resp.status_code == 200
+
+        solves = self.session.query(Solve).all()
+        assert len(solves) == 0
+
+    def test_checkin_bad_team_returns_400(self):
+        """Non-existent team should return 400."""
+        resp = self._checkin("Nonexistent Team", "192.168.1.10", "win")
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- `subprocess.run` in `execute_command` had no `timeout`, so child processes (e.g. OpenVPN checks with hardcoded `time.sleep(10)`) could block well past Celery's `soft_time_limit=30` — the signal only interrupts the Python thread, not the spawned shell process
- Adds `timeout=30` to match the `soft_time_limit`, so the child process gets killed by the OS
- Captures partial stdout from timed-out checks via `TimeoutExpired.output` so failure output is visible instead of blank
- Timed-out checks are correctly recorded as failed with `CHECK_TIMED_OUT_TEXT`

Depends on #1121

## Test plan
- [x] All 22 engine tests pass
- [x] `test_timed_out` existing test still passes
- [x] Deploy to testbed and verify OpenVPN checks no longer cause 5 tasks to hang for 30s per round

🤖 Generated with [Claude Code](https://claude.com/claude-code)