### PR TITLE
Fix nightly CI failures caused by coveralls.io outage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: "3.13"
           cache: "pip"
-          cache-dependency-paths: |
+          cache-dependency-path: |
             pyproject.toml
             tests/requirements.txt
 
@@ -33,6 +33,7 @@ jobs:
 
       - name: Upload coverage data to coveralls.io
         run: coveralls --service=github
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the coveralls upload step so third-party service outages don't fail the build (coveralls.io has been returning 503s since ~Feb 24)
- Fix `cache-dependency-paths` → `cache-dependency-path` (singular) to match the renamed input in `actions/setup-python@v5`

## Test plan
- [ ] Verify the Tests workflow passes on this PR (the coveralls step should show as a warning instead of failing the job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)