### PR TITLE
feature: improve accessibility across templates and CSS

### DIFF
--- a/scoring_engine/web/static/css/main.css
+++ b/scoring_engine/web/static/css/main.css
@@ -3,7 +3,7 @@ body {
 }
 
 a{
-  color: #430AFF;
+  color: #0000EE;
 }
 
 .navbar {

--- a/scoring_engine/web/static/css/main.css
+++ b/scoring_engine/web/static/css/main.css
@@ -2,6 +2,10 @@ body {
   min-height: 75rem; /* Can be removed; just added for demo purposes */
 }
 
+a{
+  color: #430AFF;
+}
+
 .navbar {
   margin-bottom: 0;
 }
@@ -100,6 +104,85 @@ tr.shown td.details-control {
   text-align:center;
 }
 
+/* DataTables pagination accessibility overrides */
+.dataTables_paginate .pagination > li > :is(a, span) {
+  color: #1f2937;
+}
+
+.dataTables_paginate .pagination > li > a:hover,
+.dataTables_paginate .pagination > li > a:focus {
+  color: #111827;
+}
+
+.dataTables_paginate .pagination > li.disabled > :is(a, span) {
+  color: #6b7280;
+}
+
+.dataTables_paginate .pagination > li.active > :is(a, span) {
+  color: #ffffff;
+  background-color: #0b3e75;
+  border-color: #0b3e75;
+}
+
+/* Services status accessibility overrides */
+:is(#services, #checks, #service_navbar) .label {
+  font-weight: 700;
+  font-size: 0.9em;
+  line-height: 1.2;
+  padding: 0.25em 0.55em;
+}
+
+:is(#services, #checks, #service_navbar) .label-success {
+  color: #ffffff;
+  background-color: #166534;
+}
+
+:is(#services, #checks, #service_navbar) .label-danger {
+  color: #ffffff;
+  background-color: #991b1b;
+}
+
+:is(#services, #checks, #service_navbar) .label-default {
+  color: #ffffff;
+  background-color: #374151;
+}
+
+/* Inject status accessibility overrides */
+.inject-status .label {
+  font-weight: 700;
+  font-size: 0.9em;
+  line-height: 1.2;
+  padding: 0.25em 0.55em;
+}
+
+.inject-status .label-success {
+  color: #ffffff;
+  background-color: #15803d;
+}
+
+.inject-status .label-info {
+  color: #ffffff;
+  background-color: #0369a1;
+}
+
+.inject-status .label-danger {
+  color: #ffffff;
+  background-color: #b91c1c;
+}
+
+.inject-status .label-warning {
+  color: #ffffff;
+  background-color: #92400e;
+}
+
+.status-icon-up {
+  color: #166534;
+}
+
+.status-icon-down {
+  color: #991b1b;
+}
+
 .md-page {
     background: #fff;
     padding: 0px 25px 25px 25px;
@@ -169,6 +252,84 @@ a.editable-click {
 .lefthand-nav {
     width: 20%;
 }
+
+/* Admin Related Overrides */
+.lefthand-nav .list-group-item {
+  color: #1f2937;
+  background-color: #ffffff;
+}
+
+.lefthand-nav .list-group-item:is(:hover, :focus) {
+  color: #0b3e75;
+  background-color: #eaf2fb;
+}
+
+.lefthand-nav .list-group-item.active:is(:hover, :focus),
+.lefthand-nav .list-group-item.active {
+  color: #0b3e75;
+  background-color: #dbeafe;
+  border-color: #93c5fd;
+  font-weight: 600;
+}
+
+.lefthand-nav .list-group-item .label {
+  margin-left: 6px;
+}
+
+.lefthand-nav .list-group-item .label-success {
+  color: #14532d;
+  background-color: #dcfce7;
+}
+
+.lefthand-nav .list-group-item .label-default {
+  color: #1f2937;
+  background-color: #e5e7eb;
+}
+
+/* Notifications badge accessibility overrides */
+.notifications-tabs .badge {
+  color: #ffffff;
+  background-color: #1f2937;
+  font-weight: 700;
+}
+
+#engine_toggle {
+  color: #1f2937;
+  background-color: #f3f4f6;
+  border-color: #cbd5e1;
+  font-weight: 600;
+}
+
+#engine_toggle:is(:hover, :focus) {
+  color: #111827;
+  background-color: #e5e7eb;
+  border-color: #94a3b8;
+}
+
+#engine_toggle.btn-danger {
+  color: #7f1d1d;
+  background-color: #fee2e2;
+  border-color: #fca5a5;
+}
+
+#engine_toggle.btn-danger:is(:hover, :focus) {
+  color: #7f1d1d;
+  background-color: #fecaca;
+  border-color: #f87171;
+}
+
+#engine_toggle.btn-success {
+  color: #14532d;
+  background-color: #dcfce7;
+  border-color: #86efac;
+}
+
+#engine_toggle.btn-success:is(:hover, :focus) {
+  color: #14532d;
+  background-color: #bbf7d0;
+  border-color: #4ade80;
+}
+
 
 /* Mobile Responsive Styles */
 @media (max-width: 768px) {

--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -16,7 +16,7 @@
         </div>
         <div class="list-group">
           <a class="list-group-item {% if request.path == '/admin/status' %}active{% endif %}"
-            href="/admin/status" id="engine" aria-live="polite">Engine</a>
+            href="/admin/status" id="engine"><span aria-live="polite">Engine</span></a>
           <a class="list-group-item {% if request.path == '/admin/workers' %}active{% endif %}"
             href="/admin/workers">Workers</a>
           <a class="list-group-item {% if request.path == '/admin/queues' %}active{% endif %}"

--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -16,7 +16,8 @@
         </div>
         <div class="list-group">
           <a class="list-group-item {% if request.path == '/admin/status' %}active{% endif %}"
-            href="/admin/status" id="engine"><span aria-live="polite">Engine</span></a>
+            href="/admin/status" id="engine">Engine</a>
+          <span id="engine-status-live" class="sr-only" aria-live="polite"></span>
           <a class="list-group-item {% if request.path == '/admin/workers' %}active{% endif %}"
             href="/admin/workers">Workers</a>
           <a class="list-group-item {% if request.path == '/admin/queues' %}active{% endif %}"
@@ -107,11 +108,13 @@
       success: function (data) {
         if (!data.paused) {
           document.getElementById('engine').innerHTML = 'Engine <span class="label label-success">Running</span>';
+          document.getElementById('engine-status-live').textContent = 'Engine is running';
           document.getElementById('engine_toggle').innerHTML = '<span class="glyphicon glyphicon-pause" aria-hidden="true"></span> Pause';
           document.getElementById('engine_toggle').className = "btn btn-danger btn-lg";
           document.getElementById('engine_toggle').setAttribute('aria-label', 'Pause Scoring Engine');
         } else {
           document.getElementById('engine').innerHTML ='Engine <span class="label label-default">Paused</span>';
+          document.getElementById('engine-status-live').textContent = 'Engine is paused';
           document.getElementById('engine_toggle').innerHTML = '<span class="glyphicon glyphicon-play" aria-hidden="true"></span> Resume';
           document.getElementById('engine_toggle').className = "btn btn-success btn-lg";
           document.getElementById('engine_toggle').setAttribute('aria-label', 'Resume Scoring Engine');

--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<div id="main-content" class="container md-page">
+<div class="container md-page">
   <div class="row">
     <div class="col-sm-3 lefthand-nav" style="padding-top: 10px;">
       <div class="list-group text-center">

--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -1,22 +1,22 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="container md-page">
+<div id="main-content" class="container md-page">
   <div class="row">
     <div class="col-sm-3 lefthand-nav" style="padding-top: 10px;">
       <div class="list-group text-center">
-          <button type="button" class="btn btn-default btn-lg" id="engine_toggle">
+          <button type="button" class="btn btn-default btn-lg" id="engine_toggle" aria-label="Pause Scoring Engine">
             <span class="glyphicon glyphicon-pause" aria-hidden="true"></span> Pause
           </button>
       </div>
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="panel-title">
-            <span>Stats <b class="pull-right glyphicon glyphicon-list-alt"></b></span>
+            <span>Stats <b class="pull-right glyphicon glyphicon-list-alt" aria-hidden="true"></b></span>
           </div>
         </div>
         <div class="list-group">
           <a class="list-group-item {% if request.path == '/admin/status' %}active{% endif %}"
-            href="/admin/status" id="engine">Engine</a>
+            href="/admin/status" id="engine" aria-live="polite">Engine</a>
           <a class="list-group-item {% if request.path == '/admin/workers' %}active{% endif %}"
             href="/admin/workers">Workers</a>
           <a class="list-group-item {% if request.path == '/admin/queues' %}active{% endif %}"
@@ -26,7 +26,7 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="panel-title">
-            <span>Settings <b class="pull-right glyphicon glyphicon-cog"></b></span>
+            <span>Settings <b class="pull-right glyphicon glyphicon-cog" aria-hidden="true"></b></span>
           </div>
         </div>
         <div class="list-group">
@@ -43,7 +43,7 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="panel-title">
-            <span>Injects <b class="pull-right glyphicon glyphicon-file"></b></span>
+            <span>Injects <b class="pull-right glyphicon glyphicon-file" aria-hidden="true"></b></span>
           </div>
         </div>
         <div class="list-group">
@@ -56,19 +56,21 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <div class="panel-title">
-            <span>Services <b class="pull-right glyphicon glyphicon-tasks"></b></span>
+            <span>Services <b class="pull-right glyphicon glyphicon-tasks" aria-hidden="true"></b></span>
           </div>
         </div>
         <div class="list-group">
           {% for team in blue_teams %}
           <a href="#" class="list-group-item" data-toggle="collapse"
-            data-target="#services_team{{team.id}}">{{team.name}}</a>
+            data-target="#services_team{{team.id}}"
+            aria-expanded="{% if service and team.id == service.team.id %}true{% else %}false{% endif %}"
+            aria-controls="services_team{{team.id}}">{{team.name}}</a>
           <div id="services_team{{team.id}}"
             class="sublinks collapse {% if service and team.id == service.team.id %}in{% endif %}">
             {% for service in team.services %}
             <a href="/admin/service/{{service.id}}"
               class="list-group-item small {% if service and request.path == '/admin/service/{0}'.format(service.id) %}active{% endif %}"><span
-                class="glyphicon glyphicon-chevron-right"></span> {{service.name}}</a>
+                class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span> {{service.name}}</a>
             {% endfor %}
           </div>
           {% endfor %}
@@ -80,9 +82,9 @@
         <div class="panel-group">
           <div class="panel panel-default">
             <div class="panel-heading" style="background-color:#f9f9f9">
-              <h2 class="panel-title">
+              <h1 class="panel-title">
                 {% block header %}{% endblock %}
-              </h2>
+              </h1>
             </div>
             <div class="panel" style="border-top: 0.5px solid gray;">
               <div class="panel-body" style="padding-top: 0px;">
@@ -105,12 +107,14 @@
       success: function (data) {
         if (!data.paused) {
           document.getElementById('engine').innerHTML = 'Engine <span class="label label-success">Running</span>';
-          document.getElementById('engine_toggle').innerHTML = '<span class="glyphicon glyphicon-pause" aria-hidden="true"></span> Pause'
+          document.getElementById('engine_toggle').innerHTML = '<span class="glyphicon glyphicon-pause" aria-hidden="true"></span> Pause';
           document.getElementById('engine_toggle').className = "btn btn-danger btn-lg";
+          document.getElementById('engine_toggle').setAttribute('aria-label', 'Pause Scoring Engine');
         } else {
           document.getElementById('engine').innerHTML ='Engine <span class="label label-default">Paused</span>';
-          document.getElementById('engine_toggle').innerHTML = '<span class="glyphicon glyphicon-play" aria-hidden="true"></span> Resume'
+          document.getElementById('engine_toggle').innerHTML = '<span class="glyphicon glyphicon-play" aria-hidden="true"></span> Resume';
           document.getElementById('engine_toggle').className = "btn btn-success btn-lg";
+          document.getElementById('engine_toggle').setAttribute('aria-label', 'Resume Scoring Engine');
         }
       }
     });

--- a/scoring_engine/web/templates/admin/settings.html
+++ b/scoring_engine/web/templates/admin/settings.html
@@ -13,13 +13,13 @@
   <form method="POST" action="{{ url_for('api.admin_update_target_round_time') }}" role="form">
     <div class="form-group row">
       <div class="col-xs-3">
-        <label for="ex1" class="pull-right" style="padding-top: 7px;">Target Round Time (s)</label>
+        <label for="target_round_time" class="pull-right" style="padding-top: 7px;">Target Round Time (s)</label>
       </div>
       <div class="col-xs-2 settings_middle_column" style="padding-top: 5px;">
         <div class="input-group input-group-md">
           <input class="form-control" id="target_round_time" name="target_round_time"
-            placeholder="Insert Targer Round Time Value Here (in seconds)" value="{{ target_round_time|safe }}"
-            required />
+            placeholder="Insert Target Round Time Value Here (in seconds)" value="{{ target_round_time|safe }}"
+            aria-label="Target Round Time in seconds" required />
           <div class="input-group-btn">
             <button type="submit" class="btn btn-primary center-block">Save</button>
           </div>
@@ -34,19 +34,19 @@
   <form method="POST" action="{{ url_for('api.admin_update_worker_refresh_time') }}" role="form">
     <div class="form-group row" style="margin-bottom: 0px;">
       <div class="col-xs-3">
-        <label for="ex1" class="pull-right" style="padding-top: 7px;">Worker Refresh Time (s)</label>
+        <label for="worker_refresh_time" class="pull-right" style="padding-top: 7px;">Worker Refresh Time (s)</label>
       </div>
       <div class="col-xs-2 settings_middle_column" style="padding-top: 5px;">
         <div class="input-group input-group-md">
           <input class="form-control" id="worker_refresh_time" name="worker_refresh_time"
-            placeholder="Insert Worker Refresh Time Here" value="{{ worker_refresh_time|safe }}" required />
+            placeholder="Insert Worker Refresh Time Here (in seconds)" value="{{ worker_refresh_time|safe }}" aria-label="Worker Refresh Time in seconds" required />
           <div class="input-group-btn">
             <button type="submit" class="btn btn-primary center-block">Save</button>
           </div>
         </div>
       </div>
       <div class="col-xs-6">
-        <span class="help-block" style="margin-top: 0px;">Determines how long the engine sleeps iterations of checking
+        <span class="help-block" style="margin-top: 0px;">Determines how long the engine sleeps between iterations of checking
           for finished checks (also displays in the engine log).</span>
       </div>
     </div>
@@ -61,7 +61,7 @@
         <div class="input-group input-group-md">
           <textarea class="form-control" rows="12" style="width: 685px;" id="welcome_page_content"
             name="welcome_page_content" placeholder="Insert Welcome Page Content Here"
-            required>{{ welcome_page_content|safe }}</textarea>
+            aria-label="Welcome Page Content" required>{{ welcome_page_content|safe }}</textarea>
           <label for="about_page_content_footer">* This text shows up on <a href="/">this</a> page</label>
         </div>
         <button type="submit" class="btn btn-primary center-block">Save</button>
@@ -78,7 +78,7 @@
         <div class="input-group input-group-md">
           <textarea class="form-control" rows="9" style="width: 685px;" id="about_page_content"
             name="about_page_content" placeholder="Insert About Page Content Here"
-            required>{{ about_page_content|safe }}</textarea>
+            aria-label="About Page Content" required>{{ about_page_content|safe }}</textarea>
           <label for="about_page_content_footer">* This text shows up on <a href="/about">this</a> page</label>
         </div>
         <button type="submit" class="btn btn-primary center-block">Save</button>

--- a/scoring_engine/web/templates/admin/settings.html
+++ b/scoring_engine/web/templates/admin/settings.html
@@ -19,7 +19,7 @@
         <div class="input-group input-group-md">
           <input class="form-control" id="target_round_time" name="target_round_time"
             placeholder="Insert Target Round Time Value Here (in seconds)" value="{{ target_round_time|safe }}"
-            aria-label="Target Round Time in seconds" required />
+            required />
           <div class="input-group-btn">
             <button type="submit" class="btn btn-primary center-block">Save</button>
           </div>
@@ -39,7 +39,7 @@
       <div class="col-xs-2 settings_middle_column" style="padding-top: 5px;">
         <div class="input-group input-group-md">
           <input class="form-control" id="worker_refresh_time" name="worker_refresh_time"
-            placeholder="Insert Worker Refresh Time Here (in seconds)" value="{{ worker_refresh_time|safe }}" aria-label="Worker Refresh Time in seconds" required />
+            placeholder="Insert Worker Refresh Time Here (in seconds)" value="{{ worker_refresh_time|safe }}" required />
           <div class="input-group-btn">
             <button type="submit" class="btn btn-primary center-block">Save</button>
           </div>
@@ -53,7 +53,7 @@
   </form>
 
   <div class="col-xs-3">
-    <label for="ex1" class="pull-right" style="padding-top: 7px;">Welcome Page Content</label>
+    <label for="welcome_page_content" class="pull-right" style="padding-top: 7px;">Welcome Page Content</label>
   </div>
   <form method="POST" action="{{ url_for('api.admin_update_welcome_page_content') }}" role="form">
     <div class="form-group row">
@@ -61,7 +61,7 @@
         <div class="input-group input-group-md">
           <textarea class="form-control" rows="12" style="width: 685px;" id="welcome_page_content"
             name="welcome_page_content" placeholder="Insert Welcome Page Content Here"
-            aria-label="Welcome Page Content" required>{{ welcome_page_content|safe }}</textarea>
+            required>{{ welcome_page_content|safe }}</textarea>
           <label for="about_page_content_footer">* This text shows up on <a href="/">this</a> page</label>
         </div>
         <button type="submit" class="btn btn-primary center-block">Save</button>
@@ -70,7 +70,7 @@
   </form>
 
   <div class="col-xs-3">
-    <label for="ex1" class="pull-right" style="padding-top: 7px;">About Page Content</label>
+    <label for="about_page_content" class="pull-right" style="padding-top: 7px;">About Page Content</label>
   </div>
   <form method="POST" action="{{ url_for('api.admin_update_about_page_content') }}" role="form">
     <div class="form-group row" style="margin-bottom: 0px;">
@@ -78,7 +78,7 @@
         <div class="input-group input-group-md">
           <textarea class="form-control" rows="9" style="width: 685px;" id="about_page_content"
             name="about_page_content" placeholder="Insert About Page Content Here"
-            aria-label="About Page Content" required>{{ about_page_content|safe }}</textarea>
+            required>{{ about_page_content|safe }}</textarea>
           <label for="about_page_content_footer">* This text shows up on <a href="/about">this</a> page</label>
         </div>
         <button type="submit" class="btn btn-primary center-block">Save</button>

--- a/scoring_engine/web/templates/base.html
+++ b/scoring_engine/web/templates/base.html
@@ -54,36 +54,36 @@
           </button>
           <a class="navbar-brand" href="/" aria-label="Go to Home Page">Scoring Engine</a>
         </div>
-        <div id="navbar" class="navbar-collapse collapse" aria-expanded="false" style="">
+        <div id="navbar" class="navbar-collapse collapse" aria-expanded="false">
           <ul class="nav navbar-nav">
-            <li class="navbar-item {% if request.path == '/scoreboard' %}active{% endif %}"><a class="nav-link" href="{{ url_for('scoreboard.home') }}" aria-label="Go to Scoreboard">Scoreboard</a></li>
-            <li class="navbar-item {% if request.path == '/overview' %}active{% endif %}"><a class="nav-link"  href="{{ url_for('overview.home') }}" aria-label="Go to Overview">Overview</a></li>
+            <li class="navbar-item {% if request.path == '/scoreboard' %}active{% endif %}"><a class="nav-link" href="{{ url_for('scoreboard.home') }}">Scoreboard</a></li>
+            <li class="navbar-item {% if request.path == '/overview' %}active{% endif %}"><a class="nav-link"  href="{{ url_for('overview.home') }}">Overview</a></li>
             {% if current_user.is_authenticated %}
               {% if current_user.is_blue_team %}
               <li class="navbar-item {% if request.path == '/services' %}active{% endif %}"><a class="nav-link"
-                  href="{{ url_for('services.home') }}" aria-label="Go to Services">Services</a></li>
+                  href="{{ url_for('services.home') }}">Services</a></li>
               {% endif %}
               {% if current_user.is_blue_team or current_user.is_red_team %}
               <li class="navbar-item {% if request.path == '/injects' %}active{% endif %}"><a class="nav-link"
-                  href="{{ url_for('injects.home') }}" aria-label="Go to Injects">Injects</a></li>
+                  href="{{ url_for('injects.home') }}">Injects</a></li>
               {% endif %}
               {% if current_user.is_blue_team or current_user.is_white_team %}
               <li class="navbar-item {% if request.path == '/stats' %}active{% endif %}"><a class="nav-link"
-                  href="{{ url_for('stats.home') }}" aria-label="Go to Stats">Stats</a></li>
+                  href="{{ url_for('stats.home') }}">Stats</a></li>
               {% endif %}
               {% if current_user.is_red_team or current_user.is_white_team %}
               <li class="navbar-item {% if request.path == '/flags' %}active{% endif %}"><a class="nav-link"
-                  href="{{ url_for('flags.home') }}" aria-label="Go to Flags">Flags</a></li>
+                  href="{{ url_for('flags.home') }}">Flags</a></li>
               {% endif %}
               {% if current_user.is_white_team %}
               <li class="navbar-item {% if 'admin' in request.path %}active{% endif %}"><a class="nav-link"
-                  href="{{ url_for('admin.status') }}" aria-label="Go to Admin">Admin</a></li>
+                  href="{{ url_for('admin.status') }}">Admin</a></li>
               {% endif %}
               {% endif %}
             </ul>
             <ul class="nav navbar-nav navbar-right">
               {% if not current_user.is_authenticated %}
-              <li class="navbar-item"><a href="{{ url_for('auth.login') }}" aria-label="Go to Login">Login</a></li>
+              <li class="navbar-item"><a href="{{ url_for('auth.login') }}">Login</a></li>
               {% else %}
               <!-- <li class="navbar-item">
                 <a href="{{ url_for('notifications.unread') }}">Notifications {% if notification_count %}<span
@@ -93,13 +93,13 @@
                 <a href="#" data-toggle="dropdown" class="dropdown-toggle navbar-item" style="margin-right: 20px;">{{
                   current_user.get_username }} <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="{{ url_for('profile.home') }}" aria-label="Go to Profile">Profile</a></li>
+                  <li><a href="{{ url_for('profile.home') }}">Profile</a></li>
                   <li class="divider"></li>
                   <li><a href="{{ url_for('auth.logout') }}">Logout</a></li>
                 </ul>
               </li>
               {% endif %}
-              <li class="navbar-item"><a href="{{ url_for('about.about') }}" aria-label="Go to About">About</a></li>
+              <li class="navbar-item"><a href="{{ url_for('about.about') }}">About</a></li>
             </ul>
           </div>
           <!--/.nav-collapse -->

--- a/scoring_engine/web/templates/base.html
+++ b/scoring_engine/web/templates/base.html
@@ -22,6 +22,7 @@
 
   <body style="background-color: #f9f9f9;">
     {% endif %}
+    <a class="sr-only sr-only-focusable" href="#main-content">Skip to main content</a>
     <script>
       $(document).ready(function () {
         $("#alert-info").fadeTo(2000, 500).slideUp(500, function () {

--- a/scoring_engine/web/templates/base.html
+++ b/scoring_engine/web/templates/base.html
@@ -14,11 +14,6 @@
   <link href="{{ url_for('static', filename='vendor/css/bootstrap-glyphicons.css') }}" rel="stylesheet">
   <link rel="shortcut icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
   <link href="{{ url_for('static', filename='css/main.css') }}" rel="stylesheet">
-  <style>
-    *:focus {
-      outline: 2px solid red !important;
-    }
-  </style>
 </head>
 {% if 'unauthorized' in request.path %}
 

--- a/scoring_engine/web/templates/base.html
+++ b/scoring_engine/web/templates/base.html
@@ -14,6 +14,11 @@
   <link href="{{ url_for('static', filename='vendor/css/bootstrap-glyphicons.css') }}" rel="stylesheet">
   <link rel="shortcut icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
   <link href="{{ url_for('static', filename='css/main.css') }}" rel="stylesheet">
+  <style>
+    *:focus {
+      outline: 2px solid red !important;
+    }
+  </style>
 </head>
 {% if 'unauthorized' in request.path %}
 
@@ -33,7 +38,7 @@
     {% for category, message in get_flashed_messages(with_categories=true) %}
     <div class="alert alert-{{category}} alert-dismissable alert-fixed" id="alert-info" role="alert"
       style="margin-bottom: 0px">
-      <button type="button" class="close" data-dismiss="alert">x</button>
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close alert"><span aria-hidden="true">&times;</span></button>
       <strong>{{ message }}</strong>
     </div>
     {% endfor %}
@@ -52,38 +57,38 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="/">Scoring Engine</a>
+          <a class="navbar-brand" href="/" aria-label="Go to Home Page">Scoring Engine</a>
         </div>
         <div id="navbar" class="navbar-collapse collapse" aria-expanded="false" style="">
           <ul class="nav navbar-nav">
-            <li class="navbar-item {% if request.path == '/scoreboard' %}active{% endif %}"><a class="nav-link" href="{{ url_for('scoreboard.home') }}">Scoreboard</a></li>
-            <li class="navbar-item {% if request.path == '/overview' %}active{% endif %}"><a class="nav-link"  href="{{ url_for('overview.home') }}">Overview</a></li>
+            <li class="navbar-item {% if request.path == '/scoreboard' %}active{% endif %}"><a class="nav-link" href="{{ url_for('scoreboard.home') }}" aria-label="Go to Scoreboard">Scoreboard</a></li>
+            <li class="navbar-item {% if request.path == '/overview' %}active{% endif %}"><a class="nav-link"  href="{{ url_for('overview.home') }}" aria-label="Go to Overview">Overview</a></li>
             {% if current_user.is_authenticated %}
               {% if current_user.is_blue_team %}
               <li class="navbar-item {% if request.path == '/services' %}active{% endif %}"><a class="nav-link"
-                  href="{{ url_for('services.home') }}">Services</a></li>
+                  href="{{ url_for('services.home') }}" aria-label="Go to Services">Services</a></li>
               {% endif %}
               {% if current_user.is_blue_team or current_user.is_red_team %}
               <li class="navbar-item {% if request.path == '/injects' %}active{% endif %}"><a class="nav-link"
-                  href="{{ url_for('injects.home') }}">Injects</a></li>
+                  href="{{ url_for('injects.home') }}" aria-label="Go to Injects">Injects</a></li>
               {% endif %}
               {% if current_user.is_blue_team or current_user.is_white_team %}
               <li class="navbar-item {% if request.path == '/stats' %}active{% endif %}"><a class="nav-link"
-                  href="{{ url_for('stats.home') }}">Stats</a></li>
+                  href="{{ url_for('stats.home') }}" aria-label="Go to Stats">Stats</a></li>
               {% endif %}
               {% if current_user.is_red_team or current_user.is_white_team %}
               <li class="navbar-item {% if request.path == '/flags' %}active{% endif %}"><a class="nav-link"
-                  href="{{ url_for('flags.home') }}">Flags</a></li>
+                  href="{{ url_for('flags.home') }}" aria-label="Go to Flags">Flags</a></li>
               {% endif %}
               {% if current_user.is_white_team %}
               <li class="navbar-item {% if 'admin' in request.path %}active{% endif %}"><a class="nav-link"
-                  href="{{ url_for('admin.status') }}">Admin</a></li>
+                  href="{{ url_for('admin.status') }}" aria-label="Go to Admin">Admin</a></li>
               {% endif %}
               {% endif %}
             </ul>
             <ul class="nav navbar-nav navbar-right">
               {% if not current_user.is_authenticated %}
-              <li class="navbar-item"><a href="{{ url_for('auth.login') }}">Login</a></li>
+              <li class="navbar-item"><a href="{{ url_for('auth.login') }}" aria-label="Go to Login">Login</a></li>
               {% else %}
               <!-- <li class="navbar-item">
                 <a href="{{ url_for('notifications.unread') }}">Notifications {% if notification_count %}<span
@@ -93,21 +98,23 @@
                 <a href="#" data-toggle="dropdown" class="dropdown-toggle navbar-item" style="margin-right: 20px;">{{
                   current_user.get_username }} <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="{{ url_for('profile.home') }}">Profile</a></li>
+                  <li><a href="{{ url_for('profile.home') }}" aria-label="Go to Profile">Profile</a></li>
                   <li class="divider"></li>
                   <li><a href="{{ url_for('auth.logout') }}">Logout</a></li>
                 </ul>
               </li>
               {% endif %}
-              <li class="navbar-item"><a href="{{ url_for('about.about') }}">About</a></li>
+              <li class="navbar-item"><a href="{{ url_for('about.about') }}" aria-label="Go to About">About</a></li>
             </ul>
           </div>
           <!--/.nav-collapse -->
         </div>
         <!--/.container-fluid -->
       </nav>
-      {% block content %}
-      {% endblock %}
+      <main id="main-content" {% block main_attrs %}{% endblock %}>
+        {% block content %}
+        {% endblock %}
+      </main>
   </body>
 
 </html>

--- a/scoring_engine/web/templates/flags.html
+++ b/scoring_engine/web/templates/flags.html
@@ -35,11 +35,11 @@
     <section aria-labelledby="capture-status-heading">
     <div class="row">
         <h2 class="text-center" id="capture-status-heading">Capture Status for Active Flags</h2>
-	<h5 class="text-center">
+	<p class="text-center">
 	    <span class='glyphicon glyphicon-minus' style='color: gray' aria-hidden='true'></span><span class='sr-only'>Gray minus icon</span> means no capture;
 	    <span class='glyphicon glyphicon-user' style='color: blue' aria-hidden='true'></span><span class='sr-only'>Blue user icon</span> means user level capture; and
 	    <span class='glyphicon glyphicon-fire' style='color: red' aria-hidden='true'></span><span class='sr-only'>Red fire icon</span> means root level capture
-	</h5>
+	</p>
     </div>
     <div class="row">
         <table id="solves" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%" aria-labelledby="capture-status-heading">
@@ -54,7 +54,7 @@
     <section aria-labelledby="capture-stats-heading">
     <div class="row">
         <h2 class="text-center" id="capture-stats-heading">Competition Flag Capture Stats</h2>
-	<h5 class="text-center">A lower score means the team is doing better</h5>
+	<p class="text-center">A lower score means the team is doing better</p>
         <table id="totals" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%" aria-labelledby="capture-stats-heading">
             <caption class="sr-only">Competition flag capture totals by team, with Windows, Linux, and total scores</caption>
             <thead>

--- a/scoring_engine/web/templates/flags.html
+++ b/scoring_engine/web/templates/flags.html
@@ -1,58 +1,73 @@
 {% extends 'base.html' %}
-{% block title %}Stats{% endblock %}
+{% block title %}Flags{% endblock %}
 {% block head %}
 {{ super() }}
 <script src="{{ url_for('static', filename='vendor/js/jquery.dataTables.min.js') }}"></script>
 <script src="{{ url_for('static', filename='vendor/js/dataTables.bootstrap.min.js') }}"></script>
 <link rel="stylesheet" href="{{ url_for('static', filename='vendor/css/dataTables.bootstrap.min.css') }}" />
 {% endblock %}
+{% block main_attrs %}aria-label="Flags page"{% endblock %}
 {% block content %}
 <div class="container-fluid md-page">
+    <h1 class="sr-only">Flags</h1>
+    <section aria-labelledby="active-flags-heading">
     <div class="row">
-        <h2 class="text-center">Active Flags</h2>
+        <h2 class="text-center" id="active-flags-heading">Active Flags</h2>
     </div>
     <div class="row">
-        <table id="flags" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+        <table id="flags" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%" aria-labelledby="active-flags-heading">
+            <caption class="sr-only">List of active flags with timing, type, platform, permission, path, and content</caption>
             <thead>
                 <tr>
-                    <th>ID</th>
-                    <th>Start Time</th>
-                    <th>End Time</th>
-                    <th>Type</th>
-                    <th>Platform</th>
-                    <th>Permission</th>
-                    <th>Path</th>
-                    <th>Content</th>
+                    <th scope="col">ID</th>
+                    <th scope="col">Start Time</th>
+                    <th scope="col">End Time</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Platform</th>
+                    <th scope="col">Permission</th>
+                    <th scope="col">Path</th>
+                    <th scope="col">Content</th>
                 </tr>
             </thead>
         </table>
     </div>
+    </section>
+    <section aria-labelledby="capture-status-heading">
     <div class="row">
-        <h2 class="text-center">Capture Status for Active Flags</h2>
-	<h5 class="text-center"><span class='glyphicon glyphicon-minus' style='color: gray'></span> means no capture; <span class='glyphicon glyphicon-user' style='color: blue'></span> means user level capture; and <span class='glyphicon glyphicon-fire' style='color: red'></span> means root level capture</h5>
+        <h2 class="text-center" id="capture-status-heading">Capture Status for Active Flags</h2>
+	<h5 class="text-center">
+	    <span class='glyphicon glyphicon-minus' style='color: gray' aria-hidden='true'></span><span class='sr-only'>Gray minus icon</span> means no capture;
+	    <span class='glyphicon glyphicon-user' style='color: blue' aria-hidden='true'></span><span class='sr-only'>Blue user icon</span> means user level capture; and
+	    <span class='glyphicon glyphicon-fire' style='color: red' aria-hidden='true'></span><span class='sr-only'>Red fire icon</span> means root level capture
+	</h5>
     </div>
     <div class="row">
-        <table id="solves" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+        <table id="solves" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%" aria-labelledby="capture-status-heading">
+            <caption class="sr-only">Capture status matrix showing which teams have captured which flags</caption>
             <thead>
                 <tr>
                 </tr>
             </thead>
         </table>
     </div>
+    </section>
+    <section aria-labelledby="capture-stats-heading">
     <div class="row">
-        <h2 class="text-center">Competition Flag Capture Stats</h2>
+        <h2 class="text-center" id="capture-stats-heading">Competition Flag Capture Stats</h2>
 	<h5 class="text-center">A lower score means the team is doing better</h5>
-        <table id="totals" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+        <table id="totals" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%" aria-labelledby="capture-stats-heading">
+            <caption class="sr-only">Competition flag capture totals by team, with Windows, Linux, and total scores</caption>
             <thead>
                 <tr>
-                    <th>Team</th>
-                    <th>Windows Score</th>
-                    <th>nix Score</th>
-                    <th>Total Score</th>
+                    <th scope="col">Team</th>
+                    <th scope="col">Windows Score</th>
+                    <th scope="col">nix Score</th>
+                    <th scope="col">Total Score</th>
                 </tr>
             </thead>
         </table>
     </div>
+    </section>
 </div>
 <script>
   $('#flags').DataTable( {
@@ -86,15 +101,18 @@ $(document).ready(function() {
 			    return data;
 			} else if (Array.isArray(data)) {
 			    if(data[1] == 1) {
-			        return "<span class='glyphicon glyphicon-fire' style='color: red'></span>";
-			    } else if(data[0] == 1) {
-			        return "<span class='glyphicon glyphicon-user' style='color: blue'></span>";
-		            } else {
-			        return "<span class='glyphicon glyphicon-minus' style='color: gray'></span>";
+		        return "<span class='glyphicon glyphicon-fire' style='color: red' aria-hidden='true'></span><span class='sr-only'>Root level capture</span>";
+		    } else if(data[0] == 1) {
+		        return "<span class='glyphicon glyphicon-user' style='color: blue' aria-hidden='true'></span><span class='sr-only'>User level capture</span>";
+	            } else {
+		        return "<span class='glyphicon glyphicon-minus' style='color: gray' aria-hidden='true'></span><span class='sr-only'>No capture</span>";
 			    }
 			}
                     }
 		})), 
+                headerCallback: function(thead) {
+                    $(thead).find('th').attr('scope', 'col');
+                },
                 ordering: false,  // Disable ordering on all columns
             });
         },

--- a/scoring_engine/web/templates/inject.html
+++ b/scoring_engine/web/templates/inject.html
@@ -19,42 +19,46 @@
 <script src="{{ url_for('static', filename='vendor/js/moment-timezone.min.js') }}"></script>
 
 {% endblock %}
+{% block main_attrs %}aria-label="Inject" tabindex="-1"{% endblock %}
 {% block content %}
 <div class="container md-page">
+  <a class="sr-only sr-only-focusable" href="#injectMainContent">Skip inject list and jump to inject details</a>
   <div class="row">
-    <div class="col-sm-3 lefthand-nav" style="padding-top: 20px;">
-      <div id="inject_navbar" class="list-group"></div>
-    </div>
-    <div class="col-sm-9">
+    <nav class="col-sm-3 lefthand-nav" style="padding-top: 20px;" aria-label="Inject list navigation">
+      <div id="inject_navbar" class="list-group" aria-live="polite" aria-atomic="true"></div>
+    </nav>
+    <section id="injectMainContent" class="col-sm-9" tabindex="-1" aria-label="Inject details">
+      <h1 class="sr-only">Inject</h1>
+      <div id="injectStatus" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
+      <div id="injectAlert" class="sr-only" role="alert" aria-live="assertive" aria-atomic="true"></div>
       {% if inject.status == 'Submitted' %}
-      <h3>{{ inject.template.title }} <span class="label label-success">{{ inject.status}}</span></h3>
+      <h2 class="inject-status">{{ inject.template.title }} <span class="label label-success" aria-label="Inject status: {{ inject.status }}">{{ inject.status}}</span></h2>
       {% elif inject.status == 'Graded' %}
-      <h3>{{ inject.template.title }} <span class="label label-info">{{ inject.status}}</span></h3>
+      <h2 class="inject-status">{{ inject.template.title }} <span class="label label-info" aria-label="Inject status: {{ inject.status }}">{{ inject.status}}</span></h2>
       {% elif inject.template.expired %}
-      <h3>{{ inject.template.title }} <span class="label label-danger">Expired</span></h3>
+      <h2 class="inject-status">{{ inject.template.title }} <span class="label label-danger" aria-label="Inject status: Expired">Expired</span></h2>
       {% elif inject.status == 'Draft' %}
       <button type="button" class="btn btn-primary pull-right" data-toggle="modal"
-        data-target="#submitInjectConfirmation">Submit Inject</button>
-      <h3>{{ inject.template.title }} <span class="label label-warning">{{ inject.status}}</span></h3>
+        data-target="#submitInjectConfirmation" aria-label="Open submit inject confirmation" aria-haspopup="dialog"
+        aria-controls="submitInjectConfirmation">Submit Inject</button>
+      <h2 class="inject-status">{{ inject.template.title }} <span class="label label-warning" aria-label="Inject status: {{ inject.status }}">{{ inject.status}}</span></h2>
       {% else %}
-      <h3>{{ inject.template.title }}</h3>
+      <h2>{{ inject.template.title }}</h2>
       {% endif %}
-      <!-- <h5>Status</h5> -->
-      <h5>Points - {{ inject.score }}</h5>
-      <h5>Start Time - <div id="startTime">{{ inject.template.start_time }}</div>
-      </h5>
-      <h5>End Time - <div id="endTime">{{ inject.template.end_time }}</div>
-      </h5>
-      <h4>Scenario</h4>
+      <p aria-label="Inject points">Points - {{ inject.score }}</p>
+      <p>Start Time - <span id="startTime" aria-label="Inject start time">{{ inject.template.start_time }}</span></p>
+      <p>End Time - <span id="endTime" aria-label="Inject end time">{{ inject.template.end_time }}</span></p>
+      <h3>Scenario</h3>
       <p>{{ inject.template.scenario }}</p>
-      <h4>Deliverable</h4>
+      <h3>Deliverable</h3>
       <p>{{ inject.template.deliverable }}</p>
       {% if inject.template.rubric %}
-      <h4>Rubric</h4>
+      <h3>Rubric</h3>
       <table class="table table-bordered">
+        <caption class="sr-only">Inject grading rubric</caption>
         <tr>
-          <th>Deliverable</th>
-          <th>Value</th>
+          <th scope="col">Deliverable</th>
+          <th scope="col">Value</th>
         </tr>
         {% for rubric in inject.template.rubric %}
         <tr>
@@ -70,28 +74,30 @@
       <h5>Graded</h5> -->
       <div class="row">
         <div class="well">
-          <form class="dropzone" id="file-upload"></form>
+          <h3 id="file-upload-label" class="sr-only">Upload files for this inject</h3>
+          <form class="dropzone" id="file-upload" aria-labelledby="file-upload-label"></form>
         </div>
       </div>
-      <h4>Files</h4>
-      <div id="files">
+      <h3>Files</h3>
+      <div id="files" role="region" aria-live="polite" aria-label="Uploaded files list">
       </div>
-      <h4>Comments</h4>
-      <div id="comments">
+      <h3>Comments</h3>
+      <div id="comments" role="region" aria-live="polite" aria-label="Inject comments list">
       </div>
       <div class="panel panel-default">
         <div class="panel-body">
           <form>
             <div class="form-group">
+              <label for="commentArea" class="sr-only">Add a comment</label>
               <textarea id="commentArea" class="form-control" rows="3"></textarea>
             </div>
             <div class="form-group">
-              <button id="addCommentButton" type="button" class="btn btn-primary">Comment</button>
+              <button id="addCommentButton" type="button" class="btn btn-primary" aria-label="Submit comment">Comment</button>
             </div>
           </form>
         </div>
       </div>
-    </div>
+    </section>
   </div>
 </div>
 <!-- Submit Modal -->
@@ -102,7 +108,7 @@
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
             aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title">Submit Inject</h4>
+        <h4 class="modal-title" id="submitInjectConfirmationLabel">Submit Inject</h4>
       </div>
       <div class="modal-body">
         <input type="hidden" name="injectId" id="injectId" value="{{ inject.id }}" />
@@ -110,13 +116,15 @@
         <p><b>You will not be able to edit this inject after submitting.</b></p>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-        <button type="button" id="injectSubmitConfirmButton" class="btn btn-primary">Submit</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal" aria-label="Cancel inject submission">Cancel</button>
+        <button type="button" id="injectSubmitConfirmButton" class="btn btn-primary" aria-label="Confirm inject submission">Submit</button>
       </div>
     </div>
   </div>
 </div>
 <script>
+  var submitInjectTrigger = null;
+
   $(document).ready(function () {
     // Update Timestamps
     var startTime = moment.utc($('#startTime').text()).tz(moment.tz.guess()).format('YYYY-MM-DD HH:mm:ss z');
@@ -138,6 +146,17 @@
     // Load files and update every 30 seconds
     updateFiles();
     setInterval(updateFiles, 30000);
+
+    $('#submitInjectConfirmation').on('shown.bs.modal', function (event) {
+      submitInjectTrigger = event.relatedTarget || document.activeElement;
+      $('#injectSubmitConfirmButton').focus();
+    });
+
+    $('#submitInjectConfirmation').on('hidden.bs.modal', function () {
+      if (submitInjectTrigger) {
+        $(submitInjectTrigger).focus();
+      }
+    });
   });
 </script>
 <script>
@@ -153,6 +172,8 @@
         location.reload();  // Reload page
       },
       error: function (result) {
+        $('#injectAlert').text('');
+        setTimeout(function () { $('#injectAlert').text('Unable to submit inject.'); }, 100);
         console.error(result['responseJSON']['status']);
       }
     });
