### PR TITLE
fix/bin setup improvements

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -4,6 +4,7 @@ from random import choice, randint, sample
 
 import optparse
 import os
+import sys
 
 from scoring_engine.models.inject import Template, Inject
 from scoring_engine.models.team import Team
@@ -33,18 +34,12 @@ parser.add_option("--example", action="store_true", default=False)
 
 options, arguments = parser.parse_args()
 
-# In order to handle docker-compose usability
-# we have a check to see if the SCORINGENGINE_EXAMPLE environment
-# variable is true. If it is, we want to populate
-# the db with example data
-if "SCORINGENGINE_EXAMPLE" in os.environ and os.environ["SCORINGENGINE_EXAMPLE"].lower() == "true":
+if os.environ.get("SCORINGENGINE_EXAMPLE", "").lower() == "true":
     options.overwrite_db = True
     options.example = True
 
-# If the SCORINGENGINE_OVERWRITE_DB environment variable is set
-# we want to delete any previous data in the db
-if "SCORINGENGINE_OVERWRITE_DB" in os.environ and os.environ["SCORINGENGINE_OVERWRITE_DB"].lower() == "true":
-    options.overwrite_db = os.environ["SCORINGENGINE_OVERWRITE_DB"] == "true"
+if os.environ.get("SCORINGENGINE_OVERWRITE_DB", "").lower() == "true":
+    options.overwrite_db = True
 
 logger.info("Starting Setup v.{0}".format(version))
 
@@ -52,20 +47,23 @@ logger.info("Starting Setup v.{0}".format(version))
 app = create_app()
 
 with app.app_context():
-    if not options.overwrite_db:
-        if verify_db_ready():
-            logger.error("Exiting script and not overwriting db...must use --overwrite-db to overwrite data.")
-            exit()
-        else:
-            # Database doesn't exist, so continuing on to setup script
-            logger.debug("Database doesn't exist yet...")
+    db_ready = verify_db_ready()
+
+    if db_ready and not options.overwrite_db:
+        logger.info("Database already initialized; skipping setup. (use --overwrite-db to reset)")
+        sys.exit(0)
 
     logger.info("Setting up DB")
-    delete_db()
+
+    if options.overwrite_db and db_ready:
+        logger.warning("Overwriting existing DB (--overwrite-db enabled)")
+        delete_db()
+
     init_db()
 
     competition_config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "competition.yaml")
-    sample_competition_str = open(competition_config_file, "r").read()
+    with open(competition_config_file, "r") as f:
+        sample_competition_str = f.read()
     competition = Competition.parse_yaml_str(sample_competition_str)
     competition.save()
 


### PR DESCRIPTION
Closing [PR#1127](https://github.com/scoringengine/scoringengine/pull/1127) and splitting into individual PR's.

## Summary
- If the database is already initialized and `--overwrite-db` is not set, exit cleanly with code 0 instead of logging an error and calling `exit()`. This makes the script safe to call multiple times (e.g. from docker bootstrap on restart).
- **Fix silent overwrite bug**: previously `SCORINGENGINE_OVERWRITE_DB=true` set `options.overwrite_db` to the result of `os.environ[...] == "true"`. Replaced with `os.environ.get()` pattern and explicit `True`.
- **Don't delete DB unnecessarily**: `delete_db()` was always called even on a fresh empty database.
  - Now only called when `--overwrite-db` is set and the DB already exists.
- `os.environ.get()` instead of double key lookup, `sys.exit()` instead of `exit()`, `with open()` for file handle.

## Testing
- Fresh install `docker compose up` bootstraps normally
- Second run without `--overwrite-db` exits 0, skips setup
- `SCORINGENGINE_OVERWRITE_DB=true` wipes and re-seeds
- `SCORINGENGINE_EXAMPLE=true` loads example data