### PR TITLE
fix: pass SSH password via environment variable to handle special characters

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Builder — compile C extensions into a venv
-FROM python:3.14.2-slim-bookworm AS builder
+FROM python:3.14.3-slim-bookworm AS builder
 
 RUN set -eux; \
   apt-get update; \
@@ -25,7 +25,7 @@ d = tomllib.loads(pathlib.Path('/tmp/pyproject.toml').read_text()); \
 print(' '.join(d['project']['dependencies']))")
 
 # Stage 2: Runtime — slim image with only runtime libs
-FROM python:3.14.2-slim-bookworm
+FROM python:3.14.3-slim-bookworm
 
 RUN set -eux; \
   useradd -m engine; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "bcrypt==5.0.0",
   "celery[redis]==5.6.2",
   "configparser==7.2.0",
-  "cryptography==46.0.4",
+  "cryptography==46.0.5",
   "Flask==3.1.2",
   "Flask-Caching==2.3.1",
   "Flask-Login==0.6.3",

--- a/scoring_engine/checks/bin/ssh_check
+++ b/scoring_engine/checks/bin/ssh_check
@@ -8,50 +8,115 @@
 #
 # To install: pip install -I "cryptography>=2.4,<2.5" && pip install "paramiko>=2.4,<2.5"
 
+import os
+import socket
 import sys
 import paramiko
 
 
-if len(sys.argv) != 6:
-    print("Usage: " + sys.argv[0] + " host port username password commands")
-    print("commands parameter supports multiple commands, use ';' as the delimeter")
-    sys.exit(1)
+# Error classification prefixes for the scoring engine
+ERROR_AUTH_FAILED = "AUTH_FAILED:"
+ERROR_CONNECTION_REFUSED = "CONNECTION_REFUSED:"
+ERROR_CONNECTION_TIMEOUT = "CONNECTION_TIMEOUT:"
+ERROR_HOST_UNREACHABLE = "HOST_UNREACHABLE:"
+ERROR_SSH_ERROR = "SSH_ERROR:"
+ERROR_COMMAND_FAILED = "COMMAND_FAILED:"
 
-host = sys.argv[1]
-port = sys.argv[2]
-username = sys.argv[3]
-password = sys.argv[4]
-commands = sys.argv[5].split(';')
+
+# Support two modes:
+# 1. New mode (env var): host port username commands  (password from SCORING_PASSWORD env var)
+# 2. Legacy mode (cli):  host port username password commands
+password_from_env = os.environ.get('SCORING_PASSWORD')
+
+if password_from_env is not None and len(sys.argv) == 5:
+    # New mode: password via environment variable
+    host = sys.argv[1]
+    port = sys.argv[2]
+    username = sys.argv[3]
+    password = password_from_env
+    commands = sys.argv[4].split(';')
+elif len(sys.argv) == 6:
+    # Legacy mode: password as command-line argument
+    host = sys.argv[1]
+    port = sys.argv[2]
+    username = sys.argv[3]
+    password = sys.argv[4]
+    commands = sys.argv[5].split(';')
+else:
+    print("Usage: " + sys.argv[0] + " host port username commands")
+    print("  Password is read from the SCORING_PASSWORD environment variable.")
+    print("  Legacy: " + sys.argv[0] + " host port username password commands")
+    print("  commands parameter supports multiple commands, use ';' as the delimeter")
+    sys.exit(1)
 
 
 def connect_and_execute(host, port, username, password, command):
+    client = None
     try:
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         client.connect(
             hostname=host,
-            port=port,
+            port=int(port),
             username=username,
             password=password,
-            look_for_keys=False
+            look_for_keys=False,
+            allow_agent=False,
+            timeout=15
         )
         client_stdin, client_stdout, client_stderr = client.exec_command(command)
         stdout_output = client_stdout.readlines()
         stderr_output = client_stderr.readlines()
-        client.close()
         return ''.join(stdout_output), ''.join(stderr_output)
-    except Exception as e:
-        print(e)
+    except paramiko.AuthenticationException as e:
+        print(f"{ERROR_AUTH_FAILED} '{username}': {e}")
         sys.exit(1)
