### PR TITLE
Fix CI test failures: coveralls, test hangs, and signal handler bug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: "3.13"
           cache: "pip"
-          cache-dependency-paths: |
+          cache-dependency-path: |
             pyproject.toml
             tests/requirements.txt
 
@@ -33,6 +33,7 @@ jobs:
 
       - name: Upload coverage data to coveralls.io
         run: coveralls --service=github
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,10 @@ jobs:
           pip install -r tests/requirements.txt
 
       - name: Run unit tests
-        run: pytest -v -n auto --cov=scoring_engine tests/
+        run: pytest -v -n auto --cov=scoring_engine --timeout=60 tests/
+        timeout-minutes: 10
+        env:
+          SCORINGENGINE_CACHE_TYPE: "null"
 
       - name: Upload coverage data to coveralls.io
         run: coveralls --service=github

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -53,8 +53,8 @@ class Engine(object):
         self.last_round = False
         self.rounds_run = 0
 
-        signal.signal(signal.SIGINT, partial(engine_sigint_handler, obj=self))
-        signal.signal(signal.SIGTERM, partial(engine_sigint_handler, obj=self))
+        signal.signal(signal.SIGINT, partial(engine_sigint_handler, engine=self))
+        signal.signal(signal.SIGTERM, partial(engine_sigint_handler, engine=self))
 
         self.current_round = Round.get_last_round_num()
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,4 +6,5 @@ flake8==7.3.0
 mock==5.2.0  # The mock package is built into the Python standard library since Python 3.3 (unittest.mock).
 pytest==9.0.2
 pytest-cov==6.1.1
+pytest-timeout==2.3.1
 pytest-xdist==3.8.0


### PR DESCRIPTION
## Summary
- **Coveralls outage resilience**: Add `continue-on-error: true` to the coveralls upload step so external outages don't fail the build
- **Fix unit test hangs in CI**: Set `SCORINGENGINE_CACHE_TYPE=null` in CI to prevent Redis connection attempts to localhost:6379 (nothing listening), which combined with SQLite contention between parallel pytest-xdist workers caused intermittent 3.5-minute test hangs and GitHub Actions runner shutdowns
- **Add test timeouts**: `pytest-timeout` (60s per test) catches hanging tests early; `timeout-minutes: 10` on the step gives clearer failure messages instead of cryptic "runner has received a shutdown signal"
- **Fix engine signal handler bug**: `partial(engine_sigint_handler, obj=self)` passed `obj=` but the function parameter is named `engine`, causing `TypeError` on SIGTERM/SIGINT

## Test plan
- [ ] CI unit tests pass without hangs
- [ ] CI coveralls step no longer fails the build on outages
- [ ] Engine shutdown via SIGINT/SIGTERM works correctly (no TypeError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)