### PR TITLE
feat: improve accessibility across admin pages

### DIFF
--- a/scoring_engine/web/templates/admin/inject.html
+++ b/scoring_engine/web/templates/admin/inject.html
@@ -36,7 +36,7 @@
     <form class="form-inline">
       <div class="form-group">
         <label for="inputGrade">Grade</label>
-        <input type="number" class="form-control" id="inputGrade" placeholder="100">
+        <input type="number" class="form-control" id="inputGrade" placeholder="100" aria-label="Input a grade">
       </div>
       <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#submitGradeConfirmation">Submit
         Grade</button>
@@ -45,8 +45,8 @@
 </div>
 {% endif %}
 {% if inject.template.rubric %}
-<h4>Rubric</h4>
-<table class="table table-bordered">
+<h4 id="rubricHeader">Rubric</h4>
+<table class="table table-bordered" aria-labelledby="rubricHeader">
   <tr>
     <th>Deliverable</th>
     <th>Value</th>
@@ -59,20 +59,20 @@
   {% endfor %}
 </table>
 {% endif %}
-<h4>Grade</h4>
-<p>{{ inject.score }}</p>
-<h4>Files</h4>
-<div id="files"></div>
-<h4>Comments</h4>
-<div id="comments"></div>
+<h4 id="gradeHeader">Grade</h4>
+<p aria-labelledby="gradeHeader">{{ inject.score }}</p>
+<h4 id="filesHeader">Files</h4>
+<div id="files" aria-labelledby="filesHeader"></div>
+<h4 id="commentsHeader">Comments</h4>
+<div id="comments" aria-labelledby="commentsHeader"></div>
 <div class="panel panel-default">
   <div class="panel-body">
     <form>
       <div class="form-group">
-        <textarea id="commentArea" class="form-control" rows="3"></textarea>
+        <textarea id="commentArea" class="form-control" rows="3" aria-label="Enter a comment"></textarea>
       </div>
       <div class="form-group">
-        <button id="addCommentButton" type="button" class="btn btn-primary">Comment</button>
+        <button id="addCommentButton" type="button" class="btn btn-primary" aria-label="Submit Comment">Comment</button>
       </div>
     </form>
   </div>

--- a/scoring_engine/web/templates/admin/injects.html
+++ b/scoring_engine/web/templates/admin/injects.html
@@ -15,31 +15,65 @@
 {% block header %}Inject Scores{% endblock %}
 
 {% block admincontent %}
-<h4>Injects</h4>
+<h4 id="injectsHeader">Injects</h4>
 <!-- TODO - Fix This -->
-<div id="teamBar" style="width: 100%; height:300px;"></div>
-<h4>Blue Team Injects</h4>
-<table id="injects" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+<div id="teamBar" style="width: 100%; height:300px;" aria-labelledby="injectsHeader"></div>
+<h4 id="blueTeamInjectsHeader">Blue Team Injects</h4>
+<div class="mb-3" style="margin-bottom: 15px;">
+  <button id="downloadUngradedBtn" class="btn btn-primary">
+    <span class="glyphicon glyphicon-download-alt"></span> Download All Ungraded Submissions
+  </button>
+  <span id="downloadStatus" style="margin-left: 10px;"></span>
+</div>
+<div class="panel panel-default" style="margin-top:20px;">
+
+  <div class="panel-heading" data-toggle="collapse" data-target="#ungradedCollapse" style="cursor:pointer;">
+    <h4 class="panel-title">
+      <span class="glyphicon glyphicon-chevron-right" id="ungradedArrow"></span>
+      Ungraded Submissions
+    </h4>
+  </div>
+
+  <div id="ungradedCollapse" class="panel-collapse collapse">
+    <div class="panel-body">
+
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Team</th>
+            <th>Inject</th>
+            <th>Score</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody id="ungradedList"></tbody>
+      </table>
+
+    </div>
+  </div>
+
+</div>
+<table id="injects" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%" aria-labelledby="blueTeamInjectsHeader">
   <thead>
     <tr>
-      <th>Inject Name</th>
-      <th>Time Left</th>
+      <th scope="col">Inject Name</th>
+      <th scope="col">Time Left</th>
       {% for team in blue_teams %}
-      <th>{{ team.name }}</th>
+      <th scope="col">{{ team.name }}</th>
       {% endfor %}
     </tr>
   </thead>
   <tbody>
   </tbody>
 </table>
-<h4>Red Team Injects</h4>
-<table id="redTeamInjects" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+<h4 id="redTeamInjectsHeader">Red Team Injects</h4>
+<table id="redTeamInjects" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%" aria-labelledby="redTeamInjectsHeader">
   <thead>
     <tr>
-      <th>Inject Name</th>
-      <th>Time Left</th>
+      <th scope="col">Inject Name</th>
+      <th scope="col">Time Left</th>
       {% for team in blue_teams %}
-      <th>{{ team.name }}</th>
+      <th scope="col">{{ team.name }}</th>
       {% endfor %}
     </tr>
   </thead>
@@ -55,11 +89,84 @@
 
     return days + "d " + hours + "h " + minutes + "m " + seconds + "s ";
   }
