### PR TITLE
Enhance admin stats pages: workers, queues, and web server

### DIFF
--- a/scoring_engine/celery_stats.py
+++ b/scoring_engine/celery_stats.py
@@ -1,3 +1,5 @@
+import platform
+
 from sqlalchemy.orm import joinedload
 
 from scoring_engine.celery_app import celery_app
@@ -8,9 +10,35 @@ from scoring_engine.models.team import Team
 
 class CeleryStats:
     @staticmethod
+    def _get_inspect_data():
+        """Call all inspect methods once and return cached results."""
+        inspector = celery_app.control.inspect(timeout=1.0)
+        return {
+            "active_queues": inspector.active_queues(),
+            "stats": inspector.stats(),
+            "active": inspector.active(),
+            "scheduled": inspector.scheduled(),
+            "reserved": inspector.reserved(),
+            "ping": inspector.ping(),
+        }
+
+    @staticmethod
+    def _summarize_services(services_running, all_services):
+        """Summarize service lists: 'All' if worker handles every service, 'ALL' per-team if all team services."""
+        total_running = sum(len(v) if isinstance(v, list) else 0 for v in services_running.values())
+        if total_running == len(all_services):
+            return "All"
+
+        blue_teams = Team.get_all_blue_teams()
+        for blue_team in blue_teams:
+            if blue_team.name in services_running and isinstance(services_running[blue_team.name], list):
+                if len(blue_team.services) == len(services_running[blue_team.name]):
+                    services_running[blue_team.name] = "ALL"
+        return services_running
+
+    @staticmethod
     def get_queue_stats():
         finished_queue_facts = []
-
         queues_facts = {}
 
         all_services = db.session.query(Service).options(joinedload(Service.team)).all()
@@ -20,35 +48,47 @@ class CeleryStats:
                     "name": service.worker_queue,
                     "workers": [],
                     "services_running": {},
+                    "running_tasks": 0,
+                    "scheduled_tasks": 0,
+                    "reserved_tasks": 0,
+                    "worker_count": 0,
                 }
             if service.team.name not in queues_facts[service.worker_queue]["services_running"]:
                 queues_facts[service.worker_queue]["services_running"][service.team.name] = []
             queues_facts[service.worker_queue]["services_running"][service.team.name].append(service.name)
 
+        # Summarize services per queue
         for queue_name, queue_facts in queues_facts.items():
-            # If all of the services are listed for this specific worker, let's just alias it as 'All'
-            queue_services_total_running = 0
-            for team_name, team_services in queues_facts[service.worker_queue]["services_running"].items():
-                queue_services_total_running += len(team_services)
-            if queue_services_total_running == len(all_services):
-                queues_facts[service.worker_queue]["services_running"] = "All"
-            else:
-                blue_teams = Team.get_all_blue_teams()
-                for blue_team in blue_teams:
-                    if blue_team.name in queue_facts["services_running"] and len(blue_team.services) == len(
-                        queue_facts["services_running"][blue_team.name]
-                    ):
-                        # Summarize it for each team if the worker runs all services
-                        queues_facts[service.worker_queue]["services_running"][blue_team.name] = "ALL"
+            queue_facts["services_running"] = CeleryStats._summarize_services(
+                queue_facts["services_running"], all_services
+            )
 
-        for queue_name, queue_facts in queues_facts.items():
-            # Get which workers are assigned to which queues
-            active_queues = celery_app.control.inspect().active_queues()
-            # If we don't have any queues, we also have no workers
-            if active_queues is not None:
-                for worker_name, queues in active_queues.items():
-                    if queue_name in [k["name"] for k in queues]:
-                        queue_facts["workers"].append(worker_name)
+        inspect_data = CeleryStats._get_inspect_data()
+        active_queues = inspect_data["active_queues"]
+        active_tasks = inspect_data["active"] or {}
+        scheduled_tasks = inspect_data["scheduled"] or {}
+        reserved_tasks = inspect_data["reserved"] or {}
+
+        if active_queues is not None:
+            # Build worker-to-queues mapping
+            for worker_name, queues in active_queues.items():
+                worker_queue_names = [q["name"] for q in queues]
+                for queue_name in worker_queue_names:
+                    if queue_name in queues_facts:
+                        queues_facts[queue_name]["workers"].append(worker_name)
+                        queues_facts[queue_name]["worker_count"] += 1
+
+            # Aggregate task counts per queue
+            for worker_name, queues in active_queues.items():
+                worker_queue_names = [q["name"] for q in queues]
+                worker_active = len(active_tasks.get(worker_name, []))
+                worker_scheduled = len(scheduled_tasks.get(worker_name, []))
+                worker_reserved = len(reserved_tasks.get(worker_name, []))
+                for queue_name in worker_queue_names:
+                    if queue_name in queues_facts:
+                        queues_facts[queue_name]["running_tasks"] += worker_active
+                        queues_facts[queue_name]["scheduled_tasks"] += worker_scheduled
+                        queues_facts[queue_name]["reserved_tasks"] += worker_reserved
 
         for queue_name, queue_facts in queues_facts.items():
             finished_queue_facts.append(queue_facts)
