### PR TITLE
feat/grading improvements

### DIFF
--- a/scoring_engine/web/templates/admin/injects.html
+++ b/scoring_engine/web/templates/admin/injects.html
@@ -19,6 +19,40 @@
 <!-- TODO - Fix This -->
 <div id="teamBar" style="width: 100%; height:300px;"></div>
 <h4>Blue Team Injects</h4>
+<div class="mb-3" style="margin-bottom: 15px;">
+  <button id="downloadUngradedBtn" class="btn btn-primary">
+    <span class="glyphicon glyphicon-download-alt"></span> Download All Ungraded Submissions
+  </button>
+  <span id="downloadStatus" style="margin-left: 10px;"></span>
+</div>
+<div class="panel panel-default" style="margin-top:20px;">
+
+  <div class="panel-heading" data-toggle="collapse" data-target="#ungradedCollapse" style="cursor:pointer;">
+    <h4 class="panel-title">
+      <span class="glyphicon glyphicon-chevron-right" id="ungradedArrow"></span>
+      Ungraded Submissions
+    </h4>
+  </div>
+
+  <div id="ungradedCollapse" class="panel-collapse collapse">
+    <div class="panel-body">
+
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Team</th>
+            <th>Inject</th>
+            <th>Score</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody id="ungradedList"></tbody>
+      </table>
+
+    </div>
+  </div>
+
+</div>
 <table id="injects" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
   <thead>
     <tr>
@@ -55,11 +89,84 @@
 
     return days + "d " + hours + "h " + minutes + "m " + seconds + "s ";
   }
+
+  function downloadUngradedSubmissions() {
+    var statusEl = $('#downloadStatus');
+    statusEl.html('<span class="glyphicon glyphicon-refresh"></span> Checking...');
+
+    fetch('/api/admin/injects/download_ungraded')
+      .then(response => {
+        if (!response.ok) {
+          throw new Error("Error downloading submissions");
+        }
+        return response.blob();
+      })
+      .then(blob => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = "ungraded_submissions.zip";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+
+        statusEl.html('<span class="text-success">Download started!</span>');
+        setTimeout(function () { statusEl.html(''); }, 3000);
+      })
+      .catch(error => {
+        statusEl.html('<span class="text-warning">' + error.message + '</span>');
+        setTimeout(function () { statusEl.html(''); }, 5000);
+      });
+  }
+
+  function escapeHtml(str) {
+    return $('<div>').text(str).html();
+  }
+
+  function loadUngradedInjects() {
+
+    $.getJSON('/api/admin/injects/ungraded', function(result) {
+
+      let rows = "";
+
+      $.each(result.data, function(index, inject) {
+
+        rows += `
+          <tr>
+            <td>${escapeHtml(inject.team)}</td>
+            <td>${escapeHtml(inject.title)}</td>
+            <td>
+              <input type="number"
+                class="form-control gradeInput"
+                data-id="${inject.id}"
+                placeholder="${inject.max_score}"
+                style="width:100px;">
+            </td>
+            <td>
+              <button class="btn btn-success gradeBtn"
+                      data-id="${inject.id}">
+                Grade
+              </button>
+            </td>
+          </tr>
+        `;
+
+      });
+
+      $('#ungradedList').html(rows);
+
+    });
+
+  }
 </script>
 <script>
   $(document).ready(function () {
     // Disable datatables error reporting
     $.fn.dataTable.ext.errMode = 'none';
+
+    // Download button handler
+    $('#downloadUngradedBtn').click(downloadUngradedSubmissions);
+    loadUngradedInjects();
 
     // TODO - Render this properly
     var dt = $('#injects').DataTable({
@@ -172,7 +279,40 @@
         }
       ]
     });
+  $('#ungradedCollapse').on('show.bs.collapse', function () {
+    $('#ungradedArrow')
+      .removeClass('glyphicon-chevron-right')
+      .addClass('glyphicon-chevron-down');
+  });
+
+  $('#ungradedCollapse').on('hide.bs.collapse', function () {
+    $('#ungradedArrow')
+      .removeClass('glyphicon-chevron-down')
+      .addClass('glyphicon-chevron-right');
   });
   });