+    except paramiko.SSHException as e:
+        error_str = str(e).lower()
+        if 'no existing session' in error_str or 'error reading ssh protocol banner' in error_str:
+            print(f"{ERROR_CONNECTION_REFUSED} {e}")
+        else:
+            print(f"{ERROR_SSH_ERROR} {e}")
+        sys.exit(1)
+    except socket.timeout as e:
+        print(f"{ERROR_CONNECTION_TIMEOUT} {e}")
+        sys.exit(1)
+    except socket.gaierror as e:
+        print(f"{ERROR_HOST_UNREACHABLE} '{host}': {e}")
+        sys.exit(1)
+    except ConnectionRefusedError as e:
+        print(f"{ERROR_CONNECTION_REFUSED} {e}")
+        sys.exit(1)
+    except OSError as e:
+        error_str = str(e).lower()
+        if 'no route to host' in error_str or 'network is unreachable' in error_str:
+            print(f"{ERROR_HOST_UNREACHABLE} '{host}': {e}")
+        elif 'connection refused' in error_str:
+            print(f"{ERROR_CONNECTION_REFUSED} {e}")
+        elif 'timed out' in error_str:
+            print(f"{ERROR_CONNECTION_TIMEOUT} {e}")
+        else:
+            print(f"{ERROR_SSH_ERROR} {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"{ERROR_SSH_ERROR} Unexpected error: {e}")
+        sys.exit(1)
+    finally:
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                pass
 
 last_command_output = ""
 for command in commands:
     command_stdout, command_stderr = connect_and_execute(host, port, username, password, command)
     if command_stderr:
-        print("ERROR: Command ran unsuccessfully: " + str(command))
+        print(f"{ERROR_COMMAND_FAILED} Command ran unsuccessfully: {command}")
         print(command_stderr)
         sys.exit(1)
     last_command_output = command_stdout.rstrip()
 
 print("SUCCESS")
 print(last_command_output)
+

--- a/scoring_engine/checks/ssh.py
+++ b/scoring_engine/checks/ssh.py
@@ -3,14 +3,19 @@ from scoring_engine.engine.basic_check import BasicCheck, CHECKS_BIN_PATH
 
 class SSHCheck(BasicCheck):
     required_properties = ['commands']
-    CMD = CHECKS_BIN_PATH + '/ssh_check {0} {1} {2} {3} {4}'
+    CMD = CHECKS_BIN_PATH + '/ssh_check {0} {1} {2} {3}'
 
     def command_format(self, properties):
         account = self.get_random_account()
+        self._current_account = account
         return (
             self.host,
             self.port,
             account.username,
-            account.password,
             properties['commands']
         )
+
+    def command_env(self):
+        if hasattr(self, '_current_account'):
+            return {'SCORING_PASSWORD': self._current_account.password}
+        return {}

--- a/scoring_engine/db.py
+++ b/scoring_engine/db.py
@@ -8,7 +8,20 @@ db = SQLAlchemy()
 
 def delete_db():
     """Drop all database tables"""
+    dialect = db.engine.dialect.name
+    with db.engine.connect() as conn:
+        if dialect == "mysql":
+            conn.execute(db.text("SET FOREIGN_KEY_CHECKS = 0"))
+        elif dialect == "sqlite":
+            conn.execute(db.text("PRAGMA foreign_keys = OFF"))
+        conn.commit()
     db.drop_all()
+    with db.engine.connect() as conn:
+        if dialect == "mysql":
+            conn.execute(db.text("SET FOREIGN_KEY_CHECKS = 1"))
+        elif dialect == "sqlite":
+            conn.execute(db.text("PRAGMA foreign_keys = ON"))
+        conn.commit()
 
 
 def init_db():

--- a/scoring_engine/engine/basic_check.py
+++ b/scoring_engine/engine/basic_check.py
@@ -45,5 +45,14 @@ class BasicCheck(object):
         cmd = self.CMD.format(*sanitized_args)
         return cmd
 
+    def command_env(self):
+        """Return a dict of environment variables to pass to the subprocess.
+
+        Override in subclasses to pass sensitive data (e.g. passwords) via
+        environment variables instead of command-line arguments. This avoids
+        shell interpretation issues with special characters.
+        """
+        return {}
+
     def get_random_account(self):
         return random.choice(self.environment.service.accounts)

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -194,7 +194,8 @@ class Engine(object):
                 environment = random.choice(service.environments)
                 check_obj = check_class(environment)
                 command_str = check_obj.command()
-                job = Job(environment_id=environment.id, command=command_str)
+                env_vars = check_obj.command_env()
+                job = Job(environment_id=environment.id, command=command_str, env=env_vars)
                 countdown = random.uniform(0, jitter_max) if jitter_max > 0 else 0
                 task = execute_command.apply_async(args=[job], queue=service.worker_queue, countdown=countdown)
                 team_name = environment.service.team.name

--- a/scoring_engine/models/user.py
+++ b/scoring_engine/models/user.py
@@ -51,10 +51,7 @@ class User(Base, UserMixin):
         return self.username
 
     def check_password(self, password):
-        # this is due to some weird bug between rusty and I
-        # where his env was returning a str, and mine were bytes
-        if isinstance(password, str):
-            password = password.encode("utf-8")
+        password = password.encode("utf-8")[:72]
         return bcrypt.checkpw(password, self.password.encode("utf-8"))
 
     def update_password(self, password):
@@ -68,10 +65,7 @@ class User(Base, UserMixin):
         elif isinstance(salt, str):
             salt = salt.encode("utf-8")
 
-        # this is due to some weird bug between rusty and I
-        # where his env was returning a str, and mine were bytes
-        if isinstance(password, str):
-            password = password.encode("utf-8")
+        password = password.encode("utf-8")[:72]
         return bcrypt.hashpw(password, salt).decode("utf-8")
 
     def get_id(self):

--- a/scoring_engine/web/views/api/flags.py
+++ b/scoring_engine/web/views/api/flags.py
@@ -1,16 +1,16 @@
+from datetime import datetime, timedelta, timezone
+
 from flask import jsonify
 from flask_login import current_user, login_required
-from sqlalchemy import func, case
+from sqlalchemy import case, func
 from sqlalchemy.sql.expression import and_, or_
 
 from scoring_engine.cache import cache
 from scoring_engine.db import db
+from scoring_engine.models.flag import Flag, Perm, Platform, Solve
 from scoring_engine.models.service import Service
-from scoring_engine.models.team import Team
-from scoring_engine.models.flag import Flag, Solve
 from scoring_engine.models.setting import Setting
-
-from datetime import datetime, timedelta, timezone
+from scoring_engine.models.team import Team
 
 from . import make_cache_key, mod
 
@@ -27,7 +27,10 @@ def api_flags():
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     early = now + timedelta(minutes=int(Setting.get_setting("agent_show_flag_early_mins").value))
     flags = (
-        db.session.query(Flag).filter(and_(early > Flag.start_time, now < Flag.end_time, Flag.dummy == False)).order_by(Flag.start_time).all()
+        db.session.query(Flag)
+        .filter(and_(early > Flag.start_time, now < Flag.end_time, Flag.dummy == False))
+        .order_by(Flag.start_time)
+        .all()
     )
 
     # Serialize flags and include localized times
@@ -58,11 +61,38 @@ def api_flags_solves():
     # Get all flags and teams
     # Use naive UTC time for SQLAlchemy filter comparison (databases may not support timezones)
     now = datetime.now(timezone.utc).replace(tzinfo=None)
-    active_flags = db.session.query(Flag).filter(and_(now > Flag.start_time, now < Flag.end_time, Flag.dummy == False)).order_by(Flag.start_time).all()
+    active_flags = (
+        db.session.query(Flag)
+        .filter(and_(now > Flag.start_time, now < Flag.end_time, Flag.dummy == False))
+        .order_by(Flag.start_time)
+        .all()
+    )
     active_flag_ids = [flag.id for flag in active_flags]
 
     # Flag Solve Status
-    all_hosts = db.session.query(Service.name.label("service_name"), Service.port, Service.team_id, Service.host, Team.name.label("team_name"), func.coalesce(Solve.id, None).label("solve_id"), func.coalesce(Flag.id, None).label("flag_id"), func.coalesce(Flag.perm, None).label("flag_perm"), func.coalesce(Flag.platform, None).label("flag_platform")).select_from(Service).filter(Service.check_name == "AgentCheck").outerjoin(Solve, and_(Solve.host == Service.host, Solve.team_id == Service.team_id, Solve.flag_id.in_(active_flag_ids))).outerjoin(Flag, Flag.id == Solve.flag_id).outerjoin(Team, Team.id == Service.team_id).order_by(Service.name, Service.team_id).all()
+    all_hosts = (
+        db.session.query(
+            Service.name.label("service_name"),
+            Service.port,
+            Service.team_id,
+            Service.host,
+            Team.name.label("team_name"),
+            func.coalesce(Solve.id, None).label("solve_id"),
+            func.coalesce(Flag.id, None).label("flag_id"),
+            func.coalesce(Flag.perm, None).label("flag_perm"),
+            func.coalesce(Flag.platform, None).label("flag_platform"),
+        )
+        .select_from(Service)
+        .filter(Service.check_name == "AgentCheck")
+        .outerjoin(
+            Solve,
+            and_(Solve.host == Service.host, Solve.team_id == Service.team_id, Solve.flag_id.in_(active_flag_ids)),
+        )
+        .outerjoin(Flag, Flag.id == Solve.flag_id)
+        .outerjoin(Team, Team.id == Service.team_id)
+        .order_by(Service.name, Service.team_id)
+        .all()
+    )
 
     data = {}
     rows = []
@@ -89,6 +119,7 @@ def api_flags_solves():
 
     return jsonify(data={"columns": columns, "rows": rows})
 
+
 @mod.route("/api/flags/totals")
 @login_required
 @cache.cached(make_cache_key=make_cache_key)
@@ -96,52 +127,62 @@ def api_flags_totals():
     if not current_user.is_red_team and not current_user.is_white_team:
         return jsonify({"status": "Unauthorized"}), 403
 
-    # Initialize totals for all blue teams: {team_name: [team_name, win_score, nix_score]}
-    totals = {}
+    totals = {}  # [ Team0, Win Score, Nix Score ]
     blue_teams = db.session.query(Team).filter(Team.color == "Blue").order_by(Team.id).all()
-    team_id_to_name = {}
     for blue_team in blue_teams:
-        totals[blue_team.name] = [blue_team.name, 0.0, 0.0]
-        team_id_to_name[blue_team.id] = blue_team.name
+        totals[blue_team.name] = [blue_team.name, 0, 0]
 
-    # Fetch all solves with their flags in one query
-    solves = (
-        db.session.query(Solve.team_id, Solve.host, Flag.platform, Flag.perm)
-        .join(Flag, Flag.id == Solve.flag_id)
-        .all()
-    )
+    for platform_enum in [Platform.windows, Platform.nix]:
+        # Subquery 1: Determine permission level per (team, host, start_time)
+        # If root perm exists in the group, level is "root"; otherwise "user"
+        subquery1 = (
+            db.session.query(
+                Solve.team_id,
+                Solve.host,
+                case(
+                    (func.max(case((Flag.perm == Perm.root, 1), else_=0)) == 1, "root"),
+                    else_="user",
+                ).label("level"),
+            )
+            .join(Flag, Flag.id == Solve.flag_id)
+            .filter(Flag.platform == platform_enum)
+            .group_by(Solve.team_id, Flag.platform, Solve.host, Flag.start_time)
+            .subquery()
+        )
 
-    # Group solves by (team_id, host, platform) and track permission levels
-    # Key: (team_id, host, platform) -> set of perms ('user', 'root')
-    solve_perms = {}
-    for solve in solves:
-        key = (solve.team_id, solve.host, solve.platform.value if hasattr(solve.platform, 'value') else solve.platform)
-        if key not in solve_perms:
-            solve_perms[key] = set()
-        perm_value = solve.perm.value if hasattr(solve.perm, 'value') else solve.perm
-        solve_perms[key].add(perm_value)
+        # Subquery 2: Compute red_amt based on level
+        subquery2 = (
+            db.session.query(
+                (subquery1.c.team_id).label("BlueTeamId"),
+                case(
+                    (subquery1.c.level == "user", 0.5 * func.count()),
+                    else_=1 * func.count(),
+                ).label("red_amt"),
+            )
+            .group_by(subquery1.c.team_id, subquery1.c.level)
+            .order_by(subquery1.c.team_id, subquery1.c.level.desc())
+            .subquery()
+        )
 
-    # Calculate scores
-    # If both user and root: count as root (1 point)
-    # If only root: 1 point
-    # If only user: 0.5 points
-    for (team_id, host, platform), perms in solve_perms.items():
-        team_name = team_id_to_name.get(team_id)
-        if not team_name:
-            continue
+        # Final Query: Sum red_amt per BlueTeamId
+        final_query = (
+            db.session.query(
+                Team.name.label("BlueTeam"),
+                func.sum(subquery2.c.red_amt).label("RedScore"),
+            )
+            .join(Team, subquery2.c.BlueTeamId == Team.id)
+            .group_by(subquery2.c.BlueTeamId)
+            .order_by(func.sum(subquery2.c.red_amt))
+        )
 
-        if "root" in perms:
-            score = 1.0
-        elif "user" in perms:
-            score = 0.5
-        else:
-            score = 0.0
+        # Execute Query
+        results = final_query.all()
 
-        # Add to appropriate platform score
-        if platform == "win":
-            totals[team_name][1] += score
-        elif platform == "nix":
-            totals[team_name][2] += score
+        for row in results:
+            if platform_enum == Platform.windows:
+                totals[row.BlueTeam][1] = row.RedScore
+            elif platform_enum == Platform.nix:
+                totals[row.BlueTeam][2] = row.RedScore
 
     data = []
     for team in totals.values():

--- a/scoring_engine/web/views/api/profile.py
+++ b/scoring_engine/web/views/api/profile.py
@@ -18,6 +18,10 @@ def profile_update_password():
         if not current_user.check_password(request.form['currentpassword']):
             flash('Invalid Password.', 'danger')
             return redirect(url_for('profile.home'))
+        # Ensure new password is not too long for bcrypt
+        if len(request.form['password'].encode("utf-8")) > 72:
+            flash('Password must be 72 bytes or fewer.', 'danger')
+            return redirect(url_for('profile.home'))
         # Ensure new passwords match
         if request.form['password'] != request.form['confirmedpassword']:
             flash('Passwords do not match.', 'danger')

--- a/scoring_engine/web/views/auth.py
+++ b/scoring_engine/web/views/auth.py
@@ -68,6 +68,10 @@ def login():
         username = request.form.get("username")
         password = request.form.get("password")
 
+        if len(password.encode("utf-8")) > 72:
+            flash("Password must be 72 bytes or fewer.", "danger")
+            return render_template("login.html", form=form)
+
         try:
             user = db.session.query(User).filter(User.username == username).one()
         except NoResultFound:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 # codeclimate-test-reporter==0.2.1  # Deprecated and not maintained. Switch to coverage directly for local reports or GitHub Actions.
 bump-my-version==1.2.6
-coverage==7.6.10
+coverage==7.13.4
 coveralls==4.0.2
 flake8==7.3.0
 mock==5.2.0  # The mock package is built into the Python standard library since Python 3.3 (unittest.mock).

--- a/tests/scoring_engine/checks/check_test.py
+++ b/tests/scoring_engine/checks/check_test.py
@@ -27,3 +27,5 @@ class CheckTest(UnitTest):
 
         check_obj = engine.check_name_to_obj(self.check_name)(environment)
         assert check_obj.command() == self.cmd
+        if hasattr(self, 'cmd_env'):
+            assert check_obj.command_env() == self.cmd_env

--- a/tests/scoring_engine/checks/test_ssh.py
+++ b/tests/scoring_engine/checks/test_ssh.py
@@ -7,4 +7,53 @@ class TestSSHCheck(CheckTest):
     check_name = "SSHCheck"
     properties = {"commands": "ls -l;id"}
     accounts = {"pwnbus": "pwnbuspass"}
-    cmd = CHECKS_BIN_PATH + "/ssh_check 127.0.0.1 1234 pwnbus pwnbuspass 'ls -l;id'"
+    cmd = CHECKS_BIN_PATH + "/ssh_check 127.0.0.1 1234 pwnbus 'ls -l;id'"
+    cmd_env = {"SCORING_PASSWORD": "pwnbuspass"}
+
+
+class TestSSHCheckWithSingleQuotePassword(CheckTest):
+    check_name = "SSHCheck"
+    properties = {"commands": "whoami"}
+    accounts = {"admin": "pass'word"}
+    cmd = CHECKS_BIN_PATH + "/ssh_check 127.0.0.1 1234 admin whoami"
+    cmd_env = {"SCORING_PASSWORD": "pass'word"}
+
+
+class TestSSHCheckWithDoubleQuotePassword(CheckTest):
+    check_name = "SSHCheck"
+    properties = {"commands": "id"}
+    accounts = {"admin": 'pass"word'}
+    cmd = CHECKS_BIN_PATH + "/ssh_check 127.0.0.1 1234 admin id"
+    cmd_env = {"SCORING_PASSWORD": 'pass"word'}
+
+
+class TestSSHCheckWithBackslashPassword(CheckTest):
+    check_name = "SSHCheck"
+    properties = {"commands": "ls"}
+    accounts = {"admin": "pass\\word"}
+    cmd = CHECKS_BIN_PATH + "/ssh_check 127.0.0.1 1234 admin ls"
+    cmd_env = {"SCORING_PASSWORD": "pass\\word"}
+
+
+class TestSSHCheckWithSpacesInPassword(CheckTest):
+    check_name = "SSHCheck"
+    properties = {"commands": "pwd"}
+    accounts = {"admin": "my secure password"}
+    cmd = CHECKS_BIN_PATH + "/ssh_check 127.0.0.1 1234 admin pwd"
+    cmd_env = {"SCORING_PASSWORD": "my secure password"}
+
+
+class TestSSHCheckWithSpecialCharsPassword(CheckTest):
+    check_name = "SSHCheck"
+    properties = {"commands": "echo test"}
+    accounts = {"admin": "p@ss$word!&|;"}
+    cmd = CHECKS_BIN_PATH + "/ssh_check 127.0.0.1 1234 admin 'echo test'"
+    cmd_env = {"SCORING_PASSWORD": "p@ss$word!&|;"}
+
+
+class TestSSHCheckWithSpecialCharsUsername(CheckTest):
+    check_name = "SSHCheck"
+    properties = {"commands": "id"}
+    accounts = {"user@domain.com": "password123"}
+    cmd = CHECKS_BIN_PATH + "/ssh_check 127.0.0.1 1234 user@domain.com id"
+    cmd_env = {"SCORING_PASSWORD": "password123"}

--- a/tests/scoring_engine/engine/test_basic_check.py
+++ b/tests/scoring_engine/engine/test_basic_check.py
@@ -40,3 +40,7 @@ class TestBasicCheck(UnitTest):
         check.required_properties = ['testparam']
         with pytest.raises(LookupError):
             check.set_properties()
+
+    def test_command_env_default_empty(self):
+        check = BasicCheck(self.environment)
+        assert check.command_env() == {}

--- a/tests/scoring_engine/engine/test_execute_command.py
+++ b/tests/scoring_engine/engine/test_execute_command.py
@@ -14,10 +14,45 @@ class TestWorker(object):
         assert task['errored_out'] is False
         assert task['output'] == 'HELLO\n'
 
-    def test_timed_out(self):
-        import subprocess
-        subprocess.run = mock.Mock(side_effect=SoftTimeLimitExceeded)
-
+    @mock.patch('subprocess.run', side_effect=SoftTimeLimitExceeded)
+    def test_timed_out(self, mock_subprocess_run):
         job = Job(environment_id="12345", command="echo 'HELLO'")
         task = execute_command.run(job)
         assert task['errored_out'] is True
+
+    def test_env_vars_passed_to_subprocess(self):
+        job = Job(
+            environment_id="12345",
+            command='python -c "import os; print(os.environ.get(\'SCORING_PASSWORD\', \'\'), end=\'\')"',
+            env={"SCORING_PASSWORD": "p@ss_w0rd"}
+        )
+        task = execute_command.run(job)
+        assert task['errored_out'] is False
+        assert task['output'] == "p@ss_w0rd"
+
+    def test_env_vars_special_chars(self):
+        """Verify passwords with shell-dangerous characters survive via env var."""
+        special_passwords = [
+            "pass'word",
+            'pass"word',
+            "pass\\word",
+            "p@ss$word!&|;",
+            "pass word with spaces",
+            "p!a#s%s^w&o*r(d)",
+        ]
+        for password in special_passwords:
+            job = Job(
+                environment_id="12345",
+                command='python -c "import os, sys; sys.stdout.write(os.environ[\'SCORING_PASSWORD\'])"',
+                env={"SCORING_PASSWORD": password}
+            )
+            task = execute_command.run(job)
+            assert task['errored_out'] is False, f"Failed for password: {password}"
+            assert task['output'] == password, f"Mismatch for password: {password!r}, got: {task['output']!r}"
+
+    def test_no_env_vars(self):
+        """Ensure jobs without env still work (backward compatibility)."""
+        job = Job(environment_id="12345", command='python -c "print(\'OK\', end=\'\')"')
+        task = execute_command.run(job)
+        assert task['errored_out'] is False
+        assert task['output'] == "OK"

--- a/tests/scoring_engine/web/views/api/test_flags_api.py
+++ b/tests/scoring_engine/web/views/api/test_flags_api.py
@@ -1,7 +1,6 @@
 """Comprehensive tests for Flags API endpoints including complex SQL queries"""
-from datetime import datetime, timedelta, timezone
 
-import pytest
+from datetime import datetime, timedelta, timezone
 
 from scoring_engine.models.flag import Flag, FlagTypeEnum, Perm, Platform, Solve
 from scoring_engine.models.service import Service
@@ -108,21 +107,18 @@ class TestFlagsAPI(UnitTest):
         resp = self.client.get("/api/flags/totals")
         assert resp.status_code == 302
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_red_team_authorized(self):
         """Test that red team can access totals"""
         self.login("reduser", "pass")
         resp = self.client.get("/api/flags/totals")
         assert resp.status_code == 200
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_white_team_authorized(self):
         """Test that white team can access totals"""
         self.login("whiteuser", "pass")
         resp = self.client.get("/api/flags/totals")
         assert resp.status_code == 200
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_blue_team_unauthorized(self):
         """Test that blue team cannot access totals"""
         self.login("blueuser1", "pass")
@@ -140,7 +136,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/tmp/past", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=2),
             end_time=datetime.now(timezone.utc) - timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create current flag (should be shown)
@@ -151,7 +147,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/tmp/current", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(minutes=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create future flag (should be shown based on early window)
@@ -162,7 +158,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/tmp/future", "content": "test"},
             start_time=datetime.now(timezone.utc) + timedelta(minutes=2),
             end_time=datetime.now(timezone.utc) + timedelta(hours=2),
-            dummy=False
+            dummy=False,
         )
 
         self.session.add_all([past_flag, current_flag, future_flag])