@@ -59,64 +99,93 @@ class CeleryStats:
         finished_worker_facts = []
         worker_facts = {}
 
-        # Get which workers are assigned to which queues
-        active_queues = celery_app.control.inspect().active_queues()
-        # If we don't have any queues, we also have no workers
+        inspect_data = CeleryStats._get_inspect_data()
+        active_queues = inspect_data["active_queues"]
+
         if active_queues is None:
             return finished_worker_facts
 
         for worker_name, queues in active_queues.items():
-            queue_names = []
-            for queue in queues:
-                queue_names.append(queue["name"])
+            queue_names = [queue["name"] for queue in queues]
             worker_facts[worker_name] = {
                 "worker_queues": queue_names,
             }
 
-        # Get worker stats about completed tasks and such
-        active_stats = celery_app.control.inspect().stats()
+        active_stats = inspect_data["stats"] or {}
         for worker_name, stats in active_stats.items():
+            if worker_name not in worker_facts:
+                continue
             completed_tasks = 0
-            if "execute_command" in stats["total"]:
+            if "execute_command" in stats.get("total", {}):
                 completed_tasks = stats["total"]["execute_command"]
             worker_facts[worker_name]["completed_tasks"] = completed_tasks
             worker_facts[worker_name]["num_threads"] = stats["pool"]["max-concurrency"]
 
-        # Get worker stats about currently running tasks
-        active_tasks_stats = celery_app.control.inspect().active()
+            # Extract uptime
+            worker_facts[worker_name]["uptime_seconds"] = stats.get("uptime", 0)
+
+            # Extract resource usage
+            rusage = stats.get("rusage", {})
+            maxrss = rusage.get("maxrss", 0)
+            # macOS reports maxrss in bytes, Linux in KB
+            if platform.system() == "Darwin":
+                worker_facts[worker_name]["max_rss_mb"] = round(maxrss / (1024 * 1024), 1)
+            else:
+                worker_facts[worker_name]["max_rss_mb"] = round(maxrss / 1024, 1)
+            worker_facts[worker_name]["cpu_user_time"] = round(rusage.get("utime", 0), 2)
+            worker_facts[worker_name]["cpu_system_time"] = round(rusage.get("stime", 0), 2)
+
+        active_tasks_stats = inspect_data["active"] or {}
         for worker_name, stats in active_tasks_stats.items():
+            if worker_name not in worker_facts:
+                continue
             worker_facts[worker_name]["running_tasks"] = len(stats)
+
+        # Extract scheduled/reserved counts
+        scheduled_tasks = inspect_data["scheduled"] or {}
+        reserved_tasks = inspect_data["reserved"] or {}
+        ping_results = inspect_data["ping"] or {}
+
+        # Build set of alive workers from ping response
+        alive_workers = set()
+        if ping_results:
+            for entry in ping_results:
+                if isinstance(entry, dict):
+                    alive_workers.update(entry.keys())
+
+        for worker_name in worker_facts:
+            worker_facts[worker_name].setdefault("completed_tasks", 0)
+            worker_facts[worker_name].setdefault("num_threads", 0)
+            worker_facts[worker_name].setdefault("running_tasks", 0)
+            worker_facts[worker_name].setdefault("uptime_seconds", 0)
+            worker_facts[worker_name].setdefault("max_rss_mb", 0)
+            worker_facts[worker_name].setdefault("cpu_user_time", 0)
+            worker_facts[worker_name].setdefault("cpu_system_time", 0)
+            worker_facts[worker_name]["scheduled_tasks"] = len(scheduled_tasks.get(worker_name, []))
+            worker_facts[worker_name]["reserved_tasks"] = len(reserved_tasks.get(worker_name, []))
+            worker_facts[worker_name]["is_alive"] = worker_name in alive_workers
+
+            # Calculate utilization
+            num_threads = worker_facts[worker_name]["num_threads"]
+            running = worker_facts[worker_name]["running_tasks"]
+            if num_threads > 0:
+                worker_facts[worker_name]["utilization_pct"] = round(running / num_threads * 100, 1)
+            else:
+                worker_facts[worker_name]["utilization_pct"] = 0
 
         # Produce list of Service checks this worker will run
         all_services = db.session.query(Service).options(joinedload(Service.team)).all()
         for worker_name, facts in worker_facts.items():
-            facts["services_running"] = []
             services_running = {}
             for service in all_services:
                 if service.worker_queue in facts["worker_queues"]:
                     if service.team.name not in services_running:
                         services_running[service.team.name] = []
                     services_running[service.team.name].append(service.name)
-            # If all of the services are listed for this specific worker, let's just alias it as 'All'
-            worker_services_total_running = 0
-            for team_name, team_services in services_running.items():
-                worker_services_total_running += len(team_services)
-            if worker_services_total_running == len(all_services):
-                facts["services_running"] = "All"
-            else:
-                facts["services_running"] = services_running
-                blue_teams = Team.get_all_blue_teams()
-                for blue_team in blue_teams:
-                    if blue_team.name in services_running and len(blue_team.services) == len(
-                        services_running[blue_team.name]
-                    ):
-                        # Summarize it for each team if the worker runs all services
-                        facts["services_running"][blue_team.name] = "ALL"
 