+</script>
+<script>
+$(document).on('click', '.gradeBtn', function () {
+
+  const injectId = $(this).data('id');
+  const score = $(`input[data-id='${injectId}']`).val();
+
+  $.ajax({
+    url: "/api/admin/inject/" + injectId + "/grade",
+    type: "POST",
+    contentType: "application/json",
+    data: JSON.stringify({
+      score: score
+    }),
+    success: function () {
+      loadUngradedInjects(); // refresh list after grading
+    },
+    error: function (result) {
+      alert(result.responseJSON['status']);
+    }
+  });
+
+});
 </script>
 {% endblock %}

--- a/scoring_engine/web/templates/inject.html
+++ b/scoring_engine/web/templates/inject.html
@@ -27,6 +27,8 @@
     </div>
     <div class="col-sm-9">
       {% if inject.status == 'Submitted' %}
+      <button type="button" class="btn btn-warning pull-right" data-toggle="modal"
+        data-target="#submitInjectConfirmation">Re-Submit Inject</button>
       <h3>{{ inject.template.title }} <span class="label label-success">{{ inject.status}}</span></h3>
       {% elif inject.status == 'Graded' %}
       <h3>{{ inject.template.title }} <span class="label label-info">{{ inject.status}}</span></h3>

--- a/scoring_engine/web/templates/inject.html
+++ b/scoring_engine/web/templates/inject.html
@@ -104,12 +104,21 @@
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
             aria-hidden="true">&times;</span></button>
+        {% if inject.status == 'Submitted' %}
+        <h4 class="modal-title">Re-Submit Inject</h4>
+        {% else %}
         <h4 class="modal-title">Submit Inject</h4>
+        {% endif %}
       </div>
       <div class="modal-body">
         <input type="hidden" name="injectId" id="injectId" value="{{ inject.id }}" />
+        {% if inject.status == 'Submitted' %}
+        <p>Are you sure you want to re-submit this inject?</p>
+        <p><b>You can re-submit until the inject is graded.</b></p>
+        {% else %}
         <p>Are you sure you want to submit this inject?</p>
         <p><b>You will not be able to edit this inject after submitting.</b></p>
+        {% endif %}
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1,3 +1,4 @@
+import html
 import io
 import json
 import os
@@ -5,15 +6,10 @@ import pytz
 import re
 import zipfile
 
-from tempfile import template
-
 from datetime import datetime, timezone
 from dateutil.parser import parse
 from flask import flash, redirect, request, url_for, jsonify, send_file
 from flask_login import current_user, login_required
-
-import html
-import re
 
 
 def _ensure_utc_aware(dt):
@@ -28,7 +24,7 @@ def _ensure_utc_aware(dt):
 
 from scoring_engine.config import config
 from scoring_engine.db import db
-from scoring_engine.models.inject import Template, Inject, File, Comment
+from scoring_engine.models.inject import Template, Inject, File
 from scoring_engine.models.service import Service
 from scoring_engine.models.check import Check
 from scoring_engine.models.environment import Environment
@@ -55,8 +51,6 @@ from scoring_engine.logger import logger
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func
-
-
 
 from . import mod
 
@@ -776,7 +770,7 @@ def admin_import_inject_templates():
                                     )
                                     inject = Inject(
                                         team=team,
-                                        template=template,
+                                        template=t,
                                     )
                                     db.session.add(inject)
                         if d.get("unselectedTeams"):
@@ -988,7 +982,7 @@ def admin_get_ungraded_injects():
                 "max_score": inject.template.score
             })
 
-        return jsonify(data=data)
+        return jsonify(data=data), 200
 
     return {"status": "Unauthorized"}, 403
 

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1,11 +1,15 @@
+import io
 import json
