### PR TITLE
feat/add integration test timeout and docker debug logs on failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,4 +42,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run integration tests
+        timeout-minutes: 25
         run: ./tests/integration/run.sh
+
+      - name: Debug docker state (on failure)
+        if: failure()
+        run: |
+          echo "=== docker ps ==="
+          docker ps -a
+          echo "=== docker compose logs (tail) ==="
+          docker compose -f docker-compose.yml -f docker/testbed/docker-compose.yml -f tests/integration/docker-compose.yml -p scoringengine logs --no-color --tail=300 || true


### PR DESCRIPTION
Closing [#1127 ](https://github.com/scoringengine/scoringengine/pull/1127) and splitting into individual PR's.

## Summary
- Add `timeout-minutes: 25` to the integration test run step to prevent hung tests from blocking CI indefinitely
- Add a "Debug docker state (on failure)" step that dumps `docker ps` and full container logs when
  the integration job fails, making it easier to diagnose what went wrong