@@ -174,13 +195,21 @@
           if ($(location).attr("pathname") == "/inject/" + value.id) {
             navbar += ' active';
           }
-          navbar += '">' + value.title + '</a>';
+          navbar += '" aria-label="Open inject ' + value.title + '"';
+          if ($(location).attr("pathname") == "/inject/" + value.id) {
+            navbar += ' aria-current="page"';
+          }
+          navbar += '>' + value.title + '</a>';
         });
 
         // Update navbar
         $("#inject_navbar").html(navbar);
+        $('#injectStatus').text('');
+        setTimeout(function () { $('#injectStatus').text('Inject list updated.'); }, 100);
       },
       error: function (result) {
+        $('#injectAlert').text('');
+        setTimeout(function () { $('#injectAlert').text('Unable to refresh inject list.'); }, 100);
         console.error("An Error Occurred Querying For Files");
       }
     });
@@ -196,13 +225,17 @@
 
         // Append new files
         $.each(result.data, function (index, value) {
-          files += "<p><a href='/api/inject/{{ inject.id }}/files/" + value.id + "/download'>" + value.name + "</a></p>";
+          files += "<p><a aria-label='Download file " + value.name + "' href='/api/inject/{{ inject.id }}/files/" + value.id + "/download'>" + value.name + "</a></p>";
         });
 
         // Update navbar
         $("#files").html(files);