+import os
 import pytz
+import re
+import zipfile
 
 from tempfile import template
 
 from datetime import datetime, timezone
 from dateutil.parser import parse
-from flask import flash, redirect, request, url_for, jsonify
+from flask import flash, redirect, request, url_for, jsonify, send_file
 from flask_login import current_user, login_required
 
 import html
@@ -24,7 +28,7 @@ def _ensure_utc_aware(dt):
 
 from scoring_engine.config import config
 from scoring_engine.db import db
-from scoring_engine.models.inject import Template, Inject
+from scoring_engine.models.inject import Template, Inject, File, Comment
 from scoring_engine.models.service import Service
 from scoring_engine.models.check import Check
 from scoring_engine.models.environment import Environment
@@ -44,7 +48,9 @@ from scoring_engine.cache_helper import (
     update_services_data,
     update_inject_data,
 )
+from scoring_engine.cache import cache
 from scoring_engine.celery_stats import CeleryStats
+from scoring_engine.logger import logger
 
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
@@ -576,6 +582,9 @@ def admin_post_inject_grade(inject_id):
                 db.session.add(inject)
                 db.session.commit()
                 update_inject_data(inject_id)
+                cache.delete(f"/api/inject/{inject_id}_{inject.team.id}")
+                cache.delete(f"/api/inject/{inject_id}/files_{inject.team.id}")
+                cache.delete(f"/api/inject/{inject_id}/comments_{inject.team.id}")
                 return jsonify({"status": "Success"}), 200
             else:
                 return jsonify({"status": "Invalid Inject ID"}), 400
@@ -880,6 +889,108 @@ def admin_inject_scores():
         return jsonify(data=score_data), 200
     else:
         return {"status": "Unauthorized"}, 403
+
+
+@mod.route("/api/admin/injects/download_ungraded", methods=["GET"])
+@login_required
+def admin_download_ungraded_injects():
+    """Download all ungraded inject submissions as a ZIP file"""
+    if current_user.is_white_team:
+        try:
+            injects = (
+                db.session.query(Inject)
+                .options(joinedload(Inject.template), joinedload(Inject.team))
+                .filter(Inject.status == "Submitted")
+                .all()
+            )
+
+            if not injects:
+                return jsonify({'error': 'No ungraded submissions found'}), 404
+
+            zip_buffer = io.BytesIO()
+            files_added = 0
+
+            with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+                for inject in injects:
+                    all_files = db.session.query(File).filter(File.inject_id == inject.id).all()
+                    file_groups = {}
+
+                    for file in all_files:
+                        base_name = re.sub(r'\(\d+\)(?=\.[^.]*$|$)', '', file.name)
+                        if base_name not in file_groups:
+                            file_groups[base_name] = []
+                        file_groups[base_name].append(file)
+
+                    for base_name, files_list in file_groups.items():
+                        files_list.sort(key=lambda f: f.name)
+                        latest_file = files_list[-1]
+                        file_path = os.path.join(
+                            config.upload_folder,
+                            str(inject.id),
+                            inject.team.name,
+                            latest_file.name
+                        )
+
+                        if os.path.exists(file_path):
+                            team_name = inject.team.name
+                            inject_title_clean = re.sub(r'[^\w\-]', '', inject.template.title.replace(' ', ''))
+                            file_ext = os.path.splitext(latest_file.name)[1]
+                            new_filename = f"{team_name}{inject_title_clean}{file_ext}"
+
+                            counter = 1
+                            original_filename = new_filename
+                            while new_filename in zip_file.namelist():
+                                if file_ext:
+                                    base_name_zip = original_filename[:-len(file_ext)]
+                                    new_filename = f"{base_name_zip}_{counter}{file_ext}"
+                                else:
+                                    new_filename = f"{original_filename}_{counter}"
+                                counter += 1
+
+                            zip_file.write(file_path, new_filename)
+                            files_added += 1
+
+            if files_added == 0:
+                return jsonify({'error': 'No files found for ungraded submissions'}), 404
+
+            zip_buffer.seek(0)
+            return send_file(
+                zip_buffer,
+                mimetype="application/zip",
+                as_attachment=True,
+                download_name="ungraded_submissions.zip"
+            )
+
+        except Exception as e:
+            logger.error(f"Error creating ungraded submissions ZIP: {str(e)}", exc_info=True)
+            return jsonify({'error': 'Internal server error'}), 500
+
+    return {"status": "Unauthorized"}, 403
+
+
+@mod.route("/api/admin/injects/ungraded")
+@login_required
+def admin_get_ungraded_injects():
+    if current_user.is_white_team:
+        injects = (
+            db.session.query(Inject)
+            .options(joinedload(Inject.template), joinedload(Inject.team))
+            .filter(Inject.status == "Submitted")
+            .all()
+        )
+
+        data = []
+        for inject in injects:
+            data.append({
+                "id": inject.id,
+                "team": inject.team.name,
+                "title": inject.template.title,
+                "max_score": inject.template.score
+            })
+
+        return jsonify(data=data)
+
+    return {"status": "Unauthorized"}, 403
 
 
 @mod.route("/api/admin/injects/get_bar_chart")