@@ -188,7 +184,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/tmp/real", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create dummy flag
@@ -199,7 +195,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/tmp/dummy", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=True
+            dummy=True,
         )
 
         self.session.add_all([real_flag, dummy_flag])
@@ -223,7 +219,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create Linux flag
@@ -234,7 +230,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/etc/test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         self.session.add_all([win_flag, nix_flag])
@@ -258,7 +254,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create root-level flag
@@ -269,7 +265,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\admin", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         self.session.add_all([user_flag, root_flag])
@@ -287,20 +283,8 @@ class TestFlagsAPI(UnitTest):
     def test_api_flags_solves_with_no_solves(self):
         """Test that solves endpoint works with no solves"""
         # Create services
-        service1 = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
-        service2 = Service(
-            name="Host2",
-            check_name="AgentCheck",
-            host="192.168.1.20",
-            team=self.blue_team2,
-            port=0
-        )
+        service1 = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+        service2 = Service(name="Host2", check_name="AgentCheck", host="192.168.1.20", team=self.blue_team2, port=0)
 
         self.session.add_all([service1, service2])
         self.session.commit()
@@ -316,20 +300,8 @@ class TestFlagsAPI(UnitTest):
     def test_api_flags_solves_shows_solve_status(self):
         """Test that solve status is correctly shown"""
         # Create services