+        $('#injectStatus').text('');
+        setTimeout(function () { $('#injectStatus').text('Files list updated.'); }, 100);
       },
       error: function (result) {
+        $('#injectAlert').text('');
+        setTimeout(function () { $('#injectAlert').text('Unable to refresh files list.'); }, 100);
         console.error("An Error Occurred Querying For Files");
       }
     });
@@ -214,9 +247,13 @@
     init: function () {
       this.on("success", file => {
         console.log("A file has been successfully uploaded");
+        $('#injectStatus').text('');
+        setTimeout(function () { $('#injectStatus').text('File uploaded successfully.'); }, 100);
         updateFiles();
       });
       this.on("error", file => {
+        $('#injectAlert').text('');
+        setTimeout(function () { $('#injectAlert').text('File upload failed.'); }, 100);
         console.error("An error occurred while uploading a file");
       });
     }
@@ -245,8 +282,12 @@
 
         // Update comments
         $("#comments").html(comments);
+        $('#injectStatus').text('');
+        setTimeout(function () { $('#injectStatus').text('Comments updated.'); }, 100);
       },
       error: function (result) {
+        $('#injectAlert').text('');
+        setTimeout(function () { $('#injectAlert').text('Unable to refresh comments.'); }, 100);
         console.error("An Error Occurred Querying For Files");
       }
     });