-            # Instead of an empty string in the table, let's tell them None
-            if len(facts["services_running"]) == 0:
+            facts["services_running"] = CeleryStats._summarize_services(services_running, all_services)
+            if not facts["services_running"]:
                 facts["services_running"] = "None"
-            # Clean up services_running
 
             finished_worker_facts.append(
                 {
@@ -126,6 +195,48 @@ class CeleryStats:
                     "completed_tasks": facts["completed_tasks"],
                     "running_tasks": facts["running_tasks"],
                     "worker_queues": facts["worker_queues"],
+                    "utilization_pct": facts["utilization_pct"],
+                    "uptime_seconds": facts["uptime_seconds"],
+                    "max_rss_mb": facts["max_rss_mb"],
+                    "cpu_user_time": facts["cpu_user_time"],
+                    "cpu_system_time": facts["cpu_system_time"],
+                    "scheduled_tasks": facts["scheduled_tasks"],
+                    "reserved_tasks": facts["reserved_tasks"],
+                    "is_alive": facts["is_alive"],
                 }
             )
         return finished_worker_facts
+
+    @staticmethod
+    def _compute_summary(workers):
+        """Compute aggregate summary from a pre-fetched worker stats list."""
+        if not workers:
+            return {
+                "total_workers": 0,
+                "total_threads": 0,
+                "total_running": 0,
+                "total_completed": 0,
+                "total_scheduled": 0,
+                "avg_utilization_pct": 0,
+            }
+
+        total_workers = len(workers)
+        total_threads = sum(w["num_threads"] for w in workers)
+        total_running = sum(w["running_tasks"] for w in workers)
+        total_completed = sum(w["completed_tasks"] for w in workers)
+        total_scheduled = sum(w["scheduled_tasks"] for w in workers)
+        avg_utilization = round(sum(w["utilization_pct"] for w in workers) / total_workers, 1)
+
+        return {
+            "total_workers": total_workers,
+            "total_threads": total_threads,
+            "total_running": total_running,
+            "total_completed": total_completed,
+            "total_scheduled": total_scheduled,
+            "avg_utilization_pct": avg_utilization,
+        }
+
+    @staticmethod
+    def get_worker_summary():
+        """Aggregate totals across all workers for stat cards."""
+        return CeleryStats._compute_summary(CeleryStats.get_worker_stats())

--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -16,6 +16,8 @@
             <i class="bi bi-people"></i> Workers</a>
           <a href="/admin/queues" class="sidebar-link {% if request.path == '/admin/queues' %}active{% endif %}">
             <i class="bi bi-stack"></i> Queues</a>
+          <a href="/admin/webserver" class="sidebar-link {% if request.path == '/admin/webserver' %}active{% endif %}">
+            <i class="bi bi-hdd-rack"></i> Web Server</a>
         </div>
 
         <div class="sidebar-section">

--- a/scoring_engine/web/templates/admin/queues.html
+++ b/scoring_engine/web/templates/admin/queues.html
@@ -10,12 +10,35 @@
 {% block header %}Queue Stats{% endblock %}
 
 {% block admincontent %}
-  <div class="chart-card mt-3" style="padding:0; overflow:hidden;">
+  <div class="stat-cards-row pt-2">
+    <div class="stat-card">
+      <div class="stat-label">Total Queues</div>
+      <div class="stat-value" id="summary_total_queues">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Workers Assigned</div>
+      <div class="stat-value" id="summary_total_workers">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Running Tasks</div>
+      <div class="stat-value text-success" id="summary_running_tasks">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Scheduled Tasks</div>
+      <div class="stat-value" id="summary_scheduled_tasks">-</div>
+    </div>
+  </div>
+  <div class="d-flex justify-content-end mt-2 mb-2">
+    <small class="text-muted">Last updated: <span id="last_updated">-</span></small>
+  </div>
+  <div class="chart-card mt-1" style="padding:0; overflow:hidden;">
     <table id="queues" class="table table-sm overview-matrix" width="100%">
       <thead>
         <tr>
           <th><div title="Name of Queue">Worker Queue Name</div></th>
           <th><div title="List of the workers that are assigned to run checks for this service">Workers Assigned</div></th>
+          <th><div title="Currently running tasks in this queue">Running Tasks</div></th>
+          <th><div title="Tasks scheduled for future execution">Scheduled Tasks</div></th>
           <th><div title="List of the services that are associated with this worker queue name">Services Associated</div></th>
         </tr>
       </thead>
@@ -24,6 +47,28 @@
     </table>
   </div>
   <script>