-        service1 = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
-        service2 = Service(
-            name="Host2",
-            check_name="AgentCheck",
-            host="192.168.1.20",
-            team=self.blue_team2,
-            port=0
-        )
+        service1 = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+        service2 = Service(name="Host2", check_name="AgentCheck", host="192.168.1.20", team=self.blue_team2, port=0)
 
         # Create flag
         flag = Flag(
@@ -339,18 +311,14 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         self.session.add_all([service1, service2, flag])
         self.session.flush()
 
         # Create solve for team1
-        solve = Solve(
-            host="192.168.1.10",
-            team_id=self.blue_team1.id,
-            flag_id=flag.id
-        )
+        solve = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=flag.id)
 
         self.session.add(solve)
         self.session.commit()
@@ -363,7 +331,6 @@ class TestFlagsAPI(UnitTest):
         assert len(data["rows"]) >= 1
 
     # Totals Tests (Complex SQL)
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_empty(self):
         """Test totals with no flags or solves"""
         self.login("reduser", "pass")
@@ -381,17 +348,10 @@ class TestFlagsAPI(UnitTest):
             assert entry["nix_score"] == 0
             assert entry["total_score"] == 0
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_user_level_scoring(self):
         """Test that user-level flags count as 0.5"""
         # Create service
-        service = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
+        service = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
 
         # Create Windows user flag
         flag = Flag(
@@ -401,17 +361,16 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
+
+        self.session.add_all([service, flag])
+        self.session.flush()
 
         # Create solve
-        solve = Solve(
-            host="192.168.1.10",
-            team_id=self.blue_team1.id,
-            flag_id=flag.id
-        )
+        solve = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=flag.id)
 