@@ -264,9 +305,13 @@
       success: function (result) {
         console.log("Comment added");
         $('#commentArea').val('');
+        $('#injectStatus').text('');
+        setTimeout(function () { $('#injectStatus').text('Comment added successfully.'); }, 100);
         updateComments();
       },
       error: function (result) {
+        $('#injectAlert').text('');
+        setTimeout(function () { $('#injectAlert').text('Unable to add comment.'); }, 100);
         alert(result.responseJSON['status']);
         console.error("ERROR:", result.responseJSON['status']);
       }

--- a/scoring_engine/web/templates/inject.html
+++ b/scoring_engine/web/templates/inject.html
@@ -45,7 +45,7 @@
       {% else %}
       <h2>{{ inject.template.title }}</h2>
       {% endif %}
-      <p aria-label="Inject points">Points - {{ inject.score }}</p>
+      <p>Points - {{ inject.score }}</p>
       <p>Start Time - <span id="startTime" aria-label="Inject start time">{{ inject.template.start_time }}</span></p>
       <p>End Time - <span id="endTime" aria-label="Inject end time">{{ inject.template.end_time }}</span></p>
       <h3>Scenario</h3>

--- a/scoring_engine/web/templates/injects.html
+++ b/scoring_engine/web/templates/injects.html
@@ -6,33 +6,23 @@
 <script src="{{ url_for('static', filename='vendor/js/dataTables.bootstrap.min.js') }}"></script>
 <link rel="stylesheet" href="{{ url_for('static', filename='vendor/css/dataTables.bootstrap.min.css') }}" />
 {% endblock %}
+{% block main_attrs %}aria-label="Injects page" tabindex="-1"{% endblock %}
 {% block content %}
-<div class="container md-page">
+<div class="container md-page inject-status">
+    <h1 class="sr-only">Injects</h1>
     <div class="row">