+    function updateLastUpdated() {
+      var now = new Date();
+      var timeStr = now.toLocaleTimeString();
+      $('#last_updated').text(timeStr);
+    }
+
+    function updateQueueSummary(data) {
+      var totalQueues = data.length;
+      var totalWorkers = 0;
+      var totalRunning = 0;
+      var totalScheduled = 0;
+      for (var i = 0; i < data.length; i++) {
+        totalWorkers += data[i].worker_count || 0;
+        totalRunning += data[i].running_tasks || 0;
+        totalScheduled += data[i].scheduled_tasks || 0;
+      }
+      $('#summary_total_queues').text(totalQueues);
+      $('#summary_total_workers').text(totalWorkers);
+      $('#summary_running_tasks').text(totalRunning);
+      $('#summary_scheduled_tasks').text(totalScheduled);
+    }
+
     $(document).ready(function() {
       // Disable datatables error reporting
       $.fn.dataTable.ext.errMode = 'none';
@@ -36,7 +81,14 @@
           'paging': false,
           'bFilter': false,
           'bInfo': false,
-          "ajax": "/api/admin/get_queue_stats",
+          "ajax": {
+            "url": "/api/admin/get_queue_stats",
+            "dataSrc": function(json) {
+              updateLastUpdated();
+              updateQueueSummary(json.data);
+              return json.data;
+            }
+          },
           "language": {
             "emptyTable": "No queues are currently configured",
           },
@@ -57,6 +109,8 @@
                 return text;
               }
             },
+            { "data": "running_tasks" },
+            { "data": "scheduled_tasks" },
             {
               "width": 170,
               "data": "services_running",
@@ -83,11 +137,8 @@
           ],
         });
       setInterval( function () {
-        table.ajax.reload();
+        table.ajax.reload(null, false);
       }, 10000 );
     } );
   </script>
-
-
-
 {% endblock %}

--- a/scoring_engine/web/templates/admin/webserver.html
+++ b/scoring_engine/web/templates/admin/webserver.html
@@ -1,0 +1,180 @@
+{% extends 'admin/adminbase.html' %}
+{% block title %}Admin - Web Server Stats{% endblock %}
+
+{% block head %}
+    {{ super() }}
+    <script src="{{ url_for('static', filename='vendor/js/dataTables.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='vendor/js/dataTables.bootstrap5.min.js') }}"></script>
+    <link href="{{ url_for('static', filename='vendor/css/dataTables.bootstrap5.min.css') }}" rel="stylesheet" />
+{% endblock %}
+{% block header %}Web Server Stats{% endblock %}
+
+{% block admincontent %}
+  <div class="stat-cards-row pt-2">
+    <div class="stat-card">
+      <div class="stat-label">uWSGI Workers</div>
+      <div class="stat-value" id="summary_total_workers">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Busy / Idle</div>
+      <div class="stat-value"><span class="text-warning" id="summary_busy">-</span> / <span class="text-success" id="summary_idle">-</span></div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Total Requests</div>
+      <div class="stat-value" id="summary_total_requests">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Listen Queue</div>
+      <div class="stat-value" id="summary_listen_queue">-</div>
+    </div>
+  </div>
+  <div class="stat-cards-row">
+    <div class="stat-card">
+      <div class="stat-label">Exceptions</div>
+      <div class="stat-value text-danger" id="summary_exceptions">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Data Transferred</div>
+      <div class="stat-value" id="summary_tx">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Queue Errors</div>
+      <div class="stat-value" id="summary_queue_errors">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">uWSGI Version</div>
+      <div class="stat-value" id="summary_version">-</div>
+    </div>
+  </div>
+  <div class="d-flex justify-content-end mt-2 mb-2">
+    <small class="text-muted">Last updated: <span id="last_updated">-</span></small>
+  </div>
+  <div class="chart-card mt-1" style="padding:0; overflow:hidden;">
+    <table id="uwsgi_workers" class="table table-sm overview-matrix" width="100%">
+      <thead>
+        <tr>
+          <th><div title="Worker ID">ID</div></th>
+          <th><div title="Process ID">PID</div></th>
+          <th><div title="Worker status">Status</div></th>
+          <th><div title="Total requests handled">Requests</div></th>
+          <th><div title="Average response time">Avg Response</div></th>
+          <th><div title="Data transmitted">TX</div></th>
+          <th><div title="Total exceptions">Exceptions</div></th>
+          <th><div title="Harakiri kills (request timeout)">Harakiri</div></th>
+          <th><div title="Total running time">Running Time</div></th>
+          <th><div title="Number of times respawned">Respawns</div></th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+  </div>
+  <script>
+    function updateLastUpdated() {
+      var now = new Date();
+      $('#last_updated').text(now.toLocaleTimeString());
+    }
+
+    function updateSummary(summary) {
+      $('#summary_total_workers').text(summary.total_workers);
+      $('#summary_busy').text(summary.busy_workers);
+      $('#summary_idle').text(summary.idle_workers);
+      $('#summary_total_requests').text(summary.total_requests.toLocaleString());
+      $('#summary_exceptions').text(summary.total_exceptions);
+      $('#summary_tx').text(summary.total_tx_mb + ' MB');
+      $('#summary_version').text(summary.version);
+      var queueText = summary.listen_queue + ' / ' + summary.listen_queue_max;
+      var $el = $('#summary_listen_queue');
+      $el.text(queueText);
+      if (summary.listen_queue > 0) {
+        $el.addClass('text-warning');
+      } else {
+        $el.removeClass('text-warning');
+      }
+      $('#summary_queue_errors').text(summary.listen_queue_errors);
+    }
+
+    function formatTime(seconds) {
+      if (seconds < 60) return seconds + 's';
+      if (seconds < 3600) return Math.floor(seconds / 60) + 'm ' + Math.floor(seconds % 60) + 's';
+      var h = Math.floor(seconds / 3600);
+      var m = Math.floor((seconds % 3600) / 60);
+      return h + 'h ' + m + 'm';
+    }
+
+    $(document).ready(function() {
+      $.fn.dataTable.ext.errMode = 'none';
+
+      var table = $('#uwsgi_workers')
+        .on('error.dt', function (e, settings, techNote, message) {
+          console.log('An error has been reported by DataTables: ', message);
+        })
+        .DataTable({
+          'paging': false,
+          'bFilter': false,
+          'bInfo': false,
+          'ordering': false,
+          "ajax": {
+            "url": "/api/admin/get_uwsgi_stats",
+            "dataSrc": function(json) {
+              updateLastUpdated();
+              if (json.summary) updateSummary(json.summary);
+              return json.workers || [];
+            }
+          },
+          "language": {
+            "emptyTable": "Unable to retrieve uWSGI stats",
+          },
+          "columns": [
+            { "data": "id" },
+            { "data": "pid" },
+            {
+              "data": "status",
+              "render": function(data) {
+                if (data === 'busy') {
+                  return '<span class="badge bg-warning text-dark">busy</span>';
+                } else if (data === 'idle') {
+                  return '<span class="badge bg-success">idle</span>';
+                }
+                return '<span class="badge bg-secondary">' + data + '</span>';
+              }
+            },
+            {
+              "data": "requests",
+              "render": function(data) { return data.toLocaleString(); }
+            },
+            {
+              "data": "avg_rt_ms",
+              "render": function(data) { return data + ' ms'; }
+            },
+            {
+              "data": "tx_kb",
+              "render": function(data) { return data + ' KB'; }
+            },
+            {
+              "data": "exceptions",
+              "render": function(data) {
+                if (data > 0) return '<span class="text-danger">' + data + '</span>';
+                return data;
+              }
+            },
+            {
+              "data": "harakiri_count",
+              "render": function(data) {
+                if (data > 0) return '<span class="text-danger">' + data + '</span>';
+                return data;
+              }
+            },
+            {
+              "data": "running_time_s",
+              "render": function(data) { return formatTime(data); }
+            },
+            { "data": "respawn_count" },
+          ],
+        });
+      setInterval(function () {
+        table.ajax.reload(null, false);
+      }, 5000);
+    });
+  </script>
+{% endblock %}

