### PR TITLE
Add optional matching_content_reject field to environments

### DIFF
--- a/scoring_engine/competition.py
+++ b/scoring_engine/competition.py
@@ -225,6 +225,20 @@ class Competition(dict):
                 team_name, service_name, e
             )
 
+        # Verify optional matching_content_reject
+        if "matching_content_reject" in environment:
+            assert (
+                type(environment["matching_content_reject"]) is str
+            ), "{0} {1} environment 'matching_content_reject' field must be a string".format(team_name, service_name)
+            try:
+                re.compile(environment["matching_content_reject"])
+            except re.error as e:
+                assert (
+                    False
+                ), "{0} {1} environment 'matching_content_reject' field must be a valid regex pattern: {2}".format(
+                    team_name, service_name, e
+                )
+
         # Verify environment properties
         if "properties" in environment:
             assert (
@@ -293,7 +307,9 @@ class Competition(dict):
                             )
                     for environment_dict in service_dict["environments"]:
                         environment_obj = Environment(
-                            service=service_obj, matching_content=environment_dict["matching_content"]
+                            service=service_obj,
+                            matching_content=environment_dict["matching_content"],
+                            matching_content_reject=environment_dict.get("matching_content_reject"),
                         )
                         db.session.add(environment_obj)
                         if "properties" in environment_dict:

--- a/scoring_engine/models/environment.py
+++ b/scoring_engine/models/environment.py
@@ -11,3 +11,4 @@ class Environment(Base):
     service = relationship("Service")
     properties = relationship("Property", back_populates="environment")
     matching_content = Column(Text, nullable=False)
+    matching_content_reject = Column(Text, nullable=True)

--- a/scoring_engine/web/templates/admin/service.html
+++ b/scoring_engine/web/templates/admin/service.html
@@ -99,7 +99,8 @@
   <table class="table table-sm overview-matrix">
     <thead>
       <tr>
-        <th style="width: 25%">Matching Content</th>
+        <th style="width: 20%">Matching Content</th>
+        <th style="width: 20%">Reject Content</th>
         <th>Properties</th>
       </tr>
     </thead>
@@ -111,6 +112,13 @@
                  data-pk="{{environment.id}}" data-name="matching_content"
                  data-url="{{url_for('api.admin_update_environment')}}"
                  value="{{environment.matching_content}}">
+        </td>
+        <td class="align-top">
+          <input type="text" class="form-control form-control-sm editable-field"
+                 data-pk="{{environment.id}}" data-name="matching_content_reject"
+                 data-url="{{url_for('api.admin_update_environment')}}"
+                 value="{{environment.matching_content_reject or ''}}"
+                 placeholder="Optional reject regex">
         </td>
         <td>
           {% if environment.properties %}

--- a/tests/scoring_engine/models/test_environment.py
+++ b/tests/scoring_engine/models/test_environment.py
@@ -11,6 +11,12 @@ class TestEnvironment:
         assert environment.id is None
         assert environment.properties == []
         assert environment.matching_content == "*"
+        assert environment.matching_content_reject is None
+
+    def test_init_with_reject(self):
+        environment = Environment(matching_content="^SUCCESS", matching_content_reject="ERROR|FAIL")
+        assert environment.matching_content == "^SUCCESS"
+        assert environment.matching_content_reject == "ERROR|FAIL"
 
     def test_basic_service(self):
         service = generate_sample_model_tree("Service", db.session)

--- a/tests/scoring_engine/web/views/api/test_admin_api.py
+++ b/tests/scoring_engine/web/views/api/test_admin_api.py
@@ -300,9 +300,7 @@ class TestAdminAPI:
 
         with patch("scoring_engine.web.views.api.admin.update_scoreboard_data") as mock_scoreboard:
             with patch("scoring_engine.web.views.api.admin.update_overview_data") as mock_overview:
-                self.client.post(
-                    "/api/admin/update_check", data={"pk": check.id, "name": "check_value", "value": "2"}
-                )
+                self.client.post("/api/admin/update_check", data={"pk": check.id, "name": "check_value", "value": "2"})
                 mock_scoreboard.assert_called_once()
                 mock_overview.assert_called_once()
 
@@ -319,9 +317,7 @@ class TestAdminAPI:
         # Invalid value (not 1 or 2)
         with patch("scoring_engine.web.views.api.admin.update_scoreboard_data"):
             with patch("scoring_engine.web.views.api.admin.update_overview_data"):
-                self.client.post(
-                    "/api/admin/update_check", data={"pk": check.id, "name": "check_value", "value": "3"}
-                )
+                self.client.post("/api/admin/update_check", data={"pk": check.id, "name": "check_value", "value": "3"})
 
         # Should not crash, just not update
         db.session.refresh(check)
@@ -405,6 +401,61 @@ class TestAdminAPI:
 
         db.session.refresh(env)
         assert env.matching_content == "^SUCCESS"
+
+    def test_admin_update_matching_content_reject_success(self):
+        """Test that matching_content_reject can be set via admin API"""
+        service = Service(name="Test", check_name="ICMP IPv4 Check", host="1.2.3.4", team=self.blue_team)
+        env = Environment(service=service, matching_content="^SUCCESS")
+        db.session.add_all([service, env])
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_environment_info",
+            data={"pk": env.id, "name": "matching_content_reject", "value": "ERROR|FAIL"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Updated Environment Information"
+
+        db.session.refresh(env)
+        assert env.matching_content_reject == "ERROR|FAIL"
+
+    def test_admin_update_matching_content_reject_invalid_regex(self):
+        """Test that invalid regex is rejected for matching_content_reject"""
+        service = Service(name="Test", check_name="ICMP IPv4 Check", host="1.2.3.4", team=self.blue_team)
+        env = Environment(service=service, matching_content="^SUCCESS")
+        db.session.add_all([service, env])
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_environment_info",
+            data={"pk": env.id, "name": "matching_content_reject", "value": "foo(bar"},
+        )
+
+        assert resp.status_code == 400
+        assert "Invalid regex pattern" in resp.json["error"]
+
+        db.session.refresh(env)
+        assert env.matching_content_reject is None
+
+    def test_admin_clear_matching_content_reject(self):
+        """Test that matching_content_reject can be cleared by setting empty value"""
+        service = Service(name="Test", check_name="ICMP IPv4 Check", host="1.2.3.4", team=self.blue_team)
+        env = Environment(service=service, matching_content="^SUCCESS", matching_content_reject="old_pattern")
+        db.session.add_all([service, env])
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_environment_info",
+            data={"pk": env.id, "name": "matching_content_reject", "value": ""},
+        )
+
+        assert resp.status_code == 200
+        db.session.refresh(env)
+        assert env.matching_content_reject is None
 
     def test_admin_nonexistent_environment(self):
         """Test updating nonexistent environment returns error"""


### PR DESCRIPTION
## Summary
- Adds a nullable `matching_content_reject` regex field to the `Environment` model
- Engine evaluates the reject pattern after a successful `matching_content` match — if the reject pattern also matches the output, the check fails with the same generic reason text
- Supports YAML competition config, admin UI editing, and regex validation

## Test plan
- [x] Environment model tests for new field
- [x] Competition YAML validation tests (bad type, bad regex, valid pattern)
- [x] Competition save/load roundtrip test
- [x] Admin API tests (set, clear, invalid regex rejection)
- [x] Full test suite passes (628 passed, 12 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)