### PR TITLE
Fix flag scoring calculation to be database-portable

### DIFF
--- a/scoring_engine/web/views/api/flags.py
+++ b/scoring_engine/web/views/api/flags.py
@@ -1,16 +1,16 @@
+from datetime import datetime, timedelta, timezone
+
 from flask import jsonify
 from flask_login import current_user, login_required
-from sqlalchemy import func, case
+from sqlalchemy import case, func
 from sqlalchemy.sql.expression import and_, or_
 
 from scoring_engine.cache import cache
 from scoring_engine.db import db
+from scoring_engine.models.flag import Flag, Perm, Platform, Solve
 from scoring_engine.models.service import Service
-from scoring_engine.models.team import Team
-from scoring_engine.models.flag import Flag, Solve
 from scoring_engine.models.setting import Setting
-
-from datetime import datetime, timedelta, timezone
+from scoring_engine.models.team import Team
 
 from . import make_cache_key, mod
 
@@ -27,7 +27,10 @@ def api_flags():
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     early = now + timedelta(minutes=int(Setting.get_setting("agent_show_flag_early_mins").value))
     flags = (
-        db.session.query(Flag).filter(and_(early > Flag.start_time, now < Flag.end_time, Flag.dummy == False)).order_by(Flag.start_time).all()
+        db.session.query(Flag)
+        .filter(and_(early > Flag.start_time, now < Flag.end_time, Flag.dummy == False))
+        .order_by(Flag.start_time)
+        .all()
     )
 
     # Serialize flags and include localized times
@@ -58,11 +61,38 @@ def api_flags_solves():
     # Get all flags and teams
     # Use naive UTC time for SQLAlchemy filter comparison (databases may not support timezones)
     now = datetime.now(timezone.utc).replace(tzinfo=None)
-    active_flags = db.session.query(Flag).filter(and_(now > Flag.start_time, now < Flag.end_time, Flag.dummy == False)).order_by(Flag.start_time).all()
+    active_flags = (
+        db.session.query(Flag)
+        .filter(and_(now > Flag.start_time, now < Flag.end_time, Flag.dummy == False))
+        .order_by(Flag.start_time)
+        .all()
+    )
     active_flag_ids = [flag.id for flag in active_flags]
 
     # Flag Solve Status
-    all_hosts = db.session.query(Service.name.label("service_name"), Service.port, Service.team_id, Service.host, Team.name.label("team_name"), func.coalesce(Solve.id, None).label("solve_id"), func.coalesce(Flag.id, None).label("flag_id"), func.coalesce(Flag.perm, None).label("flag_perm"), func.coalesce(Flag.platform, None).label("flag_platform")).select_from(Service).filter(Service.check_name == "AgentCheck").outerjoin(Solve, and_(Solve.host == Service.host, Solve.team_id == Service.team_id, Solve.flag_id.in_(active_flag_ids))).outerjoin(Flag, Flag.id == Solve.flag_id).outerjoin(Team, Team.id == Service.team_id).order_by(Service.name, Service.team_id).all()
+    all_hosts = (
+        db.session.query(
+            Service.name.label("service_name"),
+            Service.port,
+            Service.team_id,
+            Service.host,
+            Team.name.label("team_name"),
+            func.coalesce(Solve.id, None).label("solve_id"),
+            func.coalesce(Flag.id, None).label("flag_id"),
+            func.coalesce(Flag.perm, None).label("flag_perm"),
+            func.coalesce(Flag.platform, None).label("flag_platform"),
+        )
+        .select_from(Service)
+        .filter(Service.check_name == "AgentCheck")
+        .outerjoin(
+            Solve,
+            and_(Solve.host == Service.host, Solve.team_id == Service.team_id, Solve.flag_id.in_(active_flag_ids)),
+        )
+        .outerjoin(Flag, Flag.id == Solve.flag_id)
+        .outerjoin(Team, Team.id == Service.team_id)
+        .order_by(Service.name, Service.team_id)
+        .all()
+    )
 
     data = {}
     rows = []