-        self.session.add_all([service, flag, solve])
+        self.session.add(solve)
         self.session.commit()
 
         self.login("reduser", "pass")
@@ -426,17 +385,10 @@ class TestFlagsAPI(UnitTest):
         assert team1_entry["nix_score"] == 0
         assert team1_entry["total_score"] == 0.5
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_root_level_scoring(self):
         """Test that root-level flags count as 1"""
         # Create service
-        service = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
+        service = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
 
         # Create Linux root flag
         flag = Flag(
@@ -446,17 +398,16 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/etc/test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
+
+        self.session.add_all([service, flag])
+        self.session.flush()
 
         # Create solve
-        solve = Solve(
-            host="192.168.1.10",
-            team_id=self.blue_team1.id,
-            flag_id=flag.id
-        )
+        solve = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=flag.id)
 
-        self.session.add_all([service, flag, solve])
+        self.session.add(solve)
         self.session.commit()
 
         self.login("reduser", "pass")
@@ -471,17 +422,14 @@ class TestFlagsAPI(UnitTest):
         assert team1_entry["win_score"] == 0
         assert team1_entry["total_score"] == 1
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_user_and_root_scoring(self):
-        """Test that user + root on same host counts as root (1.0)"""
+        """Test that user + root on same host in same round counts as root (1.0)"""
         # Create service