--- a/scoring_engine/web/templates/admin/workers.html
+++ b/scoring_engine/web/templates/admin/workers.html
@@ -10,14 +10,39 @@
 {% block header %}Worker Stats{% endblock %}
 
 {% block admincontent %}
-  <div class="chart-card mt-3" style="padding:0; overflow:hidden;">
+  <div class="stat-cards-row pt-2">
+    <div class="stat-card">
+      <div class="stat-label">Total Workers</div>
+      <div class="stat-value" id="summary_total_workers">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Running Checks</div>
+      <div class="stat-value text-success" id="summary_total_running">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Total Completed</div>
+      <div class="stat-value" id="summary_total_completed">-</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Avg Utilization</div>
+      <div class="stat-value" id="summary_avg_utilization">-</div>
+    </div>
+  </div>
+  <div class="d-flex justify-content-end mt-2 mb-2">
+    <small class="text-muted">Last updated: <span id="last_updated">-</span></small>
+  </div>
+  <div class="chart-card mt-1" style="padding:0; overflow:hidden;">
     <table id="workers" class="table table-sm overview-matrix" width="100%">
       <thead>
         <tr>
           <th><div title="Name of Worker">Name</div></th>
+          <th><div title="Worker connectivity status">Status</div></th>
+          <th><div title="Current utilization percentage">Utilization</div></th>
           <th><div title="Number of processes available">Processes</div></th>
-          <th><div title="Number of currently running checks">Running Checks</div></th>
-          <th><div title="Number of completed checks">Completed Checks</div></th>
+          <th><div title="Number of currently running checks">Running</div></th>
+          <th><div title="Number of completed checks">Completed</div></th>
+          <th><div title="Worker uptime">Uptime</div></th>
+          <th><div title="Peak memory usage (RSS)">Memory</div></th>
           <th><div title="Queues registered to for running service checks">Queue Names</div></th>
           <th><div title="Services that the worker is registered to run">Enabled Services</div></th>
         </tr>
@@ -27,6 +52,29 @@
     </table>
   </div>
   <script>