@@ -89,6 +119,7 @@ def api_flags_solves():
 
     return jsonify(data={"columns": columns, "rows": rows})
 
+
 @mod.route("/api/flags/totals")
 @login_required
 @cache.cached(make_cache_key=make_cache_key)
@@ -96,52 +127,62 @@ def api_flags_totals():
     if not current_user.is_red_team and not current_user.is_white_team:
         return jsonify({"status": "Unauthorized"}), 403
 
-    # Initialize totals for all blue teams: {team_name: [team_name, win_score, nix_score]}
-    totals = {}
+    totals = {}  # [ Team0, Win Score, Nix Score ]
     blue_teams = db.session.query(Team).filter(Team.color == "Blue").order_by(Team.id).all()
-    team_id_to_name = {}
     for blue_team in blue_teams:
-        totals[blue_team.name] = [blue_team.name, 0.0, 0.0]
-        team_id_to_name[blue_team.id] = blue_team.name
+        totals[blue_team.name] = [blue_team.name, 0, 0]
 
-    # Fetch all solves with their flags in one query
-    solves = (
-        db.session.query(Solve.team_id, Solve.host, Flag.platform, Flag.perm)
-        .join(Flag, Flag.id == Solve.flag_id)
-        .all()
-    )
+    for platform_enum in [Platform.windows, Platform.nix]:
+        # Subquery 1: Determine permission level per (team, host, start_time)
+        # If root perm exists in the group, level is "root"; otherwise "user"
+        subquery1 = (
+            db.session.query(
+                Solve.team_id,
+                Solve.host,
+                case(
+                    (func.max(case((Flag.perm == Perm.root, 1), else_=0)) == 1, "root"),
+                    else_="user",
+                ).label("level"),
+            )
+            .join(Flag, Flag.id == Solve.flag_id)
+            .filter(Flag.platform == platform_enum)
+            .group_by(Solve.team_id, Flag.platform, Solve.host, Flag.start_time)
+            .subquery()
+        )
 
-    # Group solves by (team_id, host, platform) and track permission levels
-    # Key: (team_id, host, platform) -> set of perms ('user', 'root')
-    solve_perms = {}
-    for solve in solves:
-        key = (solve.team_id, solve.host, solve.platform.value if hasattr(solve.platform, 'value') else solve.platform)
-        if key not in solve_perms:
-            solve_perms[key] = set()
-        perm_value = solve.perm.value if hasattr(solve.perm, 'value') else solve.perm
-        solve_perms[key].add(perm_value)
+        # Subquery 2: Compute red_amt based on level
+        subquery2 = (
+            db.session.query(
+                (subquery1.c.team_id).label("BlueTeamId"),
+                case(
+                    (subquery1.c.level == "user", 0.5 * func.count()),
+                    else_=1 * func.count(),
+                ).label("red_amt"),
+            )
+            .group_by(subquery1.c.team_id, subquery1.c.level)
+            .order_by(subquery1.c.team_id, subquery1.c.level.desc())
+            .subquery()
+        )
 
-    # Calculate scores
-    # If both user and root: count as root (1 point)
-    # If only root: 1 point
-    # If only user: 0.5 points
-    for (team_id, host, platform), perms in solve_perms.items():
-        team_name = team_id_to_name.get(team_id)
-        if not team_name:
-            continue
+        # Final Query: Sum red_amt per BlueTeamId
+        final_query = (
+            db.session.query(
+                Team.name.label("BlueTeam"),
+                func.sum(subquery2.c.red_amt).label("RedScore"),
+            )
+            .join(Team, subquery2.c.BlueTeamId == Team.id)
+            .group_by(subquery2.c.BlueTeamId)
+            .order_by(func.sum(subquery2.c.red_amt))
+        )
 
-        if "root" in perms:
-            score = 1.0
-        elif "user" in perms:
-            score = 0.5
-        else:
-            score = 0.0
+        # Execute Query
+        results = final_query.all()
 