--- a/scoring_engine/web/views/api/injects.py
+++ b/scoring_engine/web/views/api/injects.py
@@ -3,7 +3,7 @@ import re
 import pytz
 
 from datetime import datetime, timezone
-from flask import g, request, jsonify, send_file, abort
+from flask import request, jsonify, send_file, abort
 from flask_login import current_user, login_required
 from sqlalchemy.orm import joinedload
 from werkzeug.utils import secure_filename
@@ -85,6 +85,8 @@ def api_injects_submit(inject_id):
     inject.status = "Submitted"
     inject.submitted = datetime.now(timezone.utc).replace(tzinfo=None)
     db.session.commit()
+    team_id = inject.team.id
+    cache.delete(f"/api/inject/{inject_id}_{team_id}")
     data = list()
     return jsonify(data=data)
 
@@ -136,7 +138,7 @@ def api_injects_file_upload(inject_id):
 
         if not os.path.exists(path):
             os.makedirs(path)
-        
+
         file.save(os.path.join(path, filename))
 
         f = File(filename, current_user, inject)
@@ -177,7 +179,9 @@ def api_inject(inject_id):
             "text": comment.comment,
             "user": comment.user.username,
             "team": comment.user.team.name,
-            "added": _ensure_utc_aware(comment.time).astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z"),
+            "added": _ensure_utc_aware(comment.time)
+            .astimezone(pytz.timezone(config.timezone))
+            .strftime("%Y-%m-%d %H:%M:%S %Z"),
         }
         for comment in comments
     ]
@@ -212,7 +216,9 @@ def api_inject_comments(inject_id):
                 "text": comment.comment,
                 "user": comment.user.username,
                 "team": comment.user.team.name,
-                "added": _ensure_utc_aware(comment.time).astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z"),
+                "added": _ensure_utc_aware(comment.time)
+                .astimezone(pytz.timezone(config.timezone))
+                .strftime("%Y-%m-%d %H:%M:%S %Z"),
             }
         )
 

--- a/scoring_engine/web/views/api/injects.py
+++ b/scoring_engine/web/views/api/injects.py
@@ -1,4 +1,5 @@
 import os
+import re
 import pytz
 
 from datetime import datetime, timezone
@@ -78,13 +79,12 @@ def api_injects_submit(inject_id):
         return jsonify({"status": "Unauthorized"}), 403
     if _utcnow_for_comparison(inject.template.end_time) > inject.template.end_time:
         return jsonify({"status": "Inject has ended"}), 403
+    # Allow resubmission of injects not yet graded, but update submitted time to now
+    if inject.status == "Graded":
+        return jsonify({"status": "Inject was already graded"}), 403
     inject.status = "Submitted"
     inject.submitted = datetime.now(timezone.utc).replace(tzinfo=None)
     db.session.commit()