-        <h3>{{ current_user.team.name }}</h3>
+        <h2>{{ current_user.team.name }}</h2>
     </div>
     <div class="row">
-        <table id="injects" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+        <table id="injects" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%" aria-label="Injects table">
+            <caption class="sr-only">List of injects with score, status, and time remaining</caption>
             <thead>
                 <tr>
-                    <th>
-                        <div title="ID">ID</div>
-                    </th>
-                    <th>
-                        <div title="Title">Title</div>
-                    </th>
-                    <th>
-                        <div title="Score">Score</div>
-                    </th>
-                    <th>
-                        <div title="Status">Status</div>
-                    </th>
-                    <!-- <th>
-                        <div title="Status">Status</div>
-                    </th> -->
-                    <th>
-                        <div title="Time Remaining">Time Remaining</div>
-                    </th>
+                    <th scope="col">ID</th>
+                    <th scope="col">Title</th>
+                    <th scope="col">Score</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Time Remaining</th>
                 </tr>
             </thead>
             <!-- <tbody>
@@ -111,7 +101,7 @@
                     "data": "title",
                     "width": "65%",
                     "render": function (data, type, row) {
-                        return '<a href="/inject/' + row['id'] + '">' + data + '</a>';
+                        return '<a href="/inject/' + row['id'] + '" aria-label="Open inject ' + data + '">' + data + '</a>';
                     }
 
                 },
@@ -119,7 +109,8 @@
                     "data": "score",
                     "width": "5%",
                     "render": function (data, type, row) {
-                        return data + " (" + (100 * data) / row['max_score'] + "%)";
+                        var percent = row['max_score'] ? ((100 * data) / row['max_score']) : 0;
+                        return '<span aria-label="Score ' + data + ' out of ' + row['max_score'] + ', ' + percent.toFixed(2) + ' percent">' + data + ' (' + percent.toFixed(2) + '%)</span>';
                     }
                 },
                 {
@@ -131,16 +122,16 @@
                             var endTime = new Date(row['end_time']);
 
                             if (currentTime > endTime) {
-                                return '<span class="label label-danger">Expired</span>';
+                                return '<span class="label label-danger" aria-label="Status Expired">Expired</span>';
                             } else {
-                                return '<span class="label label-warning">' + data + '</span>';
+                                return '<span class="label label-warning" aria-label="Status ' + data + '">' + data + '</span>';
                             }
                         } else if (data == "Submitted") {
-                            return '<span class="label label-success">' + data + '</span>';
+                            return '<span class="label label-success" aria-label="Status ' + data + '">' + data + '</span>';
                         } else if (data == "Graded") {
-                            return '<span class="label label-info">' + data + '</span>';
+                            return '<span class="label label-info" aria-label="Status ' + data + '">' + data + '</span>';
                         } else {
-                            return '<span class="label label-danger">' + data + '</span>';
+                            return '<span class="label label-danger" aria-label="Status ' + data + '">' + data + '</span>';
                         }
                     }
                 },
@@ -165,9 +156,11 @@
                         var endTime = new Date(data);
 
                         if (endTime > currentTime) {
-                            return formatTimer(endTime - currentTime);
+                            var remaining = formatTimer(endTime - currentTime);
+                            return '<span aria-label="Time remaining ' + remaining + '">' + remaining + '</span>';
                         } else {
-                            return formatTimer(0)
+                            var expiredTime = formatTimer(0);
+                            return '<span aria-label="Time remaining ' + expiredTime + '">' + expiredTime + '</span>';
                         }
                     }
                 },

--- a/scoring_engine/web/templates/notifications.html
+++ b/scoring_engine/web/templates/notifications.html
@@ -7,7 +7,6 @@
 
 {% block main_attrs %}aria-label="Notifications" tabindex="-1"{% endblock %}
 {% block content %}
-<a class="sr-only sr-only-focusable" href="#main-content">Skip to notifications content</a>
 <div class="container md-page" style="padding-bottom: 0px;">
   <div class="page-header">
     <h3>Notifications</h3>

--- a/scoring_engine/web/templates/notifications.html
+++ b/scoring_engine/web/templates/notifications.html
@@ -15,27 +15,23 @@
   <div class="panel panel-default">
     <!-- Default panel contents -->
     <div class="panel-body">
-      <ul class="nav nav-tabs notifications-tabs" role="tablist" aria-label="Notification filters">
-        <li role="presentation" {% if request.path=='/notifications/unread' %}class="active" {% endif %}><a
+      <nav aria-label="Notification filters">
+      <ul class="nav nav-tabs notifications-tabs">
+        <li {% if request.path=='/notifications/unread' %}class="active" {% endif %}><a
             id="notifications-tab-unread"
-            role="tab"
             href="/notifications/unread"
             aria-label="Show unread notifications"
-            aria-controls="notifications-tabpanel"
-            aria-selected="{% if request.path=='/notifications/unread' %}true{% else %}false{% endif %}"
             {% if request.path=='/notifications/unread' %}aria-current="page"{% endif %}>Unread{% if notification_count %} <span class="badge" aria-label="{{ notification_count }} unread notifications">{{ notification_count
               }}</span>{% endif %}</a></li>
-        <li role="presentation" {% if request.path=='/notifications/read' %}class="active" {% endif %}><a
+        <li {% if request.path=='/notifications/read' %}class="active" {% endif %}><a
             id="notifications-tab-read"
-            role="tab"
             href="/notifications/read"
             aria-label="Show read notifications"
-            aria-controls="notifications-tabpanel"
-            aria-selected="{% if request.path=='/notifications/read' %}true{% else %}false{% endif %}"
             {% if request.path=='/notifications/read' %}aria-current="page"{% endif %}>Read</a></li>
       </ul>
+      </nav>
       <!-- Table -->
-      <div id="notifications-tabpanel" role="tabpanel" aria-labelledby="{% if request.path=='/notifications/read' %}notifications-tab-read{% else %}notifications-tab-unread{% endif %}">
+      <div id="notifications-tabpanel">
       <table class="table table-bordered" aria-label="Notifications table">
         <caption class="sr-only">Notifications list with message, team, and inject</caption>
         <thead>

--- a/scoring_engine/web/templates/notifications.html
+++ b/scoring_engine/web/templates/notifications.html
@@ -1,11 +1,13 @@
 {% extends 'base.html' %}
-{% block title %}About{% endblock %}
+{% block title %}Notifications{% endblock %}
 
 {% block head %}
 {{ super() }}
 {% endblock %}
 
+{% block main_attrs %}aria-label="Notifications" tabindex="-1"{% endblock %}
 {% block content %}
+<a class="sr-only sr-only-focusable" href="#main-content">Skip to notifications content</a>
 <div class="container md-page" style="padding-bottom: 0px;">
   <div class="page-header">
     <h3>Notifications</h3>
@@ -13,44 +15,74 @@
   <div class="panel panel-default">
     <!-- Default panel contents -->
     <div class="panel-body">
-      <ul class="nav nav-tabs">
-        <li role="navigation" {% if request.path=='/notifications/unread' %}class="active" {% endif %}><a
-            href="/notifications/unread">Unread{% if notification_count %} <span class="badge">{{ notification_count
+      <ul class="nav nav-tabs notifications-tabs" role="tablist" aria-label="Notification filters">
+        <li role="presentation" {% if request.path=='/notifications/unread' %}class="active" {% endif %}><a
+            id="notifications-tab-unread"
+            role="tab"
+            href="/notifications/unread"
+            aria-label="Show unread notifications"
+            aria-controls="notifications-tabpanel"
+            aria-selected="{% if request.path=='/notifications/unread' %}true{% else %}false{% endif %}"
+            {% if request.path=='/notifications/unread' %}aria-current="page"{% endif %}>Unread{% if notification_count %} <span class="badge" aria-label="{{ notification_count }} unread notifications">{{ notification_count
               }}</span>{% endif %}</a></li>
-        <li role="navigation" {% if request.path=='/notifications/read' %}class="active" {% endif %}><a
-            href="/notifications/read">Read</a></li>
+        <li role="presentation" {% if request.path=='/notifications/read' %}class="active" {% endif %}><a
+            id="notifications-tab-read"
+            role="tab"
+            href="/notifications/read"
+            aria-label="Show read notifications"
+            aria-controls="notifications-tabpanel"
+            aria-selected="{% if request.path=='/notifications/read' %}true{% else %}false{% endif %}"
+            {% if request.path=='/notifications/read' %}aria-current="page"{% endif %}>Read</a></li>
       </ul>
       <!-- Table -->
-      <table class="table table-bordered">
-        <tbody>
+      <div id="notifications-tabpanel" role="tabpanel" aria-labelledby="{% if request.path=='/notifications/read' %}notifications-tab-read{% else %}notifications-tab-unread{% endif %}">
+      <table class="table table-bordered" aria-label="Notifications table">
+        <caption class="sr-only">Notifications list with message, team, and inject</caption>
+        <thead>
+          <tr>
+            <th scope="col">Message</th>
+            <th scope="col">Team</th>
+            <th scope="col">Inject</th>
+          </tr>
+        </thead>
+        <tbody id="notificationsBody" aria-live="polite">
           <tr>
             <td>
-              <a href="/admin/injects/1">An inject is ready to be graded</a>
+              <a href="/admin/injects/1" aria-label="Open notification: An inject is ready to be graded">An inject is ready to be graded</a>
             </td>
             <td>Team 1</td>
             <td>Journey to Mordor</td>
           </tr>
         </tbody>
       </table>
+      </div>
     </div>
   </div>
 </div>
+<p id="notificationsStatus" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></p>
 <script>
     // Query API for notifications
     $.ajax({
       url: "/api/notifications",
       success: function (result) {
-        // Append new files
+        var rows = "";
+
+        // Append notification rows
         $.each(result.data, function (index, value) {
-          files += "<p><a href='/" + value.id + "/download'>" + value.name + "</a></p>";
+          var message = value.message || value.name || 'Notification';
+          var team = value.team || '';
+          var injectTitle = value.inject || value.title || '';
+          var notificationLink = value.url || '/admin/injects/' + value.id;
+          rows += "<tr><td><a aria-label='Open notification: " + message + "' href='" + notificationLink + "'>" + message + "</a></td><td>" + team + "</td><td>" + injectTitle + "</td></tr>";
         });
 
-        // Update navbar
-        $("#files").html(files);
-        console.log(files);
+        // Update table body
+        if (rows) {
+          $("#notificationsBody").html(rows);
+        }
       },
       error: function (result) {
-        console.error("An Error Occurred Querying For Files");
+        console.error("An Error Occurred Querying For Notifications");
       }
     });
 </script>

--- a/scoring_engine/web/templates/overview.html
+++ b/scoring_engine/web/templates/overview.html
@@ -134,7 +134,6 @@
                                     color = 'black';
                                     statusLabel = rowLabel + ': Unknown';
                                 }
-                                $cell.attr('aria-label', statusLabel);
                                 $cell.html(`<span class="glyphicon ${icon}" style="color:${color}" role="img" aria-label="${statusLabel}"></span>`);
                             }
                         }

--- a/scoring_engine/web/templates/overview.html
+++ b/scoring_engine/web/templates/overview.html
@@ -6,26 +6,32 @@
 <script src="{{ url_for('static', filename='vendor/js/dataTables.bootstrap.min.js') }}"></script>
 <link rel="stylesheet" href="{{ url_for('static', filename='vendor/css/dataTables.bootstrap.min.css') }}" />
 {% endblock %}
+{% block main_attrs %}aria-label="Competition Overview" tabindex="-1"{% endblock %}
 {% block content %}
 <div class="container-fluid md-page">
+    <h1 class="sr-only">Overview</h1>
     <div class="row">
-        <h2 id="round_number" class="text-center"></h2>
-        <h4 id="round_start" class="text-center"></h4>
+        <h2 id="round_number" class="text-center" aria-live="polite" aria-atomic="true"></h2>
+        <h3 id="round_start" class="text-center" aria-live="polite" aria-atomic="true"></h3>
     </div>
     <div class="row">
+        <div id="table_status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+        <div id="table_alert" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
         <table id="overview" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+            <caption class="sr-only">Team scores and service status overview</caption>
             <thead>
                 <tr>