-        service = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
+        service = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+
+        # Both flags share the same start_time (same flag round)
+        round_start = datetime.now(timezone.utc) - timedelta(hours=1)
+        round_end = datetime.now(timezone.utc) + timedelta(hours=1)
 
         # Create Windows user flag
         user_flag = Flag(
@@ -489,9 +437,9 @@ class TestFlagsAPI(UnitTest):
             platform=Platform.windows,
             perm=Perm.user,
             data={"path": "C:\\user", "content": "test"},
-            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
-            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            start_time=round_start,
+            end_time=round_end,
+            dummy=False,
         )
 
         # Create Windows root flag
@@ -500,24 +448,19 @@ class TestFlagsAPI(UnitTest):
             platform=Platform.windows,
             perm=Perm.root,
             data={"path": "C:\\admin", "content": "test"},
-            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
-            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            start_time=round_start,
+            end_time=round_end,
+            dummy=False,
         )
+
+        self.session.add_all([service, user_flag, root_flag])
+        self.session.flush()
 
         # Create solves for both
-        solve_user = Solve(
-            host="192.168.1.10",
-            team_id=self.blue_team1.id,
-            flag_id=user_flag.id
-        )
-        solve_root = Solve(
-            host="192.168.1.10",
-            team_id=self.blue_team1.id,
-            flag_id=root_flag.id
-        )
+        solve_user = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=user_flag.id)
+        solve_root = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=root_flag.id)
 