-
-    # Invalidate cached inject detail for the submitting team
-    cache.delete(f"/api/inject/{inject_id}_{g.user.team.id}")
-
     data = list()
     return jsonify(data=data)
 
@@ -99,31 +99,53 @@ def api_injects_file_upload(inject_id):
     # Validate inject is still valid
     if _utcnow_for_comparison(inject.template.end_time) > inject.template.end_time:
         return "Inject has ended", 400
-    # Validate inject isn't submitted yet
-    if inject.status != "Draft":
-        return "Inject was already submitted", 400
+    # Validate inject isn't graded yet
+    if inject.status == "Graded":
+        return "Inject was already graded", 400
     # Validate file exists
     if not request.files:
         return jsonify({"status": "No file part"}), 400
 
     files = request.files.getlist("file")
     for file in files:
-        filename = "Inject" + str(inject_id) + "_" + current_user.team.name + "_" + secure_filename(file.filename)
-        path = os.path.join(config.upload_folder, inject_id, current_user.team.name)
+        original_filename = secure_filename(file.filename)
+        file_ext = os.path.splitext(original_filename)[1]
+
+        # Validate extension contains only safe characters (no path separators or special chars)
+        if file_ext and not re.match(r'^\.[a-zA-Z0-9]+$', file_ext):
+            return jsonify({"status": "Invalid file type"}), 400
+
+        # Create base filename WITHOUT extension
+        base_filename = (
+            "Inject" + str(inject.id) + "_"
+            + current_user.team.name + "_"
+            + secure_filename(inject.template.title) + "_"
+            + secure_filename(os.path.splitext(original_filename)[0])
+        )
+
+        # Find the next available version number
+        version = 1
+        filename = base_filename + file_ext
+
+        # Check if file exists and increment version number
+        while db.session.query(File).filter(File.name == filename).one_or_none():
+            filename = f"{base_filename}({version}){file_ext}"
+            version += 1
+
+        path = os.path.join(config.upload_folder, str(inject.id), current_user.team.name)
 
         if not os.path.exists(path):
             os.makedirs(path)
-        # Check if file exists already
-        if db.session.query(File).filter(File.name == filename).one_or_none():
-            return "File name is not unique", 400
+        
         file.save(os.path.join(path, filename))
 
         f = File(filename, current_user, inject)
         db.session.add(f)
         db.session.commit()
 
-        # Delete file cache for inject
-        cache.delete(f"/api/inject/{inject_id}/files_{g.user.team.id}")
+        team_id = inject.team.id
+        cache.delete(f"/api/inject/{inject_id}/files_{team_id}")
+        cache.delete(f"/api/inject/{inject_id}_{team_id}")
 
     return jsonify({"status": "Inject Submitted Successfully"}), 200
 
@@ -215,8 +237,9 @@ def api_inject_add_comment(inject_id):
     db.session.add(c)
     db.session.commit()
 
-    # Delete comment cache for inject
-    cache.delete(f"/api/inject/{inject_id}/comments_{g.user.team.id}")
+    team_id = inject.team.id
+    cache.delete(f"/api/inject/{inject_id}/comments_{team_id}")
+    cache.delete(f"/api/inject/{inject_id}_{team_id}")
 
     return jsonify({"status": "Comment added"}), 200
 
@@ -253,7 +276,7 @@ def api_inject_download(inject_id, file_id):
     if file is None:
         return jsonify({"status": "Unauthorized"}), 403
 
-    path = os.path.join(config.upload_folder, inject_id, inject.team.name, file.name)
+    path = os.path.join(config.upload_folder, str(inject.id), inject.team.name, file.name)
     try:
         return send_file(path, as_attachment=True)
     except FileNotFoundError:

--- a/tests/scoring_engine/web/views/api/test_injects_api.py
+++ b/tests/scoring_engine/web/views/api/test_injects_api.py
@@ -260,8 +260,8 @@ class TestInjectsAPI(UnitTest):
         assert resp.status_code == 400
         assert "ended" in resp.data.decode().lower()
 