-                    <th></th>
+                    <th scope="col">Service / Metric</th>
                     {% for team in teams %}
-                    <th>{{ team.name }}</th>
+                    <th scope="col">{{ team.name }}</th>
                     {% endfor %}
                 </tr>
             </thead>
         </table>
-        <div id='hint'>Hover over status icon to get host:port information</div>
+        <div id='hint' aria-hidden="true">Hover over status icon to get host:port information</div>
+        <p class="sr-only">Service status is indicated per team: green check for up, red cross for down, question mark for unknown.</p>
         <div id='overview_api_reference'>Want a json formatted version of this data (including ip addresses)? <a
-                href="{{ url_for('api.overview_data') }}">Here</a></div>
+                href="{{ url_for('api.overview_data') }}" aria-label="Overview data in JSON format">Here</a></div>
         <script>
             function refreshheader() {
                 $.ajax({
@@ -35,6 +41,10 @@
                     success: function (data) {
                         $('#round_number').text("Round " + data.number);
                         $('#round_start').text(data.round_start);
+                    },
+                    error: function () {
+                        $('#table_alert').text('');
+                        setTimeout(function () { $('#table_alert').text('Unable to refresh round information.'); }, 100);
                     }
                 });
             }
@@ -65,51 +75,67 @@
                         // Determine row type by label instead of index
                         if (rowLabel === 'Current Score') {
                             if (i == 0) {
+                                $cell.attr('scope', 'row');
                                 $cell.html(`<span style="font-weight:bold">${value}</span>`);
                             } else {
-                                $cell.html(parseFloat(value).toLocaleString());
+                                var formattedScore = parseFloat(value).toLocaleString();
+                                $cell.attr('aria-label', 'Current Score: ' + formattedScore);
+                                $cell.html(formattedScore);
                             }
                         } else if (rowLabel === 'Current Place') {
                             if (i == 0) {
+                                $cell.attr('scope', 'row');
                                 $cell.html(`<span style="font-weight:bold">${value}</span>`);
                             } else {
                                 // Add medal ribbons for top 3
                                 var medal = '';
-                                if (value == 1) medal = ' <i class="glyphicon glyphicon-tags" style="color: #C98910"></i>';
-                                else if (value == 2) medal = ' <i class="glyphicon glyphicon-tags" style="color: #A8A8A8"></i>';
-                                else if (value == 3) medal = ' <i class="glyphicon glyphicon-tags" style="color: #965A38"></i>';
+                                var placeLabel = 'Current Place: ' + value;
+                                if (value == 1) { medal = ' <i class="glyphicon glyphicon-tags" style="color: #C98910" aria-hidden="true"></i><span class="sr-only"> (Gold)</span>'; }
+                                else if (value == 2) { medal = ' <i class="glyphicon glyphicon-tags" style="color: #A8A8A8" aria-hidden="true"></i><span class="sr-only"> (Silver)</span>'; }
+                                else if (value == 3) { medal = ' <i class="glyphicon glyphicon-tags" style="color: #965A38" aria-hidden="true"></i><span class="sr-only"> (Bronze)</span>'; }
+                                if (value == 1) { placeLabel += ' (Gold)'; }
+                                else if (value == 2) { placeLabel += ' (Silver)'; }
+                                else if (value == 3) { placeLabel += ' (Bronze)'; }
+                                $cell.attr('aria-label', placeLabel);
                                 if (medal) $cell.html(value + medal);
                             }
                         } else if (rowLabel === 'SLA Penalties') {
                             // SLA Penalties row - just bold the label
                             if (i == 0) {
+                                $cell.attr('scope', 'row');
                                 $cell.html(`<span style="font-weight:bold">${value}</span>`);
                             }
                             // Leave penalty values as-is (already formatted with HTML from API)
                         } else if (rowLabel === 'Up/Down Ratio') {
                             // Up/Down Ratio row - just bold the label
                             if (i == 0) {
+                                $cell.attr('scope', 'row');
                                 $cell.html(`<span style="font-weight:bold">${value}</span>`);
                             }
                             // Leave ratio values as-is (already formatted with HTML from API)
                         } else {
                             // Service status row
                             if (i == 0) {
+                                $cell.attr('scope', 'row');
                                 $cell.html(`<span style="font-weight:bold">${value}</span>`);
                             } else {
-                                // Determine status icon and color
-                                var icon, color;
+                                // Determine status icon, color, and accessible label
+                                var icon, color, statusLabel;
                                 if (value == 'true') {
                                     icon = 'glyphicon-ok';
                                     color = 'green';
+                                    statusLabel = rowLabel + ': Up';
                                 } else if (value == 'false') {
                                     icon = 'glyphicon-remove';
                                     color = 'red';
+                                    statusLabel = rowLabel + ': Down';
                                 } else {
                                     icon = 'glyphicon-question-sign';
                                     color = 'black';
+                                    statusLabel = rowLabel + ': Unknown';
                                 }
-                                $cell.html(`<span class="glyphicon ${icon}" style="color:${color}"></span>`);
+                                $cell.attr('aria-label', statusLabel);
+                                $cell.html(`<span class="glyphicon ${icon}" style="color:${color}" role="img" aria-label="${statusLabel}"></span>`);
                             }
                         }
                     }
@@ -127,7 +153,11 @@
                 }, 30000);
 
                 setInterval(function () {
-                    overview.ajax.reload();
+                    overview.ajax.reload(function () {
+                        // Clear first so screen readers detect the DOM change even when text is identical
+                        $('#table_status').text('');
+                        setTimeout(function () { $('#table_status').text('Scores table updated.'); }, 100);
+                    });
                 }, 30000);
             });
         </script>

--- a/scoring_engine/web/templates/profile.html
+++ b/scoring_engine/web/templates/profile.html
@@ -17,15 +17,15 @@
         <input type="hidden" name="user_id" value="{{current_user.id}}">
         <div class="form-group">
           <label for="currentPassword">Current Password</label>
-          <input type="password" class="form-control" name="currentpassword" id="currentPassword" placeholder="Current Password" aria-label="Current password" required>
+          <input type="password" class="form-control" name="currentpassword" id="currentPassword" placeholder="Current Password" required>
         </div>
         <div class="form-group">
           <label for="inputPassword">New Password</label>
-          <input type="password" class="form-control" name="password" id="inputPassword" placeholder="New Password" aria-label="New password" required>
+          <input type="password" class="form-control" name="password" id="inputPassword" placeholder="New Password" required>
         </div>
         <div class="form-group">
           <label for="inputConfirmedPassword">Confirm New Password</label>
-          <input type="password" class="form-control" name="confirmedpassword" id="inputConfirmedPassword" placeholder="Confirmed Password" aria-label="Confirm new password" required>
+          <input type="password" class="form-control" name="confirmedpassword" id="inputConfirmedPassword" placeholder="Confirmed Password" required>
         </div>
         <button type="submit" class="btn btn-primary center-block">Update Password</button>
       </form>

--- a/scoring_engine/web/templates/profile.html
+++ b/scoring_engine/web/templates/profile.html
@@ -4,23 +4,28 @@
     {{ super() }}
     <link href="{{ url_for('static', filename='css/main.css') }}" rel="stylesheet">
 {% endblock %}
+{% block main_attrs %}aria-label="Profile" tabindex="-1"{% endblock %}
 {% block content %}
 <div class="container md-page">
+  <h1 class="sr-only">Profile</h1>
   <div class="row">
-    <h3>Name: {{current_user.username}}</h3>
-    <h4>Team Color: {{current_user.team.color}}</h4>
+    <p class="lead"><strong>Name:</strong> {{current_user.username}}</p>
+    <p class="lead"><strong>Team Color:</strong> {{current_user.team.color}}</p>
     <div class="card">
       <h2 class="text-center">Update Password</h2>
       <form method="POST" action="{{url_for('api.profile_update_password')}}" role="form" class="form-signin">
         <input type="hidden" name="user_id" value="{{current_user.id}}">
         <div class="form-group">
-          <input type="password" class="form-control" name="currentpassword" id="currentPassword" placeholder="Current Password" required>
+          <label for="currentPassword">Current Password</label>
+          <input type="password" class="form-control" name="currentpassword" id="currentPassword" placeholder="Current Password" aria-label="Current password" required>
         </div>
         <div class="form-group">
-          <input type="password" class="form-control" name="password" id="inputPassword" placeholder="New Password" required>
+          <label for="inputPassword">New Password</label>
+          <input type="password" class="form-control" name="password" id="inputPassword" placeholder="New Password" aria-label="New password" required>
         </div>
         <div class="form-group">
-          <input type="password" class="form-control" name="confirmedpassword" id="inputConfirmedPassword" placeholder="Confirmed Password" required>
+          <label for="inputConfirmedPassword">Confirm New Password</label>
+          <input type="password" class="form-control" name="confirmedpassword" id="inputConfirmedPassword" placeholder="Confirmed Password" aria-label="Confirm new password" required>
         </div>
         <button type="submit" class="btn btn-primary center-block">Update Password</button>
       </form>

--- a/scoring_engine/web/templates/scoreboard.html
+++ b/scoring_engine/web/templates/scoreboard.html
@@ -4,11 +4,20 @@
 {{ super() }}
 <script src="{{ url_for('static', filename='vendor/js/echarts.min.js') }}"></script>
 {% endblock %}
+{% block main_attrs %}aria-label="Scoreboard" tabindex="-1"{% endblock %}
 {% block content %}
 <div class="container md-page">
-    <div id="teamBar" style="width: 100%; height:400px;"></div>
+    <h1 class="sr-only">Scoreboard</h1>
+    <div id="scoreboard_status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+    <div id="scoreboard_alert" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+    <h2 class="sr-only">Total Scores Bar Chart</h2>
+    <div id="teamBar" style="width: 100%; height:400px;" role="img" aria-label="Bar chart showing total scores by team" tabindex="0" aria-describedby="teamBarTable"></div>
+    <div id="teamBarTable" class="sr-only"></div>
     <hr>
-    <div id="teamLine" style="width: 100%; height:400px;"></div>
+    <h2 class="sr-only">Service Scores Line Chart</h2>
+    <div id="teamLine" style="width: 100%; height:400px;" role="img" aria-label="Line chart showing service scores over time by team" tabindex="0" aria-describedby="teamLineTable"></div>
+    <div id="teamLineTable" class="sr-only"></div>
     <script>
         // Bar chart for all teams
         var teamBarChart = echarts.init(document.getElementById('teamBar'));
@@ -82,6 +91,7 @@
                 }
 
                 teamBarChart.hideLoading();
+                buildBarTable(data);
                 teamBarChart.setOption({
                     title: {
                         text: slaEnabled ? 'Total Scores (with SLA Penalties)' : 'Total Scores',
@@ -133,7 +143,37 @@
             .fail(function(jqXHR, textStatus, errorThrown) {
                 teamBarChart.hideLoading();
                 console.error('Failed to load scoreboard data:', textStatus, errorThrown);
+                $('#scoreboard_alert').text('');
+                setTimeout(function () { $('#scoreboard_alert').text('Failed to load bar chart data.'); }, 100);
             });
+
+        function buildBarTable(data) {
+            var html = '<table><caption>Total Scores by Team</caption>';
+            html += '<thead><tr><th scope="col">Team</th><th scope="col">Services</th><th scope="col">Injects</th>';
+            if (data.sla_enabled && data.sla_penalties) {
+                html += '<th scope="col">SLA Penalties</th><th scope="col">Adjusted Total</th>';
+            } else {
+                html += '<th scope="col">Total</th>';
+            }
+            html += '</tr></thead><tbody>';
+            for (var i = 0; i < data.labels.length; i++) {
+                var svc = parseInt(data.service_scores[i]) || 0;
+                var inj = parseInt(data.inject_scores[i]) || 0;
+                var total = svc + inj;
+                html += '<tr><th scope="row">' + data.labels[i] + '</th>';
+                html += '<td>' + svc + '</td><td>' + inj + '</td>';
+                if (data.sla_enabled && data.sla_penalties) {
+                    var penalty = Math.abs(parseInt(data.sla_penalties[i]) || 0);
+                    total -= penalty;
+                    html += '<td>-' + penalty + '</td><td>' + total + '</td>';
+                } else {
+                    html += '<td>' + total + '</td>';
+                }
+                html += '</tr>';
+            }
+            html += '</tbody></table>';
+            $('#teamBarTable').html(html);
+        }
 
         // Update chart every 30 seconds
         setInterval(function () {
@@ -175,12 +215,15 @@
                     seriesUpdate.push({ data: slaPenalties });
                 }
 
+                buildBarTable(data);
                 teamBarChart.setOption({
                     title: {
                         text: slaEnabled ? 'Total Scores (with SLA Penalties)' : 'Total Scores',
                     },
                     series: seriesUpdate
                 });
+                $('#scoreboard_status').text('');
+                setTimeout(function () { $('#scoreboard_status').text('Scoreboard charts updated.'); }, 100);
             });
         }, 30000);
     </script>