-        self.session.add_all([service, user_flag, root_flag, solve_user, solve_root])
+        self.session.add_all([solve_user, solve_root])
         self.session.commit()
 
         self.login("reduser", "pass")
@@ -531,24 +474,11 @@ class TestFlagsAPI(UnitTest):
         assert team1_entry["win_score"] == 1
         assert team1_entry["total_score"] == 1
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_multiple_hosts(self):
         """Test scoring across multiple hosts"""
         # Create services
-        service1 = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
-        service2 = Service(
-            name="Host2",
-            check_name="AgentCheck",
-            host="192.168.1.20",
-            team=self.blue_team1,
-            port=0
-        )
+        service1 = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+        service2 = Service(name="Host2", check_name="AgentCheck", host="192.168.1.20", team=self.blue_team1, port=0)
 
         # Create flags
         flag1 = Flag(
@@ -558,7 +488,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test1", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
         flag2 = Flag(
             type=FlagTypeEnum.file,
@@ -567,14 +497,17 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test2", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
+
+        self.session.add_all([service1, service2, flag1, flag2])
+        self.session.flush()
 
         # Create solves
         solve1 = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=flag1.id)
         solve2 = Solve(host="192.168.1.20", team_id=self.blue_team1.id, flag_id=flag2.id)
 
-        self.session.add_all([service1, service2, flag1, flag2, solve1, solve2])
+        self.session.add_all([solve1, solve2])
         self.session.commit()
 
         self.login("reduser", "pass")
@@ -588,17 +521,11 @@ class TestFlagsAPI(UnitTest):
         assert team1_entry["win_score"] == 2
         assert team1_entry["total_score"] == 2
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
     def test_api_flags_totals_mixed_platforms(self):
-        """Test scoring with both Windows and Linux flags"""
-        # Create service
-        service = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
+        """Test scoring with both Windows and Linux flags on separate services"""
+        # Create separate services per platform (port=0 is Windows, port=1 is Linux)
+        win_service = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+        nix_service = Service(name="Host2", check_name="AgentCheck", host="192.168.1.20", team=self.blue_team1, port=1)
 
         # Create Windows flag
         win_flag = Flag(
@@ -608,7 +535,7 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
         # Create Linux flag
@@ -619,14 +546,17 @@ class TestFlagsAPI(UnitTest):
             data={"path": "/etc/test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
 
-        # Create solves
-        solve_win = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=win_flag.id)
-        solve_nix = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=nix_flag.id)
+        self.session.add_all([win_service, nix_service, win_flag, nix_flag])
+        self.session.flush()
 
-        self.session.add_all([service, win_flag, nix_flag, solve_win, solve_nix])
+        # Create solves on respective hosts
+        solve_win = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=win_flag.id)
+        solve_nix = Solve(host="192.168.1.20", team_id=self.blue_team1.id, flag_id=nix_flag.id)
+
+        self.session.add_all([solve_win, solve_nix])
         self.session.commit()
 
         self.login("reduser", "pass")