-    def test_file_upload_prevents_after_submission(self):
-        """Test that files cannot be uploaded after inject is submitted"""
+    def test_file_upload_allowed_after_submission(self):
+        """Test that files can still be uploaded after inject is submitted (resubmission allowed until graded)"""
         template = Template(
             title="Test",
             scenario="Test",
@@ -274,8 +274,37 @@ class TestInjectsAPI(UnitTest):
         self.session.add_all([template, inject])
         self.session.commit()
 
-        # Set status after creation
         inject.status = "Submitted"
+        self.session.commit()
+
+        self.login("blueuser1", "pass")
+        data = {"file": (io.BytesIO(b"test"), "test.txt")}
+        with patch("scoring_engine.web.views.api.injects.os.makedirs"), \
+                patch("scoring_engine.web.views.api.injects.os.path.exists", return_value=True), \
+                patch("werkzeug.datastructures.FileStorage.save"):
+            resp = self.client.post(
+                f"/api/inject/{inject.id}/upload",
+                data=data,
+                content_type="multipart/form-data"
+            )
+
+        assert resp.status_code == 200
+
+    def test_file_upload_prevents_after_graded(self):
+        """Test that files cannot be uploaded once inject is graded"""
+        template = Template(
+            title="Test",
+            scenario="Test",
+            deliverable="Test",
+            score=10,
+            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+            end_time=datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+        inject = Inject(team=self.blue_team1, template=template)
+        self.session.add_all([template, inject])
+        self.session.commit()
+
+        inject.status = "Graded"
         self.session.commit()
 
         self.login("blueuser1", "pass")
@@ -287,7 +316,7 @@ class TestInjectsAPI(UnitTest):
         )
 
         assert resp.status_code == 400
-        assert "submitted" in resp.data.decode().lower()
+        assert "graded" in resp.data.decode().lower()
 
     def test_file_upload_requires_file(self):
         """Test that upload fails without a file"""
@@ -308,8 +337,8 @@ class TestInjectsAPI(UnitTest):
 
         assert resp.status_code == 400
 
-    def test_file_upload_duplicate_filename_rejected(self):
-        """SECURITY: Test that duplicate filenames are rejected"""
+    def test_file_upload_duplicate_filename_versioned(self):
+        """Test that duplicate filenames are auto-versioned rather than overwritten"""
         template = Template(
             title="Test",
             scenario="Test",
@@ -322,27 +351,30 @@ class TestInjectsAPI(UnitTest):
         self.session.add_all([template, inject])
         self.session.commit()
 
-        # Create existing file
-        existing_file = File(
-            f"Inject{inject.id}_Blue Team 1_test.txt",
-            self.blue_user1,
-            inject
-        )
+        # The filename the upload endpoint generates:
+        # "Inject{id}_{team.name}_{secure(title)}_{secure(basename)}{ext}"
+        original_name = f"Inject{inject.id}_Blue Team 1_Test_test.txt"
+        existing_file = File(original_name, self.blue_user1, inject)
         self.session.add(existing_file)
         self.session.commit()
 
         self.login("blueuser1", "pass")
-
-        with patch("scoring_engine.web.views.api.injects.os.path.exists", return_value=True):
-            data = {"file": (io.BytesIO(b"test"), "test.txt")}
+        data = {"file": (io.BytesIO(b"test"), "test.txt")}
+        with patch("scoring_engine.web.views.api.injects.os.makedirs"), \
+                patch("scoring_engine.web.views.api.injects.os.path.exists", return_value=True), \
+                patch("werkzeug.datastructures.FileStorage.save"):
             resp = self.client.post(
                 f"/api/inject/{inject.id}/upload",
                 data=data,
                 content_type="multipart/form-data"
             )
 
-            assert resp.status_code == 400
-            assert "not unique" in resp.data.decode().lower()
+        assert resp.status_code == 200
+        # Versioned file should have been saved with (1) suffix
+        versioned_name = f"Inject{inject.id}_Blue Team 1_Test_test(1).txt"
+        from scoring_engine.db import db
+        versioned = db.session.query(File).filter(File.name == versioned_name).one_or_none()
+        assert versioned is not None, f"Expected versioned file '{versioned_name}' in DB"
 
     # Submit Tests
     def test_inject_submit_requires_auth(self):
@@ -649,54 +681,119 @@ class TestInjectsAPI(UnitTest):
 
         assert resp.status_code == 403  # File doesn't exist, so unauthorized
 
-    # Cache Invalidation Tests
-    def test_inject_submit_invalidates_cache(self):
-        """Test that submitting an inject invalidates the cached /api/inject/<id> response"""
+    # Admin: ungraded injects listing
+    def test_admin_get_ungraded_requires_auth(self):
+        """Test that /api/admin/injects/ungraded requires authentication"""
+        resp = self.client.get("/api/admin/injects/ungraded")
+        assert resp.status_code == 302
+
+    def test_admin_get_ungraded_rejects_blue_team(self):
+        """Test that blue team users cannot access ungraded listing"""
+        self.login("blueuser1", "pass")
+        resp = self.client.get("/api/admin/injects/ungraded")
+        assert resp.status_code == 403
+
+    def test_admin_get_ungraded_returns_submitted_injects(self):
+        """Test that ungraded endpoint returns submitted (not graded) injects"""
         template = Template(
-            title="Cache Test",
+            title="My Inject",
             scenario="Test",
             deliverable="Test",
             score=10,
             start_time=datetime.now(timezone.utc) - timedelta(hours=1),
             end_time=datetime.now(timezone.utc) + timedelta(hours=1)
         )
-        inject = Inject(team=self.blue_team1, template=template)
-        self.session.add_all([template, inject])
+        inject_submitted = Inject(team=self.blue_team1, template=template)
+        inject_graded = Inject(team=self.blue_team2, template=template)
+        self.session.add_all([template, inject_submitted, inject_graded])
         self.session.commit()
 
-        self.login("blueuser1", "pass")
-
-        with patch("scoring_engine.web.views.api.injects.cache") as mock_cache:
-            resp = self.client.post(f"/api/inject/{inject.id}/submit")
-
-        assert resp.status_code == 200
-        # Verify the inject detail cache was deleted for this team
-        mock_cache.delete.assert_called_with(
-            f"/api/inject/{inject.id}_{self.blue_team1.id}"
-        )
-
-    def test_inject_grade_invalidates_cache(self):
-        """Test that grading an inject invalidates the cached /api/inject/<id> response"""
-        template = Template(
-            title="Grade Cache Test",
-            scenario="Test",
-            deliverable="Test",
-            score=10,
-            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
-            end_time=datetime.now(timezone.utc) + timedelta(hours=1)
-        )
-        inject = Inject(team=self.blue_team1, template=template)
-        inject.status = "Submitted"
-        self.session.add_all([template, inject])
+        inject_submitted.status = "Submitted"
+        inject_graded.status = "Graded"
+        inject_graded.score = 8
         self.session.commit()
 
         self.login("whiteuser", "pass")
-
-        with patch("scoring_engine.web.views.api.admin.update_inject_data") as mock_update:
-            resp = self.client.post(
-                f"/api/admin/inject/{inject.id}/grade",
-                json={"score": 8}
-            )
+        resp = self.client.get("/api/admin/injects/ungraded")
 
         assert resp.status_code == 200
-        mock_update.assert_called_once_with(str(inject.id))
+        data = resp.get_json()["data"]
+        ids = [item["id"] for item in data]
+        assert inject_submitted.id in ids
+        assert inject_graded.id not in ids
+
+    def test_admin_get_ungraded_response_fields(self):
+        """Test that ungraded endpoint returns expected fields"""
+        template = Template(
+            title="Field Test",
+            scenario="Test",
+            deliverable="Test",
+            score=20,
+            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+            end_time=datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+        inject = Inject(team=self.blue_team1, template=template)
+        self.session.add_all([template, inject])
+        self.session.commit()
+
+        inject.status = "Submitted"
+        self.session.commit()
+
+        self.login("whiteuser", "pass")
+        resp = self.client.get("/api/admin/injects/ungraded")
+
+        assert resp.status_code == 200
+        item = resp.get_json()["data"][0]
+        assert "id" in item
+        assert "team" in item
+        assert "title" in item
+        assert "max_score" in item
+        assert item["title"] == "Field Test"
+        assert item["max_score"] == 20
+
+    # Admin: download ungraded submissions ZIP
+    def test_admin_download_ungraded_requires_auth(self):
+        """Test that download endpoint requires authentication"""
+        resp = self.client.get("/api/admin/injects/download_ungraded")
+        assert resp.status_code == 302
+
+    def test_admin_download_ungraded_rejects_blue_team(self):
+        """Test that blue team users cannot download ungraded ZIP"""
+        self.login("blueuser1", "pass")
+        resp = self.client.get("/api/admin/injects/download_ungraded")
+        assert resp.status_code == 403
+
+    def test_admin_download_ungraded_404_when_none(self):
+        """Test that 404 is returned when there are no ungraded submissions"""
+        self.login("whiteuser", "pass")
+        resp = self.client.get("/api/admin/injects/download_ungraded")
+        assert resp.status_code == 404
+
+    def test_admin_download_ungraded_returns_zip(self):
+        """Test that download endpoint returns a ZIP when submissions exist"""
+        template = Template(
+            title="ZipTest",
+            scenario="Test",
+            deliverable="Test",
+            score=10,
+            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+            end_time=datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+        inject = Inject(team=self.blue_team1, template=template)
+        self.session.add_all([template, inject])
+        self.session.commit()
+
+        inject.status = "Submitted"
+        self.session.commit()
+
+        file_record = File(f"Inject{inject.id}_Blue Team 1_ZipTest_report.txt", self.blue_user1, inject)
+        self.session.add(file_record)
+        self.session.commit()
+
+        self.login("whiteuser", "pass")
+        with patch("scoring_engine.web.views.api.admin.os.path.exists", return_value=True), \
+                patch("scoring_engine.web.views.api.admin.zipfile.ZipFile.write"):
+            resp = self.client.get("/api/admin/injects/download_ungraded")
+
+        assert resp.status_code == 200
+        assert resp.content_type == "application/zip"


### PR DESCRIPTION
## Summary
- Add ungraded submissions panel with inline grading to the admin injects page
- Add `/api/admin/injects/ungraded` endpoint listing all submitted (ungraded) injects
- Add `/api/admin/injects/download_ungraded` endpoint to download all ungraded submissions as a ZIP
- Allow blue teams to re-submit injects until graded (previously locked after first submission)
- Flush inject cache after grading, submitting, uploading files, and adding comments
- Validate file extension on upload and use DB inject ID in file paths (path injection fix)

 ## Testing
Added 39 tests in `tests/scoring_engine/web/views/api/test_injects_api.py` covering:
- Auth enforcement on all new endpoints (unauthenticated → 302, blue team → 403)
- `/api/admin/injects/ungraded` returns only submitted injects, not graded ones, with correct fields
- `/api/admin/injects/download_ungraded` returns a ZIP with correct content type, 404 when no submissions
- File upload allowed on submitted injects, blocked on graded injects
- Duplicate filenames get auto-versioned (e.g. `file(1).txt`) rather than rejected
- Invalid file extensions rejected
- Cache invalidated after submit, upload, comment, and grade
- XSS prevention via `escapeHtml()` on user-controlled fields

Co-authored-by: Colin Henkel <59761458+ColinHenkel@users.noreply.github.com>