+
+  function downloadUngradedSubmissions() {
+    var statusEl = $('#downloadStatus');
+    statusEl.html('<span class="glyphicon glyphicon-refresh"></span> Checking...');
+
+    fetch('/api/admin/injects/download_ungraded')
+      .then(response => {
+        if (!response.ok) {
+          throw new Error("Error downloading submissions");
+        }
+        return response.blob();
+      })
+      .then(blob => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = "ungraded_submissions.zip";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+
+        statusEl.html('<span class="text-success">Download started!</span>');
+        setTimeout(function () { statusEl.html(''); }, 3000);
+      })
+      .catch(error => {
+        statusEl.html('<span class="text-warning">' + error.message + '</span>');
+        setTimeout(function () { statusEl.html(''); }, 5000);
+      });
+  }
+
+  function escapeHtml(str) {
+    return $('<div>').text(str).html();
+  }
+
+  function loadUngradedInjects() {
+
+    $.getJSON('/api/admin/injects/ungraded', function(result) {
+
+      let rows = "";
+
+      $.each(result.data, function(index, inject) {
+
+        rows += `
+          <tr>
+            <td>${escapeHtml(inject.team)}</td>
+            <td>${escapeHtml(inject.title)}</td>
+            <td>
+              <input type="number"
+                class="form-control gradeInput"
+                data-id="${inject.id}"
+                placeholder="${inject.max_score}"
+                style="width:100px;">
+            </td>
+            <td>
+              <button class="btn btn-success gradeBtn"
+                      data-id="${inject.id}">
+                Grade
+              </button>
+            </td>
+          </tr>
+        `;
+
+      });
+
+      $('#ungradedList').html(rows);
+
+    });
+
+  }
 </script>
 <script>
   $(document).ready(function () {
     // Disable datatables error reporting
     $.fn.dataTable.ext.errMode = 'none';
+
+    // Download button handler
+    $('#downloadUngradedBtn').click(downloadUngradedSubmissions);
+    loadUngradedInjects();
 
     // TODO - Render this properly
     var dt = $('#injects').DataTable({
@@ -95,7 +202,7 @@
             return data['score'] + " (" + (100 * data['score']) / data['max_score'] + "%)";
           } else if (data['status'] == 'Submitted') {
             // TODO - Add modal for grading / commenting
-            return "<a href=/admin/injects/" + data['id'] + ">Grade Me!</a>";
+            return "<a href=\"/admin/injects/" + data['id'] + "\">Grade Me!</a>";
           } else {
             return "Not Submitted";
           }
@@ -173,6 +280,40 @@
       ]
     });
   });
+  $('#ungradedCollapse').on('show.bs.collapse', function () {
+    $('#ungradedArrow')
+      .removeClass('glyphicon-chevron-right')
+      .addClass('glyphicon-chevron-down');
   });
+
+  $('#ungradedCollapse').on('hide.bs.collapse', function () {
+    $('#ungradedArrow')
+      .removeClass('glyphicon-chevron-down')
+      .addClass('glyphicon-chevron-right');
+  });
+  });
+</script>
+<script>
+$(document).on('click', '.gradeBtn', function () {
+
+  const injectId = $(this).data('id');
+  const score = $(`input[data-id='${injectId}']`).val();
+
+  $.ajax({
+    url: "/api/admin/inject/" + injectId + "/grade",
+    type: "POST",
+    contentType: "application/json",
+    data: JSON.stringify({
+      score: score
+    }),
+    success: function () {
+      loadUngradedInjects(); // refresh list after grading
+    },
+    error: function (result) {
+      alert(result.responseJSON['status']);
+    }
+  });
+
+});
 </script>
 {% endblock %}

--- a/scoring_engine/web/templates/admin/manage.html
+++ b/scoring_engine/web/templates/admin/manage.html
@@ -16,14 +16,14 @@
     <h4 class="text-center">Update Password</h4>
     <form method="POST" action="{{ url_for('api.admin_update_password') }}" role="form" class="form-signin">
       <div class="form-group">
-        <select class="selectpicker" name="user_id" data-width="100%" id="userSelect">
+        <select class="selectpicker" name="user_id" data-width="100%" id="userSelect" aria-label="Select user">
           {% for user in users %}
           <option value="{{ user[0] }}">{{ user[1] }}</option>
           {% endfor %}
         </select>
       </div>
       <div class="form-group">
-        <input type="password" class="form-control" name="password" id="inputPassword" placeholder="Password" required autofocus>
+        <input type="password" class="form-control" name="password" id="inputPassword" placeholder="Password" aria-label="Input selected user's new password" required autofocus>
       </div>
       <button type="submit" class="btn btn-primary center-block">Update Password</button>
     </form>
@@ -33,10 +33,10 @@
     <h4 class="text-center">Add User</h4>
     <form method="POST" action="{{ url_for('api.admin_add_user') }}" role="form" class="form-signin">
       <div class="form-group">
-        <input type="text" class="form-control" name="username" id="userUsername" placeholder="Username" required>
+        <input type="text" class="form-control" name="username" id="userUsername" placeholder="Username" aria-label="Input new user's username" required>
       </div>
       <div class="form-group">
-        <input type="password" class="form-control" name="password" id="userPassword" placeholder="Password" required>
+        <input type="password" class="form-control" name="password" id="userPassword" placeholder="Password" aria-label="Input new user's password" required>
       </div>
       <div class="form-group">
         <select class="selectpicker" name="team_id" data-width="100%" id="team_id">
@@ -53,10 +53,10 @@
     <h4 class="text-center">Add Team</h4>
     <form method="POST" action="{{ url_for('api.admin_add_team') }}" role="form" class="form-signin">
       <div class="form-group">
-        <input type="text" class="form-control" name="name" id="team" placeholder="Team Name" required>
+        <input type="text" class="form-control" name="name" id="team" placeholder="Team Name" aria-label="Input new team's name" required>
       </div>
       <div class="form-group">
-        <select class="selectpicker" name="color" data-width="100%" id="teamSelect">
+        <select class="selectpicker" name="color" data-width="100%" id="teamSelect" aria-label="Select new team's color/type">
           <option value="Red">Red</option>
           <option value="White">White</option>
           <option value="Blue">Blue</option>