@@ -209,6 +252,7 @@
                     });
                 });
                 teamLineChart.hideLoading();
+                buildLineTable(data);
                 teamLineChart.setOption({
                     title: {
                         text: 'Service Scores',
@@ -240,7 +284,21 @@
             .fail(function(jqXHR, textStatus, errorThrown) {
                 teamLineChart.hideLoading();
                 console.error('Failed to load line chart data:', textStatus, errorThrown);
+                $('#scoreboard_alert').text('');
+                setTimeout(function () { $('#scoreboard_alert').text('Failed to load line chart data.'); }, 100);
             });
+
+        function buildLineTable(data) {
+            var html = '<table><caption>Service Scores Over Time by Team</caption>';
+            html += '<thead><tr><th scope="col">Team</th><th scope="col">Latest Score</th></tr></thead><tbody>';
+            echarts.util.each(data.team, function (team) {
+                var latest = team.scores.length > 0 ? team.scores[team.scores.length - 1] : 'N/A';
+                html += '<tr><th scope="row">' + team.name + '</th><td>' + latest + '</td></tr>';
+            });
+            html += '</tbody></table>';
+            html += '<p>' + (data.rounds ? data.rounds.length : 0) + ' rounds completed.</p>';
+            $('#teamLineTable').html(html);
+        }
 
         // Update chart every 30 seconds
         setInterval(function () {
@@ -253,6 +311,7 @@
                         data: team.scores,
                     });
                 });
+                buildLineTable(data);
                 teamLineChart.setOption({
                     series: seriesList,
                 });

--- a/scoring_engine/web/templates/scoreboard.html
+++ b/scoring_engine/web/templates/scoreboard.html
@@ -289,14 +289,24 @@
             });
 
         function buildLineTable(data) {
-            var html = '<table><caption>Service Scores Over Time by Team</caption>';
-            html += '<thead><tr><th scope="col">Team</th><th scope="col">Latest Score</th></tr></thead><tbody>';
+            var totalRounds = data.rounds ? data.rounds.length : 0;
+            var recentCount = Math.min(5, totalRounds);
+            var startIdx = totalRounds - recentCount;
+            var html = '<table><caption>Service Scores Over Time by Team (last ' + recentCount + ' of ' + totalRounds + ' rounds)</caption>';
+            html += '<thead><tr><th scope="col">Team</th>';
+            for (var r = startIdx; r < totalRounds; r++) {
+                html += '<th scope="col">Round ' + data.rounds[r] + '</th>';
+            }
+            html += '</tr></thead><tbody>';
             echarts.util.each(data.team, function (team) {
-                var latest = team.scores.length > 0 ? team.scores[team.scores.length - 1] : 'N/A';
-                html += '<tr><th scope="row">' + team.name + '</th><td>' + latest + '</td></tr>';
+                html += '<tr><th scope="row">' + team.name + '</th>';
+                for (var r = startIdx; r < totalRounds; r++) {
+                    var score = r < team.scores.length ? team.scores[r] : 'N/A';
+                    html += '<td>' + score + '</td>';
+                }
+                html += '</tr>';
             });
             html += '</tbody></table>';
-            html += '<p>' + (data.rounds ? data.rounds.length : 0) + ' rounds completed.</p>';
             $('#teamLineTable').html(html);
         }
 

--- a/scoring_engine/web/templates/service.html
+++ b/scoring_engine/web/templates/service.html
@@ -11,6 +11,7 @@
     <link href="{{ url_for('static', filename='vendor/css/bootstrap-editable.css') }}" rel="stylesheet" />
     <script src="{{ url_for('static', filename='vendor/js/utils.js') }}"></script>
 {% endblock %}
+{% block main_attrs %}aria-label="Service" tabindex="-1"{% endblock %}
 {% block content %}
 <script>
   $.fn.editable.defaults.mode = 'inline';
@@ -61,43 +62,44 @@
           masked_div.style.display = 'none';
           show_div.style.display = 'inline-block';
           show_button.innerHTML = "Hide";
+          show_button.setAttribute('aria-label', 'Hide password for account ' + num);
       }
       else {
           masked_div.style.display = 'inline-block';
           show_div.style.display = 'none';
           show_button.innerHTML = "Show";
+          show_button.setAttribute('aria-label', 'Show password for account ' + num);
       }
     }
 </script>
 <div class="container md-page">
   <div class="row">
-    <div class="col-sm-3 lefthand-nav" style="padding-top: 20px;">
+    <nav class="col-sm-3 lefthand-nav" style="padding-top: 20px;" aria-label="Service navigation">
       <div id="service_navbar" class="list-group">
       </div>
-    </div>
-    <div class="col-sm-9">
-      <h2>{{service.name}}</h2>
+    </nav>
+    <section class="col-sm-9" aria-labelledby="service_name_heading">
+      <h1 id="service_name_heading">{{service.name}}</h1>
+      <section aria-labelledby="connection_details_heading">
+      <h3 id="connection_details_heading" class="sr-only">Connection details</h3>
       <table>
+        <caption class="sr-only">Service connection details</caption>
         <tbody>
           <tr>
-            <td style="padding-right:10px">
-              <h4>Host:</h4>
-            </td>
+            <th scope="row" style="padding-right:10px; font-weight:bold;">Host</th>
             <td>
               {% if modify_hostname_setting == true %}
-                <a href="#" class="editable-textfield" data-type="text" data-pk="{{service.id}}" data-title="Enter Host" data-name="host" data-url="{{url_for('api.update_host')}}">{{service.host}}</a>
+                <a href="#" class="editable-textfield" role="button" aria-label="Edit host, current value: {{service.host}}" data-type="text" data-pk="{{service.id}}" data-title="Enter Host" data-name="host" data-url="{{url_for('api.update_host')}}">{{service.host}}</a>
               {% else %}
                 {{service.host}}
               {% endif %}
             </td>
           </tr>
           <tr>
-            <td style="padding-right:10px">
-              <h4>Port:</h4>
-            </td>
+            <th scope="row" style="padding-right:10px; font-weight:bold;">Port</th>
             <td>
               {% if modify_port_setting == true %}
-                <a href="#" class="editable-textfield" data-type="text" data-pk="{{service.id}}" data-title="Enter Port" data-name="port" data-url="{{url_for('api.update_port')}}">{{service.port}}</a>
+                <a href="#" class="editable-textfield" role="button" aria-label="Edit port, current value: {{service.port}}" data-type="text" data-pk="{{service.id}}" data-title="Enter Port" data-name="port" data-url="{{url_for('api.update_port')}}">{{service.port}}</a>
               {% else %}
                 {{service.port}}
               {% endif %}
@@ -105,13 +107,16 @@
           </tr>
         </tbody>
       </table>
+      </section>
       {% if service.accounts %}
-        <h4>Accounts</h4>
+        <section aria-labelledby="accounts_heading">
+        <h3 id="accounts_heading">Accounts</h3>
         <table class="table table-striped table-bordered table-compact editable-table" style="clear: both">
+          <caption class="sr-only">Service accounts with username and password</caption>
           <thead>
             <tr>
-              <th>Username</th>
-              <th>Password</th>
+              <th scope="col">Username</th>
+              <th scope="col">Password</th>
             </tr>
           </thead>
           <tbody>
@@ -119,33 +124,37 @@
               <tr>
                 <td width="30%">
                 {% if modify_account_usernames_setting == true %}
-                  <a href="#" class="editable-textfield username" data-type="text" data-pk="{{account.id}}" data-title="Enter Username" data-name="username" data-url="{{url_for('api.update_service_account_info')}}">{{account.username}}</a></td>
+                  <a href="#" class="editable-textfield username" role="button" aria-label="Edit username, current value: {{account.username}}" data-type="text" data-pk="{{account.id}}" data-title="Enter Username" data-name="username" data-url="{{url_for('api.update_service_account_info')}}">{{account.username}}</a>
                 {% else %}
                   {{account.username}}
                 {% endif %}
                 </td>
                 <td width="70%">
                 {% if modify_account_passwords_setting == true %}
-                  <a href="#" class="editable-textfield password" data-type="text" data-pk="{{account.id}}" data-title="Enter Password" data-name="password" data-url="{{url_for('api.update_service_account_info')}}">{{account.password}}</a></td>
+                  <a href="#" class="editable-textfield password" role="button" aria-label="Edit password for {{account.username}}" data-type="text" data-pk="{{account.id}}" data-title="Enter Password" data-name="password" data-url="{{url_for('api.update_service_account_info')}}">{{account.password}}</a>
                 {% else %}
-                  <a href="#" class="btn btn-primary btn-xs" id="bootstrap_reveal_password_{{account.id}}" role="button" aria-pressed="true" onclick="togglePassword('{{account.id}}')">Show</a>
+                  <button type="button" class="btn btn-primary btn-xs" id="bootstrap_reveal_password_{{account.id}}" aria-label="Show password for {{account.username}}" onclick="togglePassword('{{account.id}}')">Show</button>
                   <div id="masked_password_{{account.id}}" style="display: inline-block;">**********</div><div id="show_password_{{account.id}}" style="display: none;">{{account.password}}</div>
                 {% endif %}
               </tr>
               {% endfor %}
           </tbody>
       </table>
+      </section>
       {% endif %}
-        <h4>Checks</h4>
+        <section aria-labelledby="checks_heading">
+        <h3 id="checks_heading">Checks</h3>
+        <div id="checks_status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
         <table id="checks" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+          <caption class="sr-only">Service check results by round</caption>
           <thead>
             <tr>
-              <th></th>
-              <th>Round</th>
-              <th>Result</th>
-              <th>Earned</th>
-              <th>Reason</th>
-              <th>Timestamp</th>
+              <th scope="col"><span class="sr-only">Expand/Collapse</span></th>
+              <th scope="col">Round</th>
+              <th scope="col">Result</th>
+              <th scope="col">Earned</th>
+              <th scope="col">Reason</th>
+              <th scope="col">Timestamp</th>
             </tr>
           </thead>
         </table>
@@ -164,12 +173,23 @@
                       if ("{{service.id}}" == value['id']){
                         navbar_row_str += " active"
                       }
-                      navbar_row_str += '">' + key;
+                      var status_text = '';
                       if (value['result'] == 'True'){
-                        navbar_row_str += '<span class="pull-right label label-success" style="margin-top: 2px;">UP</span>'
+                        status_text = 'UP';
+                      } else if (value['result'] == 'False') {
+                        status_text = 'DOWN';
                       }