+    function formatUptime(seconds) {
+      if (!seconds || seconds <= 0) return '-';
+      var d = Math.floor(seconds / 86400);
+      var h = Math.floor((seconds % 86400) / 3600);
+      var m = Math.floor((seconds % 3600) / 60);
+      if (d > 0) return d + 'd ' + h + 'h';
+      if (h > 0) return h + 'h ' + m + 'm';
+      return m + 'm';
+    }
+
+    function updateLastUpdated() {
+      var now = new Date();
+      var timeStr = now.toLocaleTimeString();
+      $('#last_updated').text(timeStr);
+    }
+
+    function updateWorkerSummary(summary) {
+      $('#summary_total_workers').text(summary.total_workers);
+      $('#summary_total_running').text(summary.total_running);
+      $('#summary_total_completed').text(summary.total_completed);
+      $('#summary_avg_utilization').text(summary.avg_utilization_pct + '%');
+    }
+
     $(document).ready(function() {
       // Disable datatables error reporting
       $.fn.dataTable.ext.errMode = 'none';
@@ -39,15 +87,52 @@
           'paging': false,
           'bFilter': false,
           'bInfo': false,
-          "ajax": "/api/admin/get_worker_stats",
+          "ajax": {
+            "url": "/api/admin/get_worker_stats_with_summary",
+            "dataSrc": function(json) {
+              updateLastUpdated();
+              updateWorkerSummary(json.summary);
+              return json.data;
+            }
+          },
           "language": {
             "emptyTable": 'No workers are currently connected <span class="bi bi-exclamation-triangle-fill" style="color:red" title="This means no services will get checked until a worker is connected."></span>',
           },
           "columns": [
             { "data": "worker_name" },
+            {
+              "data": "is_alive",
+              "render": function(data) {
+                if (data) {
+                  return '<span class="bi bi-circle-fill" style="color:#28a745" title="Online"></span>';
+                }
+                return '<span class="bi bi-circle-fill" style="color:#dc3545" title="Offline"></span>';
+              }
+            },
+            {
+              "data": "utilization_pct",
+              "render": function(data) {
+                var color = data < 50 ? '#28a745' : (data < 80 ? '#ffc107' : '#dc3545');
+                return '<div class="progress" style="min-width:80px;height:18px;">' +
+                  '<div class="progress-bar" role="progressbar" style="width:' + data + '%;background-color:' + color + ';" aria-valuenow="' + data + '" aria-valuemin="0" aria-valuemax="100">' +
+                  data + '%</div></div>';
+              }
+            },
             { "data": "num_threads" },
             { "data": "running_tasks" },
             { "data": "completed_tasks" },
+            {
+              "data": "uptime_seconds",
+              "render": function(data) {
+                return formatUptime(data);
+              }
+            },
+            {
+              "data": "max_rss_mb",
+              "render": function(data) {
+                return data + ' MB';
+              }
+            },
             {
               "data": "worker_queues",
               "render": function( data ) {
@@ -65,7 +150,7 @@
                 var text = "";
                 if (typeof data === 'string'){
                   if (data == 'None'){
-                    text = 'None <span class="bi bi-exclamation-triangle-fill" style="color:red" title="This worker isn\' currently running any services, perhaps the queue names for this worker are incorrect?"></span>';
+                    text = 'None <span class="bi bi-exclamation-triangle-fill" style="color:red" title="This worker isn\'t currently running any services, perhaps the queue names for this worker are incorrect?"></span>';
                   }
                   else{
                     text = data;
@@ -89,7 +174,7 @@
           ],
         });
       setInterval( function () {
-        table.ajax.reload();
+        table.ajax.reload(null, false);
       }, 10000 );
     } );
   </script>

--- a/scoring_engine/web/views/admin.py
+++ b/scoring_engine/web/views/admin.py
@@ -44,6 +44,16 @@ def queues():
         return redirect(url_for("auth.unauthorized"))
 
 
+@mod.route("/admin/webserver")
+@login_required
+def webserver():
+    if current_user.is_white_team:
+        blue_teams = Team.get_all_blue_teams()
+        return render_template("admin/webserver.html", blue_teams=blue_teams)
+    else:
+        return redirect(url_for("auth.unauthorized"))
+
+
 @mod.route("/admin/manage")
 @login_required
 def manage():

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1057,6 +1057,27 @@ def admin_get_worker_stats():
         return {"status": "Unauthorized"}, 403
 
 
+@mod.route("/api/admin/get_worker_summary")
+@login_required
+def admin_get_worker_summary():
+    if current_user.is_white_team:
+        summary = CeleryStats.get_worker_summary()
+        return jsonify(summary)
+    else:
+        return {"status": "Unauthorized"}, 403
+
+
+@mod.route("/api/admin/get_worker_stats_with_summary")
+@login_required
+def admin_get_worker_stats_with_summary():
+    if current_user.is_white_team:
+        worker_stats = CeleryStats.get_worker_stats()
+        summary = CeleryStats._compute_summary(worker_stats)
+        return jsonify(data=worker_stats, summary=summary)
+    else:
+        return {"status": "Unauthorized"}, 403
+
+
 @mod.route("/api/admin/get_queue_stats")
 @login_required
 def admin_get_queue_stats():

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1,6 +1,8 @@
 import html
 import json
 import re
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 
 import pytz
@@ -1084,6 +1086,59 @@ def admin_get_queue_stats():
     if current_user.is_white_team:
         queue_stats = CeleryStats.get_queue_stats()
         return jsonify(data=queue_stats)
+    else:
+        return {"status": "Unauthorized"}, 403
+
+
+@mod.route("/api/admin/get_uwsgi_stats")
+@login_required
+def admin_get_uwsgi_stats():
+    if current_user.is_white_team:
+        try:
+            with urllib.request.urlopen("http://localhost:9191", timeout=2) as resp:
+                raw = json.loads(resp.read())
+        except (urllib.error.URLError, OSError):
+            return jsonify({"error": "uwsgi stats server unavailable"}), 503
+
+        total_requests = 0
+        total_exceptions = 0
+        total_tx = 0
+        total_running_time = 0
+        workers = []
+        for w in raw.get("workers", []):
+            total_requests += w.get("requests", 0)
+            total_exceptions += w.get("exceptions", 0)
+            total_tx += w.get("tx", 0)
+            total_running_time += w.get("running_time", 0)
+            workers.append({
+                "id": w["id"],
+                "pid": w["pid"],
+                "status": w["status"],
+                "requests": w.get("requests", 0),
+                "exceptions": w.get("exceptions", 0),
+                "harakiri_count": w.get("harakiri_count", 0),
+                "avg_rt_ms": round(w.get("avg_rt", 0) / 1000, 1),
+                "tx_kb": round(w.get("tx", 0) / 1024, 1),
+                "rss_mb": round(w.get("rss", 0) / (1024 * 1024), 1),
+                "running_time_s": round(w.get("running_time", 0) / 1e6, 1),
+                "respawn_count": w.get("respawn_count", 0),
+            })
+
+        socket = raw.get("sockets", [{}])[0] if raw.get("sockets") else {}
+        summary = {
+            "version": raw.get("version", ""),
+            "total_workers": len(raw.get("workers", [])),
+            "busy_workers": sum(1 for w in raw.get("workers", []) if w.get("status") == "busy"),
+            "idle_workers": sum(1 for w in raw.get("workers", []) if w.get("status") == "idle"),
+            "total_requests": total_requests,
+            "total_exceptions": total_exceptions,
+            "total_tx_mb": round(total_tx / (1024 * 1024), 2),
+            "listen_queue": raw.get("listen_queue", 0),
+            "listen_queue_max": socket.get("max_queue", 0),
+            "listen_queue_errors": raw.get("listen_queue_errors", 0),
+        }
+
+        return jsonify(summary=summary, workers=workers)
     else:
         return {"status": "Unauthorized"}, 403
 

--- a/tests/scoring_engine/test_celery_stats.py
+++ b/tests/scoring_engine/test_celery_stats.py
@@ -15,15 +15,41 @@ class InspectAll:
             "worker1": {
                 "total": {"execute_command": 10},
                 "pool": {"max-concurrency": 5},
+                "uptime": 3600,
+                "rusage": {"maxrss": 104857600, "utime": 12.5, "stime": 3.2},
             }
         }
 
     def active(self):
         return {"worker1": [1, 2]}
 
+    def scheduled(self):
+        return {"worker1": [1]}
+
+    def reserved(self):
+        return {"worker1": [1, 2, 3]}
+
+    def ping(self):
+        return [{"worker1": {"ok": "pong"}}]
+
 
 class InspectNoQueues:
     def active_queues(self):
+        return None
+
+    def stats(self):
+        return None
+
+    def active(self):
+        return None
+
+    def scheduled(self):
+        return None
+
+    def reserved(self):
+        return None
+
+    def ping(self):
         return None
 
 
@@ -31,7 +57,7 @@ class Control:
     def __init__(self, inspect_obj):
         self._inspect_obj = inspect_obj
 
-    def inspect(self):
+    def inspect(self, **kwargs):
         return self._inspect_obj
 
 
@@ -60,25 +86,63 @@ class TestCeleryStats:
                 "name": "queue1",
                 "workers": ["worker1"],
                 "services_running": "All",
+                "running_tasks": 2,
+                "scheduled_tasks": 1,
+                "reserved_tasks": 3,
+                "worker_count": 1,
             }
         ]