-        # Add to appropriate platform score
-        if platform == "win":
-            totals[team_name][1] += score
-        elif platform == "nix":
-            totals[team_name][2] += score
+        for row in results:
+            if platform_enum == Platform.windows:
+                totals[row.BlueTeam][1] = row.RedScore
+            elif platform_enum == Platform.nix:
+                totals[row.BlueTeam][2] = row.RedScore
 
     data = []
     for team in totals.values():

--- a/tests/scoring_engine/web/views/api/test_flags_api.py
+++ b/tests/scoring_engine/web/views/api/test_flags_api.py
@@ -1,7 +1,6 @@
 """Comprehensive tests for Flags API endpoints including complex SQL queries"""
-from datetime import datetime, timedelta, timezone
 
-import pytest
+from datetime import datetime, timedelta, timezone
 
 from scoring_engine.models.flag import Flag, FlagTypeEnum, Perm, Platform, Solve
 from scoring_engine.models.service import Service
@@ -108,21 +107,18 @@ class TestFlagsAPI(UnitTest):
         resp = self.client.get("/api/flags/totals")
         assert resp.status_code == 302
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_red_team_authorized(self):
         """Test that red team can access totals"""
         self.login("reduser", "pass")
         resp = self.client.get("/api/flags/totals")
         assert resp.status_code == 200
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_white_team_authorized(self):
         """Test that white team can access totals"""
         self.login("whiteuser", "pass")
         resp = self.client.get("/api/flags/totals")
         assert resp.status_code == 200
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_blue_team_unauthorized(self):
         """Test that blue team cannot access totals"""
         self.login("blueuser1", "pass")
@@ -140,7 +136,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/tmp/past", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=2),
             end_time=datetime.now(timezone.utc) - timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create current flag (should be shown)
@@ -151,7 +147,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/tmp/current", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(minutes=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create future flag (should be shown based on early window)
@@ -162,7 +158,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/tmp/future", "content": "test"},
             start_time=datetime.now(timezone.utc) + timedelta(minutes=2),
             end_time=datetime.now(timezone.utc) + timedelta(hours=2),
-            dummy=False
+            dummy=False,
         )
 
         self.session.add_all([past_flag, current_flag, future_flag])
@@ -188,7 +184,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/tmp/real", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create dummy flag
@@ -199,7 +195,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/tmp/dummy", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=True
+            dummy=True,
         )
 
         self.session.add_all([real_flag, dummy_flag])
@@ -223,7 +219,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create Linux flag
@@ -234,7 +230,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/etc/test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         self.session.add_all([win_flag, nix_flag])
@@ -258,7 +254,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create root-level flag
@@ -269,7 +265,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\admin", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         self.session.add_all([user_flag, root_flag])
@@ -287,20 +283,8 @@ class TestFlagsAPI(UnitTest):
     def test_api_flags_solves_with_no_solves(self):
         """Test that solves endpoint works with no solves"""
         # Create services
-        service1 = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
-        service2 = Service(
-            name="Host2",
-            check_name="AgentCheck",
-            host="192.168.1.20",
-            team=self.blue_team2,
-            port=0
-        )
+        service1 = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+        service2 = Service(name="Host2", check_name="AgentCheck", host="192.168.1.20", team=self.blue_team2, port=0)
 
         self.session.add_all([service1, service2])
         self.session.commit()
@@ -316,20 +300,8 @@ class TestFlagsAPI(UnitTest):
     def test_api_flags_solves_shows_solve_status(self):
         """Test that solve status is correctly shown"""
         # Create services
-        service1 = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
-        service2 = Service(
-            name="Host2",
-            check_name="AgentCheck",
-            host="192.168.1.20",
-            team=self.blue_team2,
-            port=0
-        )
+        service1 = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+        service2 = Service(name="Host2", check_name="AgentCheck", host="192.168.1.20", team=self.blue_team2, port=0)
 
         # Create flag
         flag = Flag(
@@ -339,18 +311,14 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         self.session.add_all([service1, service2, flag])
         self.session.flush()
 
         # Create solve for team1
-        solve = Solve(
-            host="192.168.1.10",
-            team_id=self.blue_team1.id,
-            flag_id=flag.id
-        )
+        solve = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=flag.id)
 
         self.session.add(solve)
         self.session.commit()