@@ -66,12 +66,13 @@
     </form>
   </div>
 
-  <table id="users" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+  <table id="users" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%" aria-live="polite">
+    <caption>Team Information</caption>
     <thead>
       <tr>
-        <th></th>
-        <th>Team Name</th>
-        <th>Color</th>
+        <th scope="col" aria-label="Show/hide team's user information"></th>
+        <th scope="col">Team Name</th>
+        <th scope="col">Color</th>
       </tr>
     </thead>
   </table>
@@ -80,10 +81,11 @@
     function format (data) {
       var rows = [
         '<table id="users" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">',
+        '<caption>Team\'s User Information</caption>',
         '<tr>',
-        '<th>Username</th>',
-        '<th>Password</th>',
-        '<th>Logged In</th>',
+        '<th scope="col">Username</th>',
+        '<th scope="col">Password</th>',
+        '<th scope="col">Logged In</th>',
         '</tr><tbody>'
       ];
 
@@ -113,7 +115,8 @@
               "className": 'details-control',
               "orderable": false,
               "data": null,
-              "defaultContent": ''
+              "defaultContent": '',
+              "ariaTitle": "Show/hide team's user information"
             },
             { "data": "name" },
             { "data": "color" }

--- a/scoring_engine/web/templates/admin/permissions.html
+++ b/scoring_engine/web/templates/admin/permissions.html
@@ -50,8 +50,8 @@
               <form id="view_check_output_form" method="POST" action="{{ url_for('api.admin_update_blueteam_view_check_output') }}" role="form">
                 View Check Output
                 <div class="permission-switch pull-right">
-                  <input id="view_check_output_passwords" type="checkbox" onchange="$('#view_check_output_form').submit();" {{ 'checked' if blue_team_view_check_output == true }}/>
-                  <label for="view_check_output_passwords" class="label-primary"></label>
+                  <input id="view_check_output" type="checkbox" onchange="$('#view_check_output_form').submit();" {{ 'checked' if blue_team_view_check_output == true }}/>
+                  <label for="view_check_output" class="label-primary"></label>
                 </div>
               </form>
             </li>

--- a/scoring_engine/web/templates/admin/queues.html
+++ b/scoring_engine/web/templates/admin/queues.html
@@ -11,12 +11,14 @@
 
 {% block admincontent %}
   <div class="queue_stats">
+    <div id="queues_status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
     <table id="queues" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+      <caption class="sr-only">Worker queue assignments and associated services</caption>
       <thead>
         <tr>
-          <th><div title="Name of Queue">Worker Queue Name</div></th>
-          <th><div title="List of the workers that are assigned to run checks for this service">Workers Assigned</div></th>
-          <th><div title="List of the services that are associated with this worker queue name">Services Associated</div></th>
+          <th scope="col" title="Name of Queue">Worker Queue Name</th>
+          <th scope="col" title="List of the workers that are assigned to run checks for this service">Workers Assigned</th>
+          <th scope="col" title="List of the services that are associated with this worker queue name">Services Associated</th>
         </tr>
       </thead>
       <tbody>
@@ -47,7 +49,7 @@
               "render": function( data ) {
                 var text = "";
                 if (data.length == 0) {
-                  text = 'None <span class="glyphicon glyphicon-alert" style="color:red" title="No workers are setup to run service checks from this queue. This will prevent the engine from working correctly."></span>';
+                  text = 'None <span class="glyphicon glyphicon-alert" style="color:red" aria-hidden="true" title="No workers are setup to run service checks from this queue. This will prevent the engine from working correctly."></span><span class="sr-only">Warning: No workers configured</span>';
                 }
                 else {
                   for (var key in data) {
@@ -83,7 +85,10 @@
           ],
         });
       setInterval( function () {
-        table.ajax.reload();
+        table.ajax.reload(function () {
+            $('#queues_status').text('');
+            setTimeout(function () { $('#queues_status').text('Queue stats updated.'); }, 100);
+        });
       }, 10000 );
     } );
   </script>

--- a/scoring_engine/web/templates/admin/service.html
+++ b/scoring_engine/web/templates/admin/service.html
@@ -56,33 +56,34 @@
 {% block header %}{{service.team.name}} - {{service.name}}{% endblock %}
 
 {% block admincontent %}
-<table>
+<table role="presentation">
   <tr>
     <td style="width: 250px; padding-right: 30px;">
-      <h4>Host: <a href="#" class="editable-textfield" data-type="text" data-pk="{{service.id}}" data-title="Enter Host"
-          data-name="host" data-url="{{url_for('api.update_host')}}">{{service.host}}</a></h4>
-      <h4>Port: <a href="#" class="editable-textfield" data-type="text" data-pk="{{service.id}}"
+        <h4>Host: <button type="button" class="editable-textfield editable-link-button" data-type="text" data-pk="{{service.id}}" data-title="Enter Host"
+          data-name="host" data-url="{{url_for('api.update_host')}}">{{service.host}}</button></h4>
+        <h4>Port: <button type="button" class="editable-textfield editable-link-button" data-type="text" data-pk="{{service.id}}"
           data-title="Enter Port Number" data-name="port"
-          data-url="{{url_for('api.update_port')}}">{{service.port}}</a></h4>
+          data-url="{{url_for('api.update_port')}}">{{service.port}}</button></h4>
 
       <h4>Accounts</h4>
       {% if service.accounts %}
       <table class="table table-striped table-bordered table-compact editable-table" style="clear: both">
+        <caption class="sr-only">Service accounts</caption>
         <thead>
           <tr>