+
+    def test_get_queue_stats_new_fields(self):
+        """Test that queue stats include running/scheduled/reserved task counts."""
+        self.create_service()
+        mock_app = mock.Mock()
+        mock_app.control = Control(InspectAll())
+        with mock.patch("scoring_engine.celery_stats.celery_app", mock_app):
+            result = CeleryStats.get_queue_stats()
+        assert len(result) == 1
+        queue = result[0]
+        assert queue["running_tasks"] == 2
+        assert queue["scheduled_tasks"] == 1
+        assert queue["reserved_tasks"] == 3
+        assert queue["worker_count"] == 1
 
     def test_get_worker_stats(self):
         self.create_service()
         mock_app = mock.Mock()
         mock_app.control = Control(InspectAll())
         with mock.patch("scoring_engine.celery_stats.celery_app", mock_app):
-            result = CeleryStats.get_worker_stats()
-        assert result == [
-            {
-                "worker_name": "worker1",
-                "services_running": "All",
-                "num_threads": 5,
-                "completed_tasks": 10,
-                "running_tasks": 2,
-                "worker_queues": ["queue1"],
-            }
-        ]
+            with mock.patch("scoring_engine.celery_stats.platform") as mock_platform:
+                mock_platform.system.return_value = "Darwin"
+                result = CeleryStats.get_worker_stats()
+        assert len(result) == 1
+        worker = result[0]
+        assert worker["worker_name"] == "worker1"
+        assert worker["services_running"] == "All"
+        assert worker["num_threads"] == 5
+        assert worker["completed_tasks"] == 10
+        assert worker["running_tasks"] == 2
+        assert worker["worker_queues"] == ["queue1"]
+        assert worker["utilization_pct"] == 40.0
+        assert worker["uptime_seconds"] == 3600
+        assert worker["max_rss_mb"] == 100.0
+        assert worker["cpu_user_time"] == 12.5
+        assert worker["cpu_system_time"] == 3.2
+        assert worker["scheduled_tasks"] == 1
+        assert worker["reserved_tasks"] == 3
+        assert worker["is_alive"] is True
+
+    def test_get_worker_stats_linux_rss(self):
+        """Test that maxrss is converted from KB on Linux."""
+        self.create_service()
+        mock_app = mock.Mock()
+        mock_app.control = Control(InspectAll())
+        with mock.patch("scoring_engine.celery_stats.celery_app", mock_app):
+            with mock.patch("scoring_engine.celery_stats.platform") as mock_platform:
+                mock_platform.system.return_value = "Linux"
+                result = CeleryStats.get_worker_stats()
+        # On Linux, 104857600 KB = 102400 MB
+        assert result[0]["max_rss_mb"] == 102400.0
 
     def test_get_worker_stats_no_workers(self):
         mock_app = mock.Mock()