-                      else if (value['result'] == 'False') {
-                        navbar_row_str += '<span class="pull-right label label-danger" style="margin-top: 2px;">DOWN</span>'
+                      var aria_label = key + (status_text ? ', status: ' + status_text : '');
+                      navbar_row_str += '" aria-label="' + aria_label + '"';
+                      if ("{{service.id}}" == value['id']){
+                        navbar_row_str += ' aria-current="page"';
+                      }
+                      navbar_row_str += '>' + key;
+                      if (status_text == 'UP'){
+                        navbar_row_str += '<span class="pull-right label label-success" aria-hidden="true" style="margin-top: 2px;">UP</span>'
+                      }
+                      else if (status_text == 'DOWN') {
+                        navbar_row_str += '<span class="pull-right label label-danger" aria-hidden="true" style="margin-top: 2px;">DOWN</span>'
                       }
                       navbar_row_str += "</a>"
                       navbar_str += navbar_row_str
@@ -200,14 +220,14 @@
                       "orderable": false,
                       "data": null,
                       "render": function( data ) {
-                        var button_text = `<a class='expand-button'><span id='span_` + data['round'] + `' class="pull-right glyphicon `;
+                        var button_text = `<button type='button' class='expand-button btn btn-link btn-xs' aria-label='Expand round ` + data['round'] + `'><span id='span_` + data['round'] + `' class="pull-right glyphicon `;
                         var button_icon = 'glyphicon-plus'
                         if ( window.expanded_rows ){
                             if (window.expanded_rows.indexOf(data['round']) >= 0) {
                               button_icon = 'glyphicon-minus';
                             }
                         }
-                        button_text += button_icon + `"></span></a>`;
+                        button_text += button_icon + `" aria-hidden="true"></span></button>`;
                         return button_text;
                       }
                     },
@@ -237,7 +257,7 @@
                   'order': [[1, 'desc']],
                 });
 
-                $('#checks tbody').on('click', 'a.expand-button', function () {
+                $('#checks tbody').on('click', 'button.expand-button', function () {
                   var tr = $(this).closest('tr');
                   var row = table.row(tr);
 
@@ -264,6 +284,7 @@
                     row.child.hide();
                     icon_span.removeClass('glyphicon-minus')
                     icon_span.addClass('glyphicon-plus')
+                    $(tr).find('button.expand-button').attr('aria-label', 'Expand round ' + row.data().round);
                   }
                   else {
                     // Open the check output row
@@ -271,6 +292,7 @@
                     row.child(output_row).show();
                     icon_span.removeClass('glyphicon-plus')
                     icon_span.addClass('glyphicon-minus')
+                    $(tr).find('button.expand-button').attr('aria-label', 'Collapse round ' + row.data().round);
                   }
                 });
 
@@ -294,13 +316,17 @@
                 }
 
                 setInterval(function() {
-                  table.ajax.reload(expandRows, false);
+                  table.ajax.reload(function (data) {
+                      expandRows(data);
+                      $('#checks_status').text('');
+                      setTimeout(function () { $('#checks_status').text('Checks table updated.'); }, 100);
+                  }, false);
                   refreshServicesNavbar();
                 }, 30000);
             });
           </script>
-        </div>
-      </div>
+        </section>
+      </section>
     </div>
   </div>
 </div>

--- a/scoring_engine/web/templates/services.html
+++ b/scoring_engine/web/templates/services.html
@@ -6,27 +6,33 @@
     <script src="{{ url_for('static', filename='vendor/js/dataTables.bootstrap.min.js') }}"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/css/dataTables.bootstrap.min.css') }}" />
 {% endblock %}
+{% block main_attrs %}aria-label="Services" tabindex="-1"{% endblock %}
 {% block content %}
 <div class="container md-page">
-    <div class="row">
-        <h3>{{ current_user.team.name }}</h3>
+    <h1 class="sr-only">Services</h1>
+    <header class="row" aria-labelledby="team_name_heading">
+        <h2 id="team_name_heading">{{ current_user.team.name }}</h2>
         <h5 id="team_place">Place: </h5>
         <h5 id="team_current_score">Score: </h5>
-    </div>
-    <div class="row">
+    </header>
+    <div id="services_status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+    <div id="services_alert" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+    <section class="row" aria-labelledby="services_table_heading">
+        <h4 id="services_table_heading" class="sr-only">Services</h4>
         <table id="services" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+            <caption class="sr-only">Team services with status, scores, and trending checks</caption>
             <thead>
                 <tr>
-                    <th><div title="Name of Service">Service</div></th>
-                    <th><div title="Host/ip of the service">Host</div></th>
-                    <th><div title="Port of the service">Port</div></th>
-                    <th><div title="Current check result of the service">Status</div></th>
-                    <th><div title="Overall rank compared to other blue teams">Rank</div></th>
-                    <th><div title="Overall score earned for this service">Score Earned</div></th>
-                    <th><div title="Maximum possible score">Max Score</div></th>
-                    <th><div title="Percent of overall score earned">% Earned</div></th>
-                    <th><div title="Points per successful check">Pts Per Check</div></th>
-                    <th><div title="Last 10 results">Trending</div></th>
+                    <th scope="col">Service</th>
+                    <th scope="col">Host</th>
+                    <th scope="col">Port</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Rank</th>
+                    <th scope="col">Score Earned</th>
+                    <th scope="col">Max Score</th>
+                    <th scope="col">% Earned</th>
+                    <th scope="col">Pts Per Check</th>
+                    <th scope="col">Trending</th>
                 </tr>
             </thead>
             <tbody>
@@ -41,6 +47,10 @@
                     success: function(data) {
                         $('#team_place').text("Place: " + data.place);
                         $('#team_current_score').text("Score: " + parseFloat(data.current_score).toLocaleString());
+                    },
+                    error: function() {
+                        $('#services_alert').text('');
+                        setTimeout(function () { $('#services_alert').text('Failed to load team stats.'); }, 100);
                     }
                 });
             }
@@ -76,18 +86,16 @@
                             {
                                 "data": null,
                                 "render": function( data ) {
-                                    var span_str = '<span class="label label-'
-                                    var label_level = 'default'
-                                    var label_str = 'Undetermined'
+                                    var label_level = 'default';
+                                    var label_str = 'Undetermined';
                                     if ( data.check == "UP" ) {
-                                        label_level = 'success'
-                                        label_str = 'UP'
+                                        label_level = 'success';
+                                        label_str = 'UP';
                                     } else if ( data.check == "DOWN" ) {
-                                        label_level = 'danger'
-                                        label_str = 'DOWN'
+                                        label_level = 'danger';
+                                        label_str = 'DOWN';
                                     }
-                                    span_str += label_level + '">' + label_str + '</span>'
-                                    return span_str;
+                                    return '<span class="label label-' + label_level + '" role="status"><span class="sr-only">Status: </span>' + label_str + '</span>';
                                 }
                             },
                             { "data": "rank" },
@@ -112,22 +120,25 @@
                                     var last_ten_checks = '<div align="right">'
                                     for (var index in data.last_ten_checks) {
                                         if ( data.last_ten_checks[index] == true ) {
-                                            last_ten_checks += '<span class="glyphicon glyphicon-ok" style="color:green"></span>';
+                                            last_ten_checks += '<span class="glyphicon glyphicon-ok status-icon-up" role="img" aria-label="Check ' + (parseInt(index) + 1) + ': Up"></span>';
                                         }
                                         else {
-                                        last_ten_checks += '<span class="glyphicon glyphicon-remove" style="color:red"></span>';
+                                            last_ten_checks += '<span class="glyphicon glyphicon-remove status-icon-down" role="img" aria-label="Check ' + (parseInt(index) + 1) + ': Down"></span>';
                                         }
                                     }
-                                    return '</div>' + last_ten_checks;
+                                    return last_ten_checks + '</div>';
                                 }
                             },
                         ],
                     });
                 setInterval( function () {
-                    table.ajax.reload();
+                    table.ajax.reload(function () {
+                        $('#services_status').text('');
+                        setTimeout(function () { $('#services_status').text('Services table updated.'); }, 100);
+                    }, false);
                 }, 30000 );
             } );
         </script>
-    </div>
+    </section>
 </div>
 {% endblock %}

--- a/scoring_engine/web/templates/services.html
+++ b/scoring_engine/web/templates/services.html
@@ -95,7 +95,7 @@
                                         label_level = 'danger';
                                         label_str = 'DOWN';
                                     }
-                                    return '<span class="label label-' + label_level + '" role="status"><span class="sr-only">Status: </span>' + label_str + '</span>';
+                                    return '<span class="label label-' + label_level + '"><span class="sr-only">Status: </span>' + label_str + '</span>';
                                 }
                             },
                             { "data": "rank" },

--- a/scoring_engine/web/templates/stats.html
+++ b/scoring_engine/web/templates/stats.html
@@ -6,6 +6,7 @@
 <script src="{{ url_for('static', filename='vendor/js/dataTables.bootstrap.min.js') }}"></script>
 <link rel="stylesheet" href="{{ url_for('static', filename='vendor/css/dataTables.bootstrap.min.css') }}" />
 {% endblock %}
+{% block main_attrs %}aria-label="Stats" tabindex="-1"{% endblock %}
 {% block content %}
 <div class="container-fluid md-page">
     <div class="row">
@@ -13,13 +14,14 @@
     </div>
     <div class="row">
         <table id="service-summary" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+            <caption class="sr-only">All-time service uptime summary.</caption>
             <thead>
                 <tr>
-                    <th>Service</th>
-                    <th>Up</th>
-                    <th>Down</th>
-                    <th>Total</th>
-                    <th>Uptime %</th>
+                    <th scope="col">Service</th>
+                    <th scope="col">Up</th>
+                    <th scope="col">Down</th>
+                    <th scope="col">Total</th>
+                    <th scope="col">Uptime %</th>
                 </tr>
             </thead>
             <tbody></tbody>
@@ -28,16 +30,18 @@
     <div class="row">
         <h2 class="text-center">Round Stats</h2>
     </div>
+    <p id="stats-table-description" class="sr-only">Table of competition round timing and service ratio details.</p>
     <div class="row">
-        <table id="stats" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+        <table id="stats" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%" aria-describedby="stats-table-description">
+            <caption class="sr-only">Round statistics including start and end times, duration, and service ratio.</caption>
             <thead>
                 <tr>
-                    <th>Round</th>
-                    <th>Start Time</th>
-                    <th>End Time</th>
-                    <th>Duration (Seconds)</th>
-                    <th>Service Ratio</th>
-                    <th>Failures by Service</th>
+                    <th scope="col">Round</th>
+                    <th scope="col">Start Time</th>
+                    <th scope="col">End Time</th>
+                    <th scope="col">Duration (Seconds)</th>
+                    <th scope="col">Service Ratio</th>
+                    <th scope="col">Failures by Service</th>
                 </tr>
             </thead>
             <tbody></tbody>

--- a/scoring_engine/web/templates/stats.html
+++ b/scoring_engine/web/templates/stats.html
@@ -77,10 +77,10 @@
                 var breakdown = row.service_breakdown || {};
                 $.each(breakdown, function(svc, counts) {
                     if (counts.down > 0) {
-                        failures.push('<span style="color:red;">' + svc + ' x' + counts.down + '</span>');
+                        failures.push('<span style="color:red;"><span class="sr-only">Failed: </span>' + svc + ' x' + counts.down + '</span>');
                     }
                 });
-                var failureText = failures.length > 0 ? failures.join(', ') : '<span style="color:green;">All passing</span>';
+                var failureText = failures.length > 0 ? failures.join(', ') : '<span style="color:green;"><span class="sr-only">Status: </span>All passing</span>';
 
                 roundRows.push([row.round_id, row.start_time, row.end_time, row.total_seconds, ratio, failureText]);
             });


### PR DESCRIPTION
## Summary
Improves screen reader and keyboard accessibility across the interface, targeting WCAG 2.1 AA compliance.

## Changes
- ARIA landmarks, skip-to-main-content link, and visible focus styles
- `scope="col"` and `<caption>` on all data tables
- Fixed broken `<label for>` associations in forms
- `aria-live` regions for all dynamically updated content
- sr-only `<h1>` on every page; fixed heading level skips
- sr-only fallback tables for ECharts charts on scoreboard
- Replaced incorrect `role="tablist/tab"` on page navigation links with `<nav>` + `aria-current="page"`
- Fixed duplicate `id="main-content"` between `base.html` and `admin/adminbase.html`
- sr-only text prefixes so pass/fail status is not conveyed by color alone

## Known Limitation
ECharts tooltip content on the scoreboard is inaccessible to screen readers due to a library limitation so sr-only fallback tables are provided as an alternative.

## Remaining Work
Admin-specific templates will be addressed in a follow-up PR.

Co-authored-by: JJCUBER <34446698+JJCUBER@users.noreply.github.com>
Co-authored-by: David Nguyen <107872059+dnguyen0091@users.noreply.github.com>