@@ -363,7 +331,6 @@ class TestFlagsAPI(UnitTest):
         assert len(data["rows"]) >= 1
 
     # Totals Tests (Complex SQL)
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_empty(self):
         """Test totals with no flags or solves"""
         self.login("reduser", "pass")
@@ -381,17 +348,10 @@ class TestFlagsAPI(UnitTest):
             assert entry["nix_score"] == 0
             assert entry["total_score"] == 0
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_user_level_scoring(self):
         """Test that user-level flags count as 0.5"""
         # Create service
-        service = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
+        service = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
 
         # Create Windows user flag
         flag = Flag(
@@ -401,17 +361,16 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
+
+        self.session.add_all([service, flag])
+        self.session.flush()
 
         # Create solve
-        solve = Solve(
-            host="192.168.1.10",
-            team_id=self.blue_team1.id,
-            flag_id=flag.id
-        )
+        solve = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=flag.id)
 
-        self.session.add_all([service, flag, solve])
+        self.session.add(solve)
         self.session.commit()
 
         self.login("reduser", "pass")
@@ -426,17 +385,10 @@ class TestFlagsAPI(UnitTest):
         assert team1_entry["nix_score"] == 0
         assert team1_entry["total_score"] == 0.5
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_root_level_scoring(self):
         """Test that root-level flags count as 1"""
         # Create service
-        service = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
+        service = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
 
         # Create Linux root flag
         flag = Flag(
@@ -446,17 +398,16 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/etc/test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
+
+        self.session.add_all([service, flag])
+        self.session.flush()
 
         # Create solve
-        solve = Solve(
-            host="192.168.1.10",
-            team_id=self.blue_team1.id,
-            flag_id=flag.id
-        )
+        solve = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=flag.id)
 
-        self.session.add_all([service, flag, solve])
+        self.session.add(solve)
         self.session.commit()
 
         self.login("reduser", "pass")
@@ -471,17 +422,14 @@ class TestFlagsAPI(UnitTest):
         assert team1_entry["win_score"] == 0
         assert team1_entry["total_score"] == 1
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_user_and_root_scoring(self):
-        """Test that user + root on same host counts as root (1.0)"""
+        """Test that user + root on same host in same round counts as root (1.0)"""
         # Create service
-        service = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
+        service = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+
+        # Both flags share the same start_time (same flag round)
+        round_start = datetime.now(timezone.utc) - timedelta(hours=1)
+        round_end = datetime.now(timezone.utc) + timedelta(hours=1)
 
         # Create Windows user flag
         user_flag = Flag(
@@ -489,9 +437,9 @@ class TestFlagsAPI(UnitTest):
             platform=Platform.windows,
             perm=Perm.user,
             data={"path": "C:\\user", "content": "test"},
-            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
-            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            start_time=round_start,
+            end_time=round_end,
+            dummy=False,
         )
 
         # Create Windows root flag
@@ -500,24 +448,19 @@ class TestFlagsAPI(UnitTest):
             platform=Platform.windows,
             perm=Perm.root,
             data={"path": "C:\\admin", "content": "test"},
-            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
-            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            start_time=round_start,
+            end_time=round_end,
+            dummy=False,
         )
+
+        self.session.add_all([service, user_flag, root_flag])
+        self.session.flush()
 
         # Create solves for both
-        solve_user = Solve(
-            host="192.168.1.10",
-            team_id=self.blue_team1.id,
-            flag_id=user_flag.id
-        )
-        solve_root = Solve(
-            host="192.168.1.10",
-            team_id=self.blue_team1.id,
-            flag_id=root_flag.id
-        )
+        solve_user = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=user_flag.id)
+        solve_root = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=root_flag.id)
 