@@ -86,3 +150,30 @@ class TestCeleryStats:
         with mock.patch("scoring_engine.celery_stats.celery_app", mock_app):
             result = CeleryStats.get_worker_stats()
         assert result == []
+
+    def test_get_worker_summary(self):
+        self.create_service()
+        mock_app = mock.Mock()
+        mock_app.control = Control(InspectAll())
+        with mock.patch("scoring_engine.celery_stats.celery_app", mock_app):
+            with mock.patch("scoring_engine.celery_stats.platform") as mock_platform:
+                mock_platform.system.return_value = "Darwin"
+                result = CeleryStats.get_worker_summary()
+        assert result["total_workers"] == 1
+        assert result["total_threads"] == 5
+        assert result["total_running"] == 2
+        assert result["total_completed"] == 10
+        assert result["total_scheduled"] == 1
+        assert result["avg_utilization_pct"] == 40.0
+
+    def test_get_worker_summary_no_workers(self):
+        mock_app = mock.Mock()
+        mock_app.control = Control(InspectNoQueues())
+        with mock.patch("scoring_engine.celery_stats.celery_app", mock_app):
+            result = CeleryStats.get_worker_summary()
+        assert result["total_workers"] == 0
+        assert result["total_threads"] == 0
+        assert result["total_running"] == 0
+        assert result["total_completed"] == 0
+        assert result["total_scheduled"] == 0
+        assert result["avg_utilization_pct"] == 0

--- a/tests/scoring_engine/web/views/test_admin.py
+++ b/tests/scoring_engine/web/views/test_admin.py
@@ -10,6 +10,7 @@ ADMIN_PATHS = [
     "/admin/status",
     "/admin/workers",
     "/admin/queues",
+    "/admin/webserver",
     "/admin/manage",
     "/admin/permissions",
     "/admin/settings",


### PR DESCRIPTION
## Summary
- Refactor `CeleryStats` to call all Celery inspect methods once via `_get_inspect_data()`, fixing a perf bug where `active_queues()` was called inside a per-queue loop
- Extract per-worker utilization, uptime, memory (RSS), CPU time, and liveness from existing `stats()`/`ping()` responses; add queue-level running/scheduled/reserved task counts
- Add combined `get_worker_stats_with_summary` endpoint so the workers page makes one API call instead of two, halving Celery inspect round-trips; set 1s inspect timeout
- Add stat cards and "Last updated" indicator to `/admin/workers` and `/admin/queues`
- Add new `/admin/webserver` page showing uWSGI worker stats: per-worker status (busy/idle), requests, avg response time, data transferred, exceptions, harakiri kills, respawn count, with summary stat cards for listen queue depth and totals

## Test plan
- [x] `python -m pytest tests/scoring_engine/test_celery_stats.py tests/scoring_engine/web/views/api/test_admin_api.py tests/scoring_engine/web/views/test_admin.py -v` (70 pass)
- [x] Full suite `python -m pytest tests/ -x -n 8` (640 pass, 12 skipped)
- [x] Manual: `docker compose up -d`, login as white team, verify `/admin/workers`, `/admin/queues`, and `/admin/webserver`

🤖 Generated with [Claude Code](https://claude.com/claude-code)