-            <th>Username</th>
-            <th>Password</th>
+            <th scope="col">Username</th>
+            <th scope="col">Password</th>
           </tr>
         </thead>
         <tbody>
           {% for account in service.accounts %}
           <tr>
-            <td width="10%"><a href="#" class="editable-textfield" data-type="text" data-pk="{{account.id}}"
+            <td width="10%"><button type="button" class="editable-textfield editable-link-button" data-type="text" data-pk="{{account.id}}"
                 data-title="Enter Username" data-name="username"
-                data-url="{{url_for('api.update_service_account_info')}}">{{account.username}}</a></td>
-            <td width="90%"><a href="#" class="editable-textfield password" data-type="text" data-pk="{{account.id}}"
+              data-url="{{url_for('api.update_service_account_info')}}">{{account.username}}</button></td>
+            <td width="90%"><button type="button" class="editable-textfield password editable-link-button" data-type="text" data-pk="{{account.id}}"
                 data-title="Enter Password" data-name="password"
-                data-url="{{url_for('api.update_service_account_info')}}">{{account.password}}</a></td>
+              data-url="{{url_for('api.update_service_account_info')}}">{{account.password}}</button></td>
           </tr>
           {% endfor %}
         </tbody>
@@ -93,13 +94,13 @@
     </td>
     <td>
       <h4>Worker Queue Name</h4>
-      <a href="#" class="editable-textfield" data-type="text" data-pk="{{service.id}}"
+      <button type="button" class="editable-textfield editable-link-button" data-type="text" data-pk="{{service.id}}"
         data-title="Enter Worker Queue Name" data-name="worker_queue"
-        data-url="{{url_for('api.admin_update_worker_queue')}}">{{service.worker_queue}}</a>
+        data-url="{{url_for('api.admin_update_worker_queue')}}">{{service.worker_queue}}</button>
       <h4>Points</h4>
-      <a href="#" class="editable-textfield" data-type="text" data-pk="{{service.id}}"
+      <button type="button" class="editable-textfield editable-link-button" data-type="text" data-pk="{{service.id}}"
         data-title="Enter Points per successful check" data-name="points"
-        data-url="{{url_for('api.admin_update_points')}}">{{service.points}}</a>
+        data-url="{{url_for('api.admin_update_points')}}">{{service.points}}</button>
     </td>
   </tr>
 </table>
@@ -108,36 +109,38 @@
 <h4>Environments</h4>
 {% if service.environments %}
 <table class="table table-striped table-bordered table-compact" style="clear: both">
+  <caption class="sr-only">Service environments with matching content and properties</caption>
   <thead>
     <tr>
-      <th>Matching Content</th>
-      <th>Properties</th>
+      <th scope="col">Matching Content</th>
+      <th scope="col">Properties</th>
     </tr>
   </thead>
   <tbody>
     {% for environment in service.environments %}
     <tr>
-      <td width="25%"><a href="#" class="editable-textfield" data-type="text" data-pk="{{environment.id}}"
+        <td width="25%"><button type="button" class="editable-textfield editable-link-button" data-type="text" data-pk="{{environment.id}}"
           data-title="Enter Matching Content" data-url="{{url_for('api.admin_update_environment')}}"
-          data-name='matching_content'>{{environment.matching_content}}</a></td>
+          data-name='matching_content'>{{environment.matching_content}}</button></td>
       <td>
         {% if environment.properties %}
         <table class="table table-striped table-bordered table-compact" style="clear: both">
+          <caption class="sr-only">Environment properties</caption>
           <thead>
             <tr>
-              <th>Name</th>
-              <th>Value</th>
+              <th scope="col">Name</th>
+              <th scope="col">Value</th>
             </tr>
           </thead>
           <tbody>
             {% for property_obj in environment.properties %}
             <tr>
-              <td width="10%"><a href="#" class="editable-textfield" data-type="text" data-pk="{{property_obj.id}}"
+                <td width="10%"><button type="button" class="editable-textfield editable-link-button" data-type="text" data-pk="{{property_obj.id}}"
                   data-title="Enter Property Name" data-url="{{url_for('api.admin_update_property')}}"
-                  data-name='property_name'>{{property_obj.name}}</a></td>
-              <td width="50%"><a href="#" class="editable-textfield" data-type="text" data-pk="{{property_obj.id}}"
+                  data-name='property_name'>{{property_obj.name}}</button></td>
+                <td width="50%"><button type="button" class="editable-textfield editable-link-button" data-type="text" data-pk="{{property_obj.id}}"
                   data-title="Enter Property Value" data-url="{{url_for('api.admin_update_property')}}"
-                  data-name='property_value'>{{property_obj.value}}</a></td>
+                  data-name='property_value'>{{property_obj.value}}</button></td>
             </tr>
             {% endfor %}
           </tbody>
@@ -155,16 +158,18 @@ No Environments Found.
 {% endif %}
 
 <h4>Checks</h4>
+<div id="checks_status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
 <table id="checks" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+  <caption class="sr-only">Service check results by round</caption>
   <thead>
     <tr>
-      <th class="details-control sorting_disabled" rowspan="1" colspan="1" style="width: 51.1px;" aria-label=""></th>
-      <th>Round</th>
-      <th>Result</th>
-      <th>Earned</th>
-      <th>Reason</th>
-      <th>Command</th>
-      <th>Timestamp</th>
+      <th scope="col" class="details-control sorting_disabled" rowspan="1" colspan="1" style="width: 51.1px;"><span class="sr-only">Expand/Collapse</span></th>
+      <th scope="col">Round</th>
+      <th scope="col">Result</th>
+      <th scope="col">Earned</th>
+      <th scope="col">Reason</th>
+      <th scope="col">Command</th>
+      <th scope="col">Timestamp</th>
     </tr>
   </thead>
 </table>
