### PR TITLE
Fix bcrypt 5.0 ValueError for passwords over 72 bytes

### DIFF
--- a/scoring_engine/models/user.py
+++ b/scoring_engine/models/user.py
@@ -51,10 +51,7 @@ class User(Base, UserMixin):
         return self.username
 
     def check_password(self, password):
-        # this is due to some weird bug between rusty and I
-        # where his env was returning a str, and mine were bytes
-        if isinstance(password, str):
-            password = password.encode("utf-8")
+        password = password.encode("utf-8")[:72]
         return bcrypt.checkpw(password, self.password.encode("utf-8"))
 
     def update_password(self, password):
@@ -68,10 +65,7 @@ class User(Base, UserMixin):
         elif isinstance(salt, str):
             salt = salt.encode("utf-8")
 
-        # this is due to some weird bug between rusty and I
-        # where his env was returning a str, and mine were bytes
-        if isinstance(password, str):
-            password = password.encode("utf-8")
+        password = password.encode("utf-8")[:72]
         return bcrypt.hashpw(password, salt).decode("utf-8")
 
     def get_id(self):

--- a/scoring_engine/web/views/api/profile.py
+++ b/scoring_engine/web/views/api/profile.py
@@ -18,6 +18,10 @@ def profile_update_password():
         if not current_user.check_password(request.form['currentpassword']):
             flash('Invalid Password.', 'danger')
             return redirect(url_for('profile.home'))
+        # Ensure new password is not too long for bcrypt
+        if len(request.form['password'].encode("utf-8")) > 72:
+            flash('Password must be 72 bytes or fewer.', 'danger')
+            return redirect(url_for('profile.home'))
         # Ensure new passwords match
         if request.form['password'] != request.form['confirmedpassword']:
             flash('Passwords do not match.', 'danger')

--- a/scoring_engine/web/views/auth.py
+++ b/scoring_engine/web/views/auth.py
@@ -68,6 +68,10 @@ def login():
         username = request.form.get("username")
         password = request.form.get("password")
 
+        if len(password.encode("utf-8")) > 72:
+            flash("Password must be 72 bytes or fewer.", "danger")
+            return render_template("login.html", form=form)
+
         try:
             user = db.session.query(User).filter(User.username == username).one()
         except NoResultFound:


### PR DESCRIPTION
## Summary
- Truncate passwords to 72 bytes before passing to bcrypt in `User.check_password` and `User.generate_hash` (safety net for bcrypt 5.0.0 which raises `ValueError` instead of silently truncating)
- Add password length validation on login and profile password change endpoints with user-facing flash message
- Remove stale Python 2/3 `isinstance` guards in user model

## Test plan
- [ ] Verify login works with normal-length passwords
- [ ] Verify login with a 73+ byte password shows flash error instead of 500
- [ ] Verify password change rejects passwords over 72 bytes
- [ ] Existing tests pass (`test_user.py`, `test_auth.py`, `test_profile.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)