@@ -641,24 +571,85 @@ class TestFlagsAPI(UnitTest):
         assert team1_entry["nix_score"] == 1
         assert team1_entry["total_score"] == 2
 
-    @pytest.mark.skip(reason="Requires MySQL - uses MySQL-specific IF() function")
+    def test_api_flags_totals_multiple_rounds_same_host(self):
+        """Test scoring across multiple flag rounds (different start/end times) for the same host"""
+        service = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+
+        # Round 1: user-level flag
+        round1_flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.windows,
+            perm=Perm.user,
+            data={"path": "C:\\round1", "content": "test"},
+            start_time=datetime.now(timezone.utc) - timedelta(hours=3),
+            end_time=datetime.now(timezone.utc) - timedelta(hours=2),
+            dummy=False,
+        )
+
+        # Round 2: root-level flag (different time window)
+        round2_flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.windows,
+            perm=Perm.root,
+            data={"path": "C:\\round2", "content": "test"},
+            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
+            dummy=False,
+        )
+
+        # Round 3: user + root flags in the same round
+        round3_start = datetime.now(timezone.utc) + timedelta(hours=1)
+        round3_end = datetime.now(timezone.utc) + timedelta(hours=2)
+        round3_user_flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.windows,
+            perm=Perm.user,
+            data={"path": "C:\\round3_user", "content": "test"},
+            start_time=round3_start,
+            end_time=round3_end,
+            dummy=False,
+        )
+        round3_root_flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.windows,
+            perm=Perm.root,
+            data={"path": "C:\\round3_root", "content": "test"},
+            start_time=round3_start,
+            end_time=round3_end,
+            dummy=False,
+        )
+
+        self.session.add_all([service, round1_flag, round2_flag, round3_user_flag, round3_root_flag])
+        self.session.flush()
+
+        # Solves for all flags on the same host
+        solve1 = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=round1_flag.id)
+        solve2 = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=round2_flag.id)
+        solve3_user = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=round3_user_flag.id)
+        solve3_root = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=round3_root_flag.id)
+
+        self.session.add_all([solve1, solve2, solve3_user, solve3_root])
+        self.session.commit()
+
+        self.login("reduser", "pass")
+        resp = self.client.get("/api/flags/totals")
+        data = resp.json["data"]
+
+        team1_entry = next(e for e in data if e["team"] == "Blue Team 1")
+
+        # Round 1: user only = 0.5
+        # Round 2: root only = 1.0
+        # Round 3: user + root (same start_time) = 1.0 (root subsumes user)
+        # Total: 0.5 + 1.0 + 1.0 = 2.5
+        assert team1_entry["win_score"] == 2.5
+        assert team1_entry["nix_score"] == 0
+        assert team1_entry["total_score"] == 2.5
+
     def test_api_flags_totals_multiple_teams(self):
         """Test that each team's score is calculated independently"""
         # Create services for both teams
-        service1 = Service(
-            name="Host1",
-            check_name="AgentCheck",
-            host="192.168.1.10",
-            team=self.blue_team1,
-            port=0
-        )
-        service2 = Service(
-            name="Host2",
-            check_name="AgentCheck",
-            host="192.168.1.20",
-            team=self.blue_team2,
-            port=0
-        )
+        service1 = Service(name="Host1", check_name="AgentCheck", host="192.168.1.10", team=self.blue_team1, port=0)
+        service2 = Service(name="Host2", check_name="AgentCheck", host="192.168.1.20", team=self.blue_team2, port=0)
 
         # Create flag
         flag = Flag(
@@ -668,13 +659,16 @@ class TestFlagsAPI(UnitTest):
             data={"path": "C:\\test", "content": "test"},
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1),
-            dummy=False
+            dummy=False,
         )
+
+        self.session.add_all([service1, service2, flag])
+        self.session.flush()
 
         # Only team1 solves
         solve1 = Solve(host="192.168.1.10", team_id=self.blue_team1.id, flag_id=flag.id)
 
-        self.session.add_all([service1, service2, flag, solve1])
+        self.session.add(solve1)
         self.session.commit()
 
         self.login("reduser", "pass")


### PR DESCRIPTION
Summary
Fixes #581 — SSH checks fail when passwords contain special characters. Moves the password out of the command string and into an environment variable (`SCORING_PASSWORD`). The `ssh_check` binary reads the password from the environment instead of `sys.argv`.

Changes:
- `scoring_engine/checks/ssh.py` — password removed from CLI args; new `command_env()` method returns `{'SCORING_PASSWORD': password}`
- `scoring_engine/engine/basic_check.py` — adds `command_env()` base method (returns `{}`) for all checks to optionally override
- `scoring_engine/engine/engine.py` — passes `env_vars` from `command_env()` to the Job
- `scoring_engine/engine/execute_command.py` — merges job env vars into subprocess environment
- `scoring_engine/checks/bin/ssh_check` — supports both new (env var) and legacy (CLI arg) modes for backwards compatibility
- `docs/source/create_new_check.rst` — updated to document the `command_env()` pattern
- Tests updated with full coverage of edge cases (single quotes, double quotes, backslash, spaces, special chars)