@@ -192,9 +197,9 @@ No Environments Found.
         "width": "5%",
         "render": function (data, type, row) {
           if (data) {
-            return "<a href=\"#\" class=\"editable-dropdown\" data-pk=\"" + row['id'] + "\" data-value=\"1\" data-source='[{value: 1, text: \"Pass\"}, {value: 2, text: \"Fail\"}]' data-title=\"Select Result\" data-url=\"{{url_for('api.admin_update_check')}}\" data-name='check_value'>Pass</a>";
+            return "<button type=\"button\" class=\"editable-dropdown editable-link-button\" data-pk=\"" + row['id'] + "\" data-value=\"1\" data-source='[{value: 1, text: \"Pass\"}, {value: 2, text: \"Fail\"}]' data-title=\"Select Result\" data-url=\"{{url_for('api.admin_update_check')}}\" data-name='check_value'>Pass</button>";
           } else {
-            return "<a href=\"#\" class=\"editable-dropdown\" data-pk=\"" + row['id'] + "\" data-value=\"2\" data-source='[{value: 1, text: \"Pass\"}, {value: 2, text: \"Fail\"}]' data-title=\"Select Result\" data-url=\"{{url_for('api.admin_update_check')}}\" data-name='check_value'>Fail</a>";
+            return "<button type=\"button\" class=\"editable-dropdown editable-link-button\" data-pk=\"" + row['id'] + "\" data-value=\"2\" data-source='[{value: 1, text: \"Pass\"}, {value: 2, text: \"Fail\"}]' data-title=\"Select Result\" data-url=\"{{url_for('api.admin_update_check')}}\" data-name='check_value'>Fail</button>";
           }
         }
       },