-        self.session.add_all([service, user_flag, root_flag, solve_user, solve_root])
+        self.session.add_all([solve_user, solve_root])
         self.session.commit()
 
         self.login("reduser", "pass")
@@ -531,24 +474,11 @@ class TestFlagsAPI(UnitTest):
         assert team1_entry["win_score"] == 1
         assert team1_entry["total_score"] == 1
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_multiple_hosts(self):
         """Test scoring across multiple hosts"""
         # Create services
-        service1 = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
-        service2 = Service(
-            name="Host2",
-            check_name="AgentCheck",
-            host="192.168.1.20",
-            team=self.blue_team1,
-            port=0
-        )
+        service1 = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+        service2 = Service(name="Host2", check_name="AgentCheck", host="192.168.1.20", team=self.blue_team1, port=0)
 
         # Create flags
         flag1 = Flag(
@@ -558,7 +488,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test1", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
         flag2 = Flag(
             type=FlagTypeEnum.file,
@@ -567,14 +497,17 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test2", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
+
+        self.session.add_all([service1, service2, flag1, flag2])
+        self.session.flush()
 
         # Create solves
         solve1 = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=flag1.id)
         solve2 = Solve(host="192.168.1.20", team_id=self.blue_team1.id, flag_id=flag2.id)
 
-        self.session.add_all([service1, service2, flag1, flag2, solve1, solve2])
+        self.session.add_all([solve1, solve2])
         self.session.commit()
 
         self.login("reduser", "pass")
@@ -588,17 +521,10 @@ class TestFlagsAPI(UnitTest):
         assert team1_entry["win_score"] == 2
         assert team1_entry["total_score"] == 2
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_mixed_platforms(self):
         """Test scoring with both Windows and Linux flags"""
         # Create service
-        service = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
+        service = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
 
         # Create Windows flag
         win_flag = Flag(
@@ -608,7 +534,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create Linux flag
@@ -619,14 +545,17 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/etc/test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
+
+        self.session.add_all([service, win_flag, nix_flag])
+        self.session.flush()
 
         # Create solves
         solve_win = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=win_flag.id)
         solve_nix = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=nix_flag.id)
 
-        self.session.add_all([service, win_flag, nix_flag, solve_win, solve_nix])
+        self.session.add_all([solve_win, solve_nix])
         self.session.commit()
 
         self.login("reduser", "pass")
@@ -641,24 +570,11 @@ class TestFlagsAPI(UnitTest):
         assert team1_entry["nix_score"] == 1
         assert team1_entry["total_score"] == 2
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_multiple_teams(self):
         """Test that each team's score is calculated independently"""
         # Create services for both teams
-        service1 = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
-        service2 = Service(
-            name="Host2",
-            check_name="AgentCheck",
-            host="192.168.1.20",
-            team=self.blue_team2,
-            port=0
-        )
+        service1 = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+        service2 = Service(name="Host2", check_name="AgentCheck", host="192.168.1.20", team=self.blue_team2, port=0)
 
         # Create flag
         flag = Flag(
@@ -668,13 +584,16 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
+
+        self.session.add_all([service1, service2, flag])
+        self.session.flush()
 
         # Only team1 solves
         solve1 = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=flag.id)
 
-        self.session.add_all([service1, service2, flag, solve1])
+        self.session.add(solve1)
         self.session.commit()
 
         self.login("reduser", "pass")


### PR DESCRIPTION
## Summary
- Restores the original `api_flags_totals` SQL logic that was inadvertently changed in 3836053, fixing the scoring semantics (per-round scoring via `GROUP BY start_time`)
- Makes the query database-portable by replacing MySQL-specific `func.if_()` / `func.group_concat()` with standard `case()` / `func.max()` expressions
- Un-skips all 10 previously-skipped totals tests and fixes test setup bugs (flush flags before creating Solves so `flag.id` is populated)

Closes #1136

## Test plan
- [x] All 11 `api_flags_totals` tests pass on SQLite (0 skipped)
- [ ] Verify on MySQL in CI/integration environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)