@@ -216,7 +221,7 @@ No Environments Found.
         "data": "reason",
         "width": "25%",
         "render": function (data, type, row) {
-          return "<a href=\"#\" class=\"editable-textfield\" data-type=\"text\" data-pk=\"" + row['id'] + "\" data-title=\"Enter Reason\" data-url=\"{{url_for('api.admin_update_check')}}\" data-name='check_reason'>" + data + "</a>"
+          return "<button type=\"button\" class=\"editable-textfield editable-link-button\" data-type=\"text\" data-pk=\"" + row['id'] + "\" data-title=\"Enter Reason\" data-url=\"{{url_for('api.admin_update_check')}}\" data-name='check_reason'>" + data + "</button>"
         }
       },
       {

--- a/scoring_engine/web/templates/admin/sla.html
+++ b/scoring_engine/web/templates/admin/sla.html
@@ -16,89 +16,89 @@
       <h4 class="panel-title">SLA Penalty Configuration</h4>
     </div>
     <div class="panel-body">
-      <p class="text-muted">
+      <p class="help-block">
         Configure penalties for services that fail consecutive health checks.
         When enabled, teams are penalized for services that remain down.
       </p>
 
       <form method="POST" action="{{ url_for('api.admin_update_sla_enabled') }}" role="form" style="margin-bottom: 15px;">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">SLA Penalties</label>
+          <label for="sla_enabled_toggle" class="col-sm-3 control-label">SLA Penalties</label>
           <div class="col-sm-3">
-            <button type="submit" class="btn btn-{% if sla_enabled %}success{% else %}default{% endif %} btn-block">
+            <button type="submit" id="sla_enabled_toggle" class="btn btn-{% if sla_enabled %}success{% else %}default{% endif %} btn-block" aria-describedby="sla_enabled_help">
               {% if sla_enabled %}Enabled{% else %}Disabled{% endif %}
             </button>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">Click to toggle SLA penalties on/off</p>
+            <p id="sla_enabled_help" class="form-control-static help-block">Click to toggle SLA penalties on/off</p>
           </div>
         </div>
       </form>
 
       <form method="POST" action="{{ url_for('api.admin_update_sla_penalty_threshold') }}" role="form">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">Penalty Threshold</label>
+          <label for="sla_penalty_threshold" class="col-sm-3 control-label">Penalty Threshold</label>
           <div class="col-sm-3">
             <div class="input-group">
               <input class="form-control" type="number" min="1" max="100" id="sla_penalty_threshold"
-                name="sla_penalty_threshold" value="{{ sla_penalty_threshold }}" required />
+                name="sla_penalty_threshold" value="{{ sla_penalty_threshold }}" required aria-describedby="sla_threshold_help" />
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-primary">Save</button>
               </span>
             </div>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">Number of consecutive failures before penalties begin</p>
+            <p id="sla_threshold_help" class="form-control-static help-block">Number of consecutive failures before penalties begin</p>
           </div>
         </div>
       </form>
 
       <form method="POST" action="{{ url_for('api.admin_update_sla_penalty_percent') }}" role="form">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">Penalty Percent (%)</label>
+          <label for="sla_penalty_percent" class="col-sm-3 control-label">Penalty Percent (%)</label>
           <div class="col-sm-3">
             <div class="input-group">
               <input class="form-control" type="number" min="1" max="100" id="sla_penalty_percent"
-                name="sla_penalty_percent" value="{{ sla_penalty_percent }}" required />
+                name="sla_penalty_percent" value="{{ sla_penalty_percent }}" required aria-describedby="sla_percent_help" />
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-primary">Save</button>
               </span>
             </div>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">Penalty percentage per failure after threshold</p>
+            <p id="sla_percent_help" class="form-control-static help-block">Penalty percentage per failure after threshold</p>
           </div>
         </div>
       </form>
 
       <form method="POST" action="{{ url_for('api.admin_update_sla_penalty_max_percent') }}" role="form">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">Max Penalty (%)</label>
+          <label for="sla_penalty_max_percent" class="col-sm-3 control-label">Max Penalty (%)</label>
           <div class="col-sm-3">
             <div class="input-group">
               <input class="form-control" type="number" min="1" max="200" id="sla_penalty_max_percent"
-                name="sla_penalty_max_percent" value="{{ sla_penalty_max_percent }}" required />
+                name="sla_penalty_max_percent" value="{{ sla_penalty_max_percent }}" required aria-describedby="sla_max_help" />
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-primary">Save</button>
               </span>
             </div>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">Maximum total penalty percentage (cap)</p>
+            <p id="sla_max_help" class="form-control-static help-block">Maximum total penalty percentage (cap)</p>
           </div>
         </div>
       </form>
 
       <form method="POST" action="{{ url_for('api.admin_update_sla_penalty_mode') }}" role="form">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">Penalty Mode</label>
+          <label for="sla_penalty_mode" class="col-sm-3 control-label">Penalty Mode</label>
           <div class="col-sm-3">
             <div class="input-group">
               <select class="form-control" id="sla_penalty_mode" name="sla_penalty_mode">
-                <option value="additive" {% if sla_penalty_mode == 'additive' %}selected{% endif %}>Additive</option>
-                <option value="flat" {% if sla_penalty_mode == 'flat' %}selected{% endif %}>Flat</option>
-                <option value="exponential" {% if sla_penalty_mode == 'exponential' %}selected{% endif %}>Exponential</option>
-                <option value="next_check_reduction" {% if sla_penalty_mode == 'next_check_reduction' %}selected{% endif %}>Next Check Reduction</option>
+                <option value="additive" aria-label="Additive penalty mode" {% if sla_penalty_mode == 'additive' %}selected{% endif %}>Additive</option>
+                <option value="flat" aria-label="Flat penalty mode" {% if sla_penalty_mode == 'flat' %}selected{% endif %}>Flat</option>
+                <option value="exponential" aria-label="Exponential penalty mode" {% if sla_penalty_mode == 'exponential' %}selected{% endif %}>Exponential</option>
+                <option value="next_check_reduction" aria-label="Next check reduction penalty mode" {% if sla_penalty_mode == 'next_check_reduction' %}selected{% endif %}>Next Check Reduction</option>
               </select>
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-primary">Save</button>
@@ -106,21 +106,21 @@
             </div>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">How penalties accumulate (additive=10%,20%,30%..., flat=10%,10%..., exponential=10%,20%,40%...)</p>
+            <p class="form-control-static help-block">How penalties accumulate (additive=10%,20%,30%..., flat=10%,10%..., exponential=10%,20%,40%...)</p>
           </div>
         </div>
       </form>
 
       <form method="POST" action="{{ url_for('api.admin_update_sla_allow_negative') }}" role="form">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">Allow Negative Scores</label>
+          <label for="sla_allow_negative_toggle" class="col-sm-3 control-label">Allow Negative Scores</label>
           <div class="col-sm-3">
-            <button type="submit" class="btn btn-{% if sla_allow_negative %}warning{% else %}default{% endif %} btn-block">
+            <button type="submit" id="sla_allow_negative_toggle" class="btn btn-{% if sla_allow_negative %}warning{% else %}default{% endif %} btn-block" aria-describedby="sla_negative_help">
               {% if sla_allow_negative %}Enabled{% else %}Disabled{% endif %}
             </button>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">Allow scores to go below zero from penalties</p>
+            <p id="sla_negative_help" class="form-control-static help-block">Allow scores to go below zero from penalties</p>
           </div>
         </div>
       </form>
@@ -133,21 +133,21 @@
       <h4 class="panel-title">Dynamic Scoring Configuration</h4>
     </div>
     <div class="panel-body">
-      <p class="text-muted">
+      <p class="help-block">
         Configure time-based scoring multipliers. Points can be worth more or less
         during different phases of the competition.
       </p>
 
       <form method="POST" action="{{ url_for('api.admin_update_dynamic_scoring_enabled') }}" role="form" style="margin-bottom: 15px;">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">Dynamic Scoring</label>
+          <label for="dynamic_scoring_toggle" class="col-sm-3 control-label">Dynamic Scoring</label>
           <div class="col-sm-3">
-            <button type="submit" class="btn btn-{% if dynamic_scoring_enabled %}success{% else %}default{% endif %} btn-block">
+            <button type="submit" id="dynamic_scoring_toggle" class="btn btn-{% if dynamic_scoring_enabled %}success{% else %}default{% endif %} btn-block" aria-describedby="dynamic_scoring_help">
               {% if dynamic_scoring_enabled %}Enabled{% else %}Disabled{% endif %}
             </button>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">Click to toggle dynamic scoring on/off</p>
+            <p id="dynamic_scoring_help" class="form-control-static help-block">Click to toggle dynamic scoring on/off</p>
           </div>
         </div>
       </form>
@@ -155,36 +155,36 @@
       <h5><strong>Early Phase (Bonus Points)</strong></h5>
       <form method="POST" action="{{ url_for('api.admin_update_dynamic_scoring_early_rounds') }}" role="form">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">Early Phase Rounds</label>
+          <label for="dynamic_scoring_early_rounds" class="col-sm-3 control-label">Early Phase Rounds</label>
           <div class="col-sm-3">
             <div class="input-group">
               <input class="form-control" type="number" min="1" max="1000" id="dynamic_scoring_early_rounds"
-                name="dynamic_scoring_early_rounds" value="{{ dynamic_scoring_early_rounds }}" required />
+                name="dynamic_scoring_early_rounds" value="{{ dynamic_scoring_early_rounds }}" required aria-describedby="early_rounds_help" />
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-primary">Save</button>
               </span>
             </div>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">First N rounds are considered "early phase"</p>
+            <p id="early_rounds_help" class="form-control-static help-block">First N rounds are considered "early phase"</p>
           </div>
         </div>
       </form>
 
       <form method="POST" action="{{ url_for('api.admin_update_dynamic_scoring_early_multiplier') }}" role="form">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">Early Phase Multiplier</label>
+          <label for="dynamic_scoring_early_multiplier" class="col-sm-3 control-label">Early Phase Multiplier</label>
           <div class="col-sm-3">
             <div class="input-group">
               <input class="form-control" type="number" step="0.1" min="0.1" max="10" id="dynamic_scoring_early_multiplier"
-                name="dynamic_scoring_early_multiplier" value="{{ dynamic_scoring_early_multiplier }}" required />
+                name="dynamic_scoring_early_multiplier" value="{{ dynamic_scoring_early_multiplier }}" required aria-describedby="early_multiplier_help" />
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-primary">Save</button>
               </span>
             </div>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">Points multiplier during early phase (e.g., 2.0 = double points)</p>
+            <p id="early_multiplier_help" class="form-control-static help-block">Points multiplier during early phase (e.g., 2.0 = double points)</p>
           </div>
         </div>
       </form>
@@ -192,36 +192,36 @@
       <h5><strong>Late Phase (Reduced Points)</strong></h5>
       <form method="POST" action="{{ url_for('api.admin_update_dynamic_scoring_late_start_round') }}" role="form">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">Late Phase Start Round</label>
+          <label for="dynamic_scoring_late_start_round" class="col-sm-3 control-label">Late Phase Start Round</label>
           <div class="col-sm-3">
             <div class="input-group">
               <input class="form-control" type="number" min="1" max="10000" id="dynamic_scoring_late_start_round"
-                name="dynamic_scoring_late_start_round" value="{{ dynamic_scoring_late_start_round }}" required />
+                name="dynamic_scoring_late_start_round" value="{{ dynamic_scoring_late_start_round }}" required aria-describedby="late_start_help" />
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-primary">Save</button>
               </span>
             </div>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">Round number when late phase begins</p>
+            <p id="late_start_help" class="form-control-static help-block">Round number when late phase begins</p>
           </div>
         </div>
       </form>
 
       <form method="POST" action="{{ url_for('api.admin_update_dynamic_scoring_late_multiplier') }}" role="form">
         <div class="form-group row">
-          <label class="col-sm-3 control-label">Late Phase Multiplier</label>
+          <label for="dynamic_scoring_late_multiplier" class="col-sm-3 control-label">Late Phase Multiplier</label>
           <div class="col-sm-3">
             <div class="input-group">
               <input class="form-control" type="number" step="0.1" min="0.1" max="10" id="dynamic_scoring_late_multiplier"
-                name="dynamic_scoring_late_multiplier" value="{{ dynamic_scoring_late_multiplier }}" required />
+                name="dynamic_scoring_late_multiplier" value="{{ dynamic_scoring_late_multiplier }}" required aria-describedby="late_multiplier_help" />
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-primary">Save</button>
               </span>
             </div>
           </div>
           <div class="col-sm-6">
-            <p class="form-control-static text-muted">Points multiplier during late phase (e.g., 0.5 = half points)</p>
+            <p id="late_multiplier_help" class="form-control-static help-block">Points multiplier during late phase (e.g., 0.5 = half points)</p>
           </div>
         </div>
       </form>
@@ -234,8 +234,8 @@
       <h4 class="panel-title">Current SLA Status</h4>
     </div>
     <div class="panel-body">
-      <div id="sla-status-container">
-        <p class="text-muted">Loading SLA status...</p>
+      <div id="sla-status-container" aria-live="polite">
+        <p class="help-block">Loading SLA status...</p>
       </div>
     </div>
   </div>
@@ -251,8 +251,9 @@ $(document).ready(function() {
     success: function(data) {
       var html = '';
       if (data.teams && data.teams.length > 0) {
+        html += '<p class="help-block"><strong>SLA penalty summary by team</strong></p>';
         html += '<table class="table table-striped table-condensed">';
-        html += '<thead><tr><th>Team</th><th>Base Score</th><th>Penalties</th><th>Adjusted Score</th><th>Violations</th></tr></thead>';
+        html += '<thead><tr><th scope="col">Team</th><th scope="col">Base Score</th><th scope="col">Penalties</th><th scope="col">Adjusted Score</th><th scope="col">Violations</th></tr></thead>';
         html += '<tbody>';
         for (var i = 0; i < data.teams.length; i++) {
           var team = data.teams[i];
@@ -267,7 +268,7 @@ $(document).ready(function() {
         }
         html += '</tbody></table>';
       } else {
-        html = '<p class="text-muted">No team data available.</p>';
+        html = '<p class="help-block">No team data available.</p>';
       }
       $('#sla-status-container').html(html);
     },

--- a/scoring_engine/web/templates/admin/status.html
+++ b/scoring_engine/web/templates/admin/status.html
@@ -11,24 +11,25 @@ Round Stats
 {% endblock %}
 
 {% block admincontent %}
-<div class="engine_stats">
+<div class="engine_stats" aria-live="polite">
   <h4>Engine Stats</h4>
   <table class="table table-striped table-bordered table-compact">
+    <caption class="sr-only">Engine statistics for the current round</caption>
     <tbody>
       <tr>
-        <td>Round</td>
+        <th scope="row">Round</th>
         <td id="round_number"></td>
       </tr>
       <tr>
-        <td>Passed Checks</td>
+        <th scope="row">Passed Checks</th>
         <td id="num_passed_checks"></td>
       </tr>
       <tr>
-        <td>Failed Checks</td>
+        <th scope="row">Failed Checks</th>
         <td id="num_failed_checks"></td>
       </tr>
       <tr>
-        <td>Total Checks</td>
+        <th scope="row">Total Checks</th>
         <td id="total_checks"></td>
       </tr>
     </tbody>

--- a/scoring_engine/web/templates/admin/templates.html
+++ b/scoring_engine/web/templates/admin/templates.html
@@ -37,15 +37,16 @@
   </div>
 </div>
 <table id="templates" class="table table-striped table-compact" cellspacing="0" width="100%">
+  <caption>Manage Existing Inject Templates</caption>
   <thead>
     <tr>
-      <th>#</th>
-      <th>Title</th>
-      <th>Start Time</th>
-      <th>End Time</th>
-      <th>Points</th>
-      <th>Enabled</th>
-      <th></th>
+      <th scope="col" aria-label="ID number">#</th>
+      <th scope="col">Title</th>
+      <th scope="col">Start Time</th>
+      <th scope="col">End Time</th>
+      <th scope="col">Points</th>
+      <th scope="col">Enabled</th>
+      <th scope="col"></th>
     </tr>
   </thead>
 </table>
@@ -401,9 +402,9 @@
           "data": "enabled",
           "render": function (data, type, row) {
             if (data) {
-              return '<span class="glyphicon glyphicon-ok" style="color:green" aria-hidden="true"></span>';
+              return '<span class="glyphicon glyphicon-ok" style="color:green" aria-hidden="true" aria-label="Is enabled"></span>';
             } else {
-              return '<span class="glyphicon glyphicon-remove" style="color:red" aria-hidden="true"></span>';
+              return '<span class="glyphicon glyphicon-remove" style="color:red" aria-hidden="true" aria-label="Is not enabled"></span>';
             }
           }
         },

--- a/scoring_engine/web/templates/admin/workers.html
+++ b/scoring_engine/web/templates/admin/workers.html
@@ -11,15 +11,17 @@
 
 {% block admincontent %}
   <div class="worker_stats">
+    <div id="workers_status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
     <table id="workers" class="table table-striped table-bordered table-compact" cellspacing="0" width="100%">
+      <caption class="sr-only">Connected workers with process counts and queue assignments</caption>
       <thead>
         <tr>
-          <th><div title="Name of Worker">Name</div></th>
-          <th><div title="Number of processes available">Processes</div></th>
-          <th><div title="Number of currently running checks">Running Checks</div></th>
-          <th><div title="Number of completed checks">Completed Checks</div></th>
-          <th><div title="Queues registered to for running service checks">Queue Names</div></th>
-          <th><div title="Services that the worker is registered to run">Enabled Services</div></th>
+          <th scope="col" title="Name of Worker">Name</th>
+          <th scope="col" title="Number of processes available">Processes</th>
+          <th scope="col" title="Number of currently running checks">Running Checks</th>
+          <th scope="col" title="Number of completed checks">Completed Checks</th>
+          <th scope="col" title="Queues registered to for running service checks">Queue Names</th>
+          <th scope="col" title="Services that the worker is registered to run">Enabled Services</th>
         </tr>
       </thead>
       <tbody>
@@ -41,7 +43,7 @@
           'bInfo': false,
           "ajax": "/api/admin/get_worker_stats",
           "language": {
-            "emptyTable": 'No workers are currently connected <span class="glyphicon glyphicon-alert" style="color:red" title="This means no services will get checked until a worker is connected."></span>',
+            "emptyTable": 'No workers are currently connected <span class="glyphicon glyphicon-alert" style="color:red" aria-hidden="true" title="This means no services will get checked until a worker is connected."></span><span class="sr-only">Warning: No workers connected</span>',
           },
           "columns": [
             { "data": "worker_name" },
@@ -65,7 +67,7 @@
                 var text = "";
                 if (typeof data === 'string'){
                   if (data == 'None'){
-                    text = 'None <span class="glyphicon glyphicon-alert" style="color:red" title="This worker isn\' currently running any services, perhaps the queue names for this worker are incorrect?"></span>';
+                    text = 'None <span class="glyphicon glyphicon-alert" style="color:red" aria-hidden="true" title="This worker isn\' currently running any services, perhaps the queue names for this worker are incorrect?"></span><span class="sr-only">Warning: No services running</span>';
                   }
                   else{
                     text = data;
@@ -89,7 +91,10 @@
           ],
         });
       setInterval( function () {
-        table.ajax.reload();
+        table.ajax.reload(function () {
+            $('#workers_status').text('');
+            setTimeout(function () { $('#workers_status').text('Worker stats updated.'); }, 100);
+        });
       }, 10000 );
     } );
   </script>


### PR DESCRIPTION
## Summary
Extends the accessibility improvements from #1149 to the remaining admin panel pages, targeting WCAG 2.1 AA compliance.

## Changes
- Fixed all broken <label for="ex1"> associations so now every label now references its actual input's id
- Replaced inline editable  elements with buttons throughout service.html
- Added scope="col" to all table headers and sr-only <caption> elements to data tables
- Added aria-label, aria-labelledby, aria-hidden, aria-live, aria-expanded, and aria-controls attributes where missing
- Added role="status" aria-live="polite" region for dynamic check result updates in service.html

Co-authored-by: David Nguyen <107872059+dnguyen0091@users.noreply.github.com>
Co-authored-by: JJCUBER <34446698+JJCUBER@users.noreply.github.com>