### PR TITLE
Improve Docker build performance and fix version mismatches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Docker image versions — single source of truth
+# Copy to .env and modify as needed: cp .env.example .env
+PYTHON_VERSION=3.14.3-slim-bookworm
+REDIS_VERSION=7.0.4
+MARIADB_VERSION=10
+NGINX_VERSION=1.27.3-alpine3.20-slim
+
+# Database credentials
+MYSQL_ROOT_PASSWORD=CHANGEME
+MYSQL_PASSWORD=CHANGEME

--- a/bin/create-airgapped-package.sh
+++ b/bin/create-airgapped-package.sh
@@ -19,6 +19,22 @@ PACKAGE_DIR="scoringengine-airgapped"
 IMAGES_DIR="${PACKAGE_DIR}/docker-images"
 OUTPUT_ARCHIVE="scoringengine-airgapped.tar.gz"
 
+# Load versions from .env.example (can be overridden by .env or environment)
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/.env"
+elif [ -f "${SCRIPT_DIR}/.env.example" ]; then
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/.env.example"
+fi
+
+# Image versions — defaults match .env.example
+PYTHON_VERSION="${PYTHON_VERSION:-3.14.3-slim-bookworm}"
+REDIS_VERSION="${REDIS_VERSION:-7.0.4}"
+MARIADB_VERSION="${MARIADB_VERSION:-10}"
+NGINX_VERSION="${NGINX_VERSION:-1.27.3-alpine3.20-slim}"
+
 echo -e "${GREEN}=== Scoring Engine Airgapped Package Creator ===${NC}"
 echo ""
 echo "This script will create a complete airgapped deployment package."
@@ -76,17 +92,17 @@ mkdir -p "${IMAGES_DIR}"
 echo ""
 echo -e "${GREEN}Step 3: Exporting base Docker images...${NC}"
 
-echo "  - Exporting python:3.14.1-slim-bookworm..."
-docker save python:3.14.1-slim-bookworm -o "${IMAGES_DIR}/python-base.tar"
+echo "  - Exporting python:${PYTHON_VERSION}..."
+docker save "python:${PYTHON_VERSION}" -o "${IMAGES_DIR}/python-base.tar"
 
-echo "  - Exporting redis:7.0.4..."
-docker save redis:7.0.4 -o "${IMAGES_DIR}/redis.tar"
+echo "  - Exporting redis:${REDIS_VERSION}..."
+docker save "redis:${REDIS_VERSION}" -o "${IMAGES_DIR}/redis.tar"
 
-echo "  - Exporting mariadb:10..."
-docker save mariadb:10 -o "${IMAGES_DIR}/mariadb.tar"
+echo "  - Exporting mariadb:${MARIADB_VERSION}..."
+docker save "mariadb:${MARIADB_VERSION}" -o "${IMAGES_DIR}/mariadb.tar"
 
-echo "  - Exporting nginx:1.23.1..."
-docker save nginx:1.23.1 -o "${IMAGES_DIR}/nginx.tar"
+echo "  - Exporting nginx:${NGINX_VERSION}..."
+docker save "nginx:${NGINX_VERSION}" -o "${IMAGES_DIR}/nginx.tar"
 
 # Step 4: Export application images
 echo ""
@@ -161,7 +177,7 @@ echo ""
 echo "All images loaded successfully!"
 echo ""
 echo "Loaded images:"
-docker images | grep -E "(scoringengine|redis|mariadb|nginx|python)" | grep -E "(3.14.1-slim-bookworm|7.0.4|10|1.23.1|latest)"
+docker images | grep -E "(scoringengine|redis|mariadb|nginx|python)"
 
 echo ""
 echo "Next steps:"
@@ -303,10 +319,10 @@ DOCKER IMAGES:
 --------------
 
 Base Images:
-  - python:3.14.1-slim-bookworm
-  - redis:7.0.4
-  - mariadb:10
-  - nginx:1.23.1
+  - python:${PYTHON_VERSION}
+  - redis:${REDIS_VERSION}
+  - mariadb:${MARIADB_VERSION}
+  - nginx:${NGINX_VERSION}
 
 Application Images:
   - scoringengine/base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   redis:
-    image: "redis:7.0.4"
+    image: "redis:${REDIS_VERSION:-7.0.4}"
     command: ["redis-server", "--save", ""]
     healthcheck:
       test: ["CMD", "redis-cli", "-h", "127.0.0.1", "ping"]
@@ -16,7 +16,7 @@ services:
     # ports:
     #   - 6379:6379
   mysql:
-    image: mariadb:10
+    image: "mariadb:${MARIADB_VERSION:-10}"
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-CHANGEME}
       - MYSQL_DATABASE=scoring_engine
@@ -35,7 +35,7 @@ services:
     # ports:
     #   - 3306:3306
   nginx:
-    image: nginx:1.23.1
+    image: "nginx:${NGINX_VERSION:-1.27.3-alpine3.20-slim}"
     depends_on:
       web:
         condition: service_healthy
@@ -60,6 +60,8 @@ services:
     build:
       context: .
       dockerfile: ./docker/base/Dockerfile
+      args:
+        PYTHON_VERSION: ${PYTHON_VERSION:-3.14.3-slim-bookworm}
       cache_from:
         - scoringengine/base
         - base:latest

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,44 +1,48 @@
+# syntax=docker/dockerfile:1
 # Stage 1: Builder — compile C extensions into a venv
-FROM python:3.14.3-slim-bookworm AS builder
+ARG PYTHON_VERSION=3.14.3-slim-bookworm
+FROM python:${PYTHON_VERSION} AS builder
 
-RUN set -eux; \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    build-essential \
-    gcc \
-    libssl-dev \
-    pkg-config \
-    libmariadb-dev-compat \
-    libmariadb-dev \
-  ; \
-  rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      gcc \
+      libmariadb-dev \
+      libmariadb-dev-compat \
+      libssl-dev \
+      pkg-config
 
 RUN python3 -m venv /opt/venv
 ENV PATH=/opt/venv/bin:$PATH
 
 # Install deps first (cached until pyproject.toml changes)
 COPY pyproject.toml /tmp/pyproject.toml
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    pip install --no-cache-dir $(python3 -c "\
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip setuptools wheel && \
+    pip install $(python3 -c "\
 import tomllib, pathlib; \
 d = tomllib.loads(pathlib.Path('/tmp/pyproject.toml').read_text()); \
 print(' '.join(d['project']['dependencies']))")
 
 # Stage 2: Runtime — slim image with only runtime libs
-FROM python:3.14.3-slim-bookworm
+ARG PYTHON_VERSION=3.14.3-slim-bookworm
+FROM python:${PYTHON_VERSION}
 
-RUN set -eux; \
-  useradd -m engine; \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    curl \
-    libssl3 \
-    libmariadb3 \
-    iputils-ping \
-  ; \
-  rm -rf /var/lib/apt/lists/* && \
-  mkdir /app && \
-  chown engine:engine /app
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    set -eux; \
+    useradd -m -u 1000 engine; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      curl \
+      iputils-ping \
+      libmariadb3 \
+      libssl3 \
+    && mkdir /app \
+    && chown engine:engine /app
 
 COPY --from=builder --chown=engine:engine /opt/venv /opt/venv
 ENV PATH=/opt/venv/bin:$PATH
@@ -53,4 +57,5 @@ USER engine
 COPY --chown=engine:engine scoring_engine /app/scoring_engine
 
 # Fast — deps already in venv, just creates egg-link
-RUN pip install --no-cache-dir -e .
+RUN --mount=type=cache,target=/home/engine/.cache/pip \
+    pip install -e .

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -3,8 +3,8 @@
 ARG PYTHON_VERSION=3.14.3-slim-bookworm
 FROM python:${PYTHON_VERSION} AS builder
 
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=apt-cache-builder,target=/var/cache/apt \
+    --mount=type=cache,id=apt-lists-builder,target=/var/lib/apt/lists \
     set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
@@ -31,8 +31,8 @@ print(' '.join(d['project']['dependencies']))")
 ARG PYTHON_VERSION=3.14.3-slim-bookworm
 FROM python:${PYTHON_VERSION}
 
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=apt-cache-runtime,target=/var/cache/apt \
+    --mount=type=cache,id=apt-lists-runtime,target=/var/lib/apt/lists \
     set -eux; \
     useradd -m -u 1000 engine; \
     apt-get update; \

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,5 @@
-FROM nginx:1.27.3-alpine3.20-slim
+ARG NGINX_VERSION=1.27.3-alpine3.20-slim
+FROM nginx:${NGINX_VERSION}
 
 COPY docker/nginx/files/web.conf /etc/nginx/conf.d/default.conf
 COPY docker/nginx/files/scoringengine.crt /etc/nginx/scoringengine.crt

--- a/docker/tester/Dockerfile
+++ b/docker/tester/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM scoringengine/base
 
 USER root
@@ -15,8 +16,12 @@ RUN \
 
 USER engine
 
-COPY scoring_engine /app/scoring_engine
-RUN pip install -e .
-COPY tests /app/tests
-RUN pip install -r /app/tests/requirements.txt
+# Install test deps BEFORE copying tests for better layer caching
+COPY tests/requirements.txt /tmp/test-requirements.txt
+RUN --mount=type=cache,target=/home/engine/.cache/pip \
+    pip install -r /tmp/test-requirements.txt
 
+COPY scoring_engine /app/scoring_engine
+RUN --mount=type=cache,target=/home/engine/.cache/pip \
+    pip install -e .
+COPY tests /app/tests

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG BASE_IMAGE=ghcr.io/scoringengine/scoringengine/base:latest
 FROM ${BASE_IMAGE}
 
@@ -5,41 +6,30 @@ USER root
 
 # Install system dependencies in a single layer to reduce image size
 # This consolidates all apt-get operations to minimize layers
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    # allows adding HTTPS apt repos for MSSQL checks
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
-    # verifies apt repository signatures for MSSQL checks
-    gpg \
-    # ICMP ping checks
-    iputils-ping \
-    # HTTP/HTTPS/WordPress checks
     curl \
-    # MySQL checks
     default-mysql-client \
-    # LDAP checks
-    ldap-utils \
-    # POP3/IMAP/VNC login checks
-    medusa \
-    # DNS checks
     dnsutils \
-    # PostgreSQL checks
-    postgresql-client \
-    # NFS checks
-    nfs-common \
-    # OpenVPN checks
-    openvpn \
-    # OpenVPN check uses ip command
+    gpg \
     iproute2 \
-    # OpenVPN check runs openvpn via sudo
+    iputils-ping \
+    ldap-utils \
+    medusa \
+    nfs-common \
+    openvpn \
+    postgresql-client \
     sudo \
-    # RDP checks - virtual X server for freerdp
-    xvfb \
-  && rm -rf /var/lib/apt/lists/*
+    xvfb
 
 # Install Microsoft SQL Server tools and freerdp in single layer
 # freerdp2-x11 was renamed to freerdp3-x11 on newer distributions
 # Some distributions ship only a generic "freerdp" package
-RUN curl -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb && \
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists \
+    curl -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb && \
     dpkg -i /tmp/packages-microsoft-prod.deb && \
     rm /tmp/packages-microsoft-prod.deb && \
     apt-get update && \
@@ -50,12 +40,12 @@ RUN curl -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/conf
       unixodbc-dev \
     && (apt-get install -y --no-install-recommends freerdp2-x11 || \
         apt-get install -y --no-install-recommends freerdp3-x11 || \
-        apt-get install -y --no-install-recommends freerdp) \
-    && rm -rf /var/lib/apt/lists/*
+        apt-get install -y --no-install-recommends freerdp)
 
 # Worker-specific Python packages + Playwright in a single pip layer
 # Note: update docker/engine/Dockerfile as well when changing playwright version
-RUN pip install --no-cache-dir -I \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -I \
     # SSH checks
     "paramiko==3.5.0" \
     # WinRM checks
@@ -82,4 +72,4 @@ RUN playwright install chromium
 # Xvfb is a virtual X server which tricks freerdp2
 # into thinking it has a screen. This is used for
 # RDP scorechecks.
-CMD Xvfb :1 -screen 0 1024x768x16 & /app/bin/worker
+CMD ["sh", "-c", "Xvfb :1 -screen 0 1024x768x16 & exec /app/bin/worker"]

--- a/tests/scoring_engine/web/views/api/test_admin_api_extended.py
+++ b/tests/scoring_engine/web/views/api/test_admin_api_extended.py
@@ -1,0 +1,1448 @@
+"""Extended tests for Admin API endpoints not covered by test_admin_api.py."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.check import Check
+from scoring_engine.models.environment import Environment
+from scoring_engine.models.inject import Inject, InjectComment, InjectRubricScore, RubricItem, Template
+from scoring_engine.models.property import Property
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+
+
+class TestAdminAPIExtended:
+    """Tests for admin API endpoints not covered by test_admin_api.py."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.white_team = three_teams["white_team"]
+        self.blue_team = three_teams["blue_team"]
+        self.red_team = three_teams["red_team"]
+        self.white_user = three_teams["white_user"]
+        self.blue_user = three_teams["blue_user"]
+        self.red_user = three_teams["red_user"]
+
+    def login(self, username, password="testpass"):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def logout(self):
+        return self.client.get("/logout", follow_redirects=True)
+
+    def _make_service(self, **kwargs):
+        defaults = dict(name="TestSvc", check_name="ICMP IPv4 Check", host="10.0.0.1", team=self.blue_team)
+        defaults.update(kwargs)
+        svc = Service(**defaults)
+        db.session.add(svc)
+        db.session.flush()
+        return svc
+
+    def _make_template(self, **kwargs):
+        defaults = dict(
+            title="Test Inject",
+            scenario="Test scenario",
+            deliverable="Test deliverable",
+            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        defaults.update(kwargs)
+        t = Template(**defaults)
+        db.session.add(t)
+        db.session.flush()
+        return t
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/update_host
+    # -----------------------------------------------------------------------
+    def test_update_host_requires_auth(self):
+        resp = self.client.post("/api/admin/update_host")
+        assert resp.status_code == 302
+
+    def test_update_host_requires_white_team(self):
+        svc = self._make_service()
+        db.session.commit()
+        self.login("blueuser")
+        resp = self.client.post("/api/admin/update_host", data={"pk": svc.id, "name": "host", "value": "10.0.0.2"})
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_update_host_success(self):
+        svc = self._make_service()
+        db.session.commit()
+        self.login("whiteuser")
+        with patch("scoring_engine.web.views.api.admin.update_overview_data"), \
+             patch("scoring_engine.web.views.api.admin.update_services_data"), \
+             patch("scoring_engine.web.views.api.admin.update_service_data"):
+            resp = self.client.post("/api/admin/update_host", data={"pk": svc.id, "name": "host", "value": "10.0.0.2"})
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Updated Service Information"
+        db.session.refresh(svc)
+        assert svc.host == "10.0.0.2"
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/update_port
+    # -----------------------------------------------------------------------
+    def test_update_port_requires_auth(self):
+        resp = self.client.post("/api/admin/update_port")
+        assert resp.status_code == 302
+
+    def test_update_port_requires_white_team(self):
+        svc = self._make_service()
+        db.session.commit()
+        self.login("blueuser")
+        resp = self.client.post("/api/admin/update_port", data={"pk": svc.id, "name": "port", "value": "8080"})
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_update_port_success(self):
+        svc = self._make_service()
+        db.session.commit()
+        self.login("whiteuser")
+        with patch("scoring_engine.web.views.api.admin.update_overview_data"), \
+             patch("scoring_engine.web.views.api.admin.update_services_data"), \
+             patch("scoring_engine.web.views.api.admin.update_service_data"):
+            resp = self.client.post("/api/admin/update_port", data={"pk": svc.id, "name": "port", "value": "8080"})
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Updated Service Information"
+        db.session.refresh(svc)
+        assert svc.port == 8080
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/update_worker_queue
+    # -----------------------------------------------------------------------
+    def test_update_worker_queue_requires_auth(self):
+        resp = self.client.post("/api/admin/update_worker_queue")
+        assert resp.status_code == 302
+
+    def test_update_worker_queue_requires_white_team(self):
+        svc = self._make_service()
+        db.session.commit()
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/admin/update_worker_queue", data={"pk": svc.id, "name": "worker_queue", "value": "worker2"}
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_update_worker_queue_success(self):
+        svc = self._make_service()
+        db.session.commit()
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_worker_queue", data={"pk": svc.id, "name": "worker_queue", "value": "worker2"}
+        )
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Updated Service Information"
+        db.session.refresh(svc)
+        assert svc.worker_queue == "worker2"
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/update_points
+    # -----------------------------------------------------------------------
+    def test_update_points_requires_auth(self):
+        resp = self.client.post("/api/admin/update_points")
+        assert resp.status_code == 302
+
+    def test_update_points_requires_white_team(self):
+        svc = self._make_service()
+        db.session.commit()
+        self.login("blueuser")
+        resp = self.client.post("/api/admin/update_points", data={"pk": svc.id, "name": "points", "value": "200"})
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_update_points_success(self):
+        svc = self._make_service()
+        db.session.commit()
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/update_points", data={"pk": svc.id, "name": "points", "value": "200"})
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Updated Service Information"
+        db.session.refresh(svc)
+        assert svc.points == 200
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/update_about_page_content
+    # -----------------------------------------------------------------------
+    def test_update_about_page_content_requires_auth(self):
+        resp = self.client.post("/api/admin/update_about_page_content")
+        assert resp.status_code == 302
+
+    def test_update_about_page_content_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/admin/update_about_page_content", data={"about_page_content": "new content"}
+        )
+        assert resp.status_code == 403
+
+    def test_update_about_page_content_success(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_about_page_content",
+            data={"about_page_content": "Updated about page"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        setting = Setting.get_setting("about_page_content")
+        assert setting.value == "Updated about page"
+
+    def test_update_about_page_content_missing_field(self):
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/update_about_page_content", data={}, follow_redirects=True)
+        assert resp.status_code == 200  # Redirects with flash error
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/update_welcome_page_content
+    # -----------------------------------------------------------------------
+    def test_update_welcome_page_content_requires_auth(self):
+        resp = self.client.post("/api/admin/update_welcome_page_content")
+        assert resp.status_code == 302
+
+    def test_update_welcome_page_content_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/admin/update_welcome_page_content", data={"welcome_page_content": "new"}
+        )
+        assert resp.status_code == 403
+
+    def test_update_welcome_page_content_success(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_welcome_page_content",
+            data={"welcome_page_content": "New welcome content"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        setting = Setting.get_setting("welcome_page_content")
+        assert setting.value == "New welcome content"
+
+    def test_update_welcome_page_content_missing_field(self):
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/update_welcome_page_content", data={}, follow_redirects=True)
+        assert resp.status_code == 200  # Redirects with flash error
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/update_target_round_time
+    # -----------------------------------------------------------------------
+    def test_update_target_round_time_requires_auth(self):
+        resp = self.client.post("/api/admin/update_target_round_time")
+        assert resp.status_code == 302
+
+    def test_update_target_round_time_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/admin/update_target_round_time", data={"target_round_time": "120"}
+        )
+        assert resp.status_code == 403
+
+    def test_update_target_round_time_success(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_target_round_time",
+            data={"target_round_time": "120"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        setting = Setting.get_setting("target_round_time")
+        assert str(setting.value) == "120"
+
+    def test_update_target_round_time_non_integer(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_target_round_time",
+            data={"target_round_time": "abc"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200  # Redirect with flash error
+
+    def test_update_target_round_time_missing_field(self):
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/update_target_round_time", data={}, follow_redirects=True)
+        assert resp.status_code == 200
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/update_worker_refresh_time
+    # -----------------------------------------------------------------------
+    def test_update_worker_refresh_time_requires_auth(self):
+        resp = self.client.post("/api/admin/update_worker_refresh_time")
+        assert resp.status_code == 302
+
+    def test_update_worker_refresh_time_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/admin/update_worker_refresh_time", data={"worker_refresh_time": "45"}
+        )
+        assert resp.status_code == 403
+
+    def test_update_worker_refresh_time_success(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_worker_refresh_time",
+            data={"worker_refresh_time": "45"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        setting = Setting.get_setting("worker_refresh_time")
+        assert str(setting.value) == "45"
+
+    def test_update_worker_refresh_time_non_integer(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_worker_refresh_time",
+            data={"worker_refresh_time": "abc"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+    def test_update_worker_refresh_time_missing_field(self):
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/update_worker_refresh_time", data={}, follow_redirects=True)
+        assert resp.status_code == 200
+
+    # -----------------------------------------------------------------------
+    # Blue team permission toggle endpoints
+    # -----------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "endpoint,setting_name",
+        [
+            ("/api/admin/update_blueteam_edit_hostname", "blue_team_update_hostname"),
+            ("/api/admin/update_blueteam_edit_port", "blue_team_update_port"),
+            ("/api/admin/update_blueteam_edit_account_usernames", "blue_team_update_account_usernames"),
+            ("/api/admin/update_blueteam_edit_account_passwords", "blue_team_update_account_passwords"),
+            ("/api/admin/update_blueteam_view_check_output", "blue_team_view_check_output"),
+        ],
+    )
+    def test_blueteam_toggle_requires_auth(self, endpoint, setting_name):
+        resp = self.client.post(endpoint)
+        assert resp.status_code == 302
+
+    @pytest.mark.parametrize(
+        "endpoint,setting_name",
+        [
+            ("/api/admin/update_blueteam_edit_hostname", "blue_team_update_hostname"),
+            ("/api/admin/update_blueteam_edit_port", "blue_team_update_port"),
+            ("/api/admin/update_blueteam_edit_account_usernames", "blue_team_update_account_usernames"),
+            ("/api/admin/update_blueteam_edit_account_passwords", "blue_team_update_account_passwords"),
+            ("/api/admin/update_blueteam_view_check_output", "blue_team_view_check_output"),
+        ],
+    )
+    def test_blueteam_toggle_requires_white_team(self, endpoint, setting_name):
+        self.login("blueuser")
+        resp = self.client.post(endpoint)
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize(
+        "endpoint,setting_name",
+        [
+            ("/api/admin/update_blueteam_edit_hostname", "blue_team_update_hostname"),
+            ("/api/admin/update_blueteam_edit_port", "blue_team_update_port"),
+            ("/api/admin/update_blueteam_edit_account_usernames", "blue_team_update_account_usernames"),
+            ("/api/admin/update_blueteam_edit_account_passwords", "blue_team_update_account_passwords"),
+            ("/api/admin/update_blueteam_view_check_output", "blue_team_view_check_output"),
+        ],
+    )
+    def test_blueteam_toggle_true_to_false(self, endpoint, setting_name):
+        """Default is True; toggling should set to False."""
+        self.login("whiteuser")
+        setting = Setting.get_setting(setting_name)
+        assert setting.value is True
+        resp = self.client.post(endpoint, follow_redirects=True)
+        assert resp.status_code == 200
+        Setting.clear_cache(setting_name)
+        setting = Setting.get_setting(setting_name)
+        assert setting.value is False
+
+    @pytest.mark.parametrize(
+        "endpoint,setting_name",
+        [
+            ("/api/admin/update_blueteam_edit_hostname", "blue_team_update_hostname"),
+            ("/api/admin/update_blueteam_edit_port", "blue_team_update_port"),
+            ("/api/admin/update_blueteam_edit_account_usernames", "blue_team_update_account_usernames"),
+            ("/api/admin/update_blueteam_edit_account_passwords", "blue_team_update_account_passwords"),
+            ("/api/admin/update_blueteam_view_check_output", "blue_team_view_check_output"),
+        ],
+    )
+    def test_blueteam_toggle_false_to_true(self, endpoint, setting_name):
+        """Set to False first, then toggle should set back to True."""
+        setting = Setting.get_setting(setting_name)
+        setting.value = False
+        db.session.commit()
+        Setting.clear_cache(setting_name)
+
+        self.login("whiteuser")
+        resp = self.client.post(endpoint, follow_redirects=True)
+        assert resp.status_code == 200
+        Setting.clear_cache(setting_name)
+        setting = Setting.get_setting(setting_name)
+        assert setting.value is True
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/update_anonymize_team_names
+    # -----------------------------------------------------------------------
+    def test_update_anonymize_team_names_requires_auth(self):
+        resp = self.client.post("/api/admin/update_anonymize_team_names")
+        assert resp.status_code == 302
+
+    def test_update_anonymize_team_names_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post("/api/admin/update_anonymize_team_names")
+        assert resp.status_code == 403
+
+    def test_update_anonymize_team_names_toggle_on(self):
+        """Default is False; toggling should set to True."""
+        self.login("whiteuser")
+        setting = Setting.get_setting("anonymize_team_names")
+        assert setting.value is False
+        resp = self.client.post("/api/admin/update_anonymize_team_names", follow_redirects=True)
+        assert resp.status_code == 200
+        Setting.clear_cache("anonymize_team_names")
+        setting = Setting.get_setting("anonymize_team_names")
+        assert setting.value is True
+
+    def test_update_anonymize_team_names_toggle_off(self):
+        """Set to True first, toggle should set back to False."""
+        setting = Setting.get_setting("anonymize_team_names")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("anonymize_team_names")
+
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/update_anonymize_team_names", follow_redirects=True)
+        assert resp.status_code == 200
+        Setting.clear_cache("anonymize_team_names")
+        setting = Setting.get_setting("anonymize_team_names")
+        assert setting.value is False
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/check/<check_id>/full_output
+    # -----------------------------------------------------------------------
+    def test_check_full_output_requires_auth(self):
+        resp = self.client.get("/api/admin/check/1/full_output")
+        assert resp.status_code == 302
+
+    def test_check_full_output_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/check/1/full_output")
+        assert resp.status_code == 403
+
+    def test_check_full_output_not_found(self):
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/check/99999/full_output")
+        assert resp.status_code == 404
+
+    def test_check_full_output_from_db(self):
+        svc = self._make_service()
+        rnd = Round(number=1)
+        db.session.add(rnd)
+        db.session.flush()
+        check = Check(service=svc, round=rnd, result=True, output="check output text")
+        db.session.add(check)
+        db.session.commit()
+
+        self.login("whiteuser")
+        with patch("scoring_engine.web.views.api.admin.os.path.isfile", return_value=False):
+            resp = self.client.get(f"/api/admin/check/{check.id}/full_output")
+        assert resp.status_code == 200
+        assert b"check output text" in resp.data
+
+    def test_check_full_output_from_file(self):
+        svc = self._make_service()
+        rnd = Round(number=1)
+        db.session.add(rnd)
+        db.session.flush()
+        check = Check(service=svc, round=rnd, result=True, output="db fallback")
+        db.session.add(check)
+        db.session.commit()
+
+        self.login("whiteuser")
+        mock_open = MagicMock()
+        mock_open.return_value.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value="file output")))
+        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("scoring_engine.web.views.api.admin.os.path.isfile", return_value=True), \
+             patch("builtins.open", mock_open):
+            resp = self.client.get(f"/api/admin/check/{check.id}/full_output")
+        assert resp.status_code == 200
+        assert b"file output" in resp.data
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/injects/templates/<template_id>
+    # -----------------------------------------------------------------------
+    def test_get_template_by_id_requires_auth(self):
+        resp = self.client.get("/api/admin/injects/templates/1")
+        assert resp.status_code == 302
+
+    def test_get_template_by_id_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/injects/templates/1")
+        assert resp.status_code == 403
+
+    def test_get_template_by_id_success(self):
+        template = self._make_template()
+        ri = RubricItem(title="Quality", points=50, template=template, order=0)
+        db.session.add(ri)
+        inject = Inject(team=self.blue_team, template=template)
+        db.session.add(inject)
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.get(f"/api/admin/injects/templates/{template.id}")
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["title"] == "Test Inject"
+        assert len(data["rubric_items"]) == 1
+        assert data["rubric_items"][0]["title"] == "Quality"
+        assert "Blue Team" in data["teams"]
+
+    # -----------------------------------------------------------------------
+    # PUT /api/admin/injects/templates/<template_id>
+    # -----------------------------------------------------------------------
+    def test_put_template_requires_auth(self):
+        resp = self.client.put("/api/admin/injects/templates/1", json={})
+        assert resp.status_code == 302
+
+    def test_put_template_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.put("/api/admin/injects/templates/1", json={})
+        assert resp.status_code == 403
+
+    def test_put_template_not_found(self):
+        self.login("whiteuser")
+        resp = self.client.put("/api/admin/injects/templates/99999", json={"title": "X"})
+        assert resp.status_code == 400
+        assert resp.json["message"] == "Template not found"
+
+    def test_put_template_update_fields(self):
+        template = self._make_template()
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.put(
+            f"/api/admin/injects/templates/{template.id}",
+            json={
+                "title": "Updated Title",
+                "scenario": "Updated scenario",
+                "deliverable": "Updated deliverable",
+                "status": "Disabled",
+            },
+        )
+        assert resp.status_code == 200
+        db.session.refresh(template)
+        assert template.title == "Updated Title"
+        assert template.scenario == "Updated scenario"
+        assert template.enabled is False
+
+    def test_put_template_update_rubric_items(self):
+        template = self._make_template()
+        ri = RubricItem(title="Old Item", points=50, template=template, order=0)
+        db.session.add(ri)
+        db.session.commit()
+        ri_id = ri.id
+
+        self.login("whiteuser")
+        resp = self.client.put(
+            f"/api/admin/injects/templates/{template.id}",
+            json={
+                "rubric_items": [
+                    {"id": ri_id, "title": "Updated Item", "points": 75, "order": 0},
+                    {"title": "New Item", "points": 25, "order": 1},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        db.session.refresh(template)
+        assert len(template.rubric_items) == 2
+
+    def test_put_template_selected_teams(self):
+        template = self._make_template()
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.put(
+            f"/api/admin/injects/templates/{template.id}",
+            json={"selectedTeams": ["Blue Team"]},
+        )
+        assert resp.status_code == 200
+        inject = db.session.query(Inject).filter_by(template_id=template.id).first()
+        assert inject is not None
+        assert inject.team.name == "Blue Team"
+
+    def test_put_template_unselected_teams(self):
+        template = self._make_template()
+        inject = Inject(team=self.blue_team, template=template)
+        db.session.add(inject)
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.put(
+            f"/api/admin/injects/templates/{template.id}",
+            json={"unselectedTeams": ["Blue Team"]},
+        )
+        assert resp.status_code == 200
+        db.session.refresh(inject)
+        assert inject.enabled is False
+
+    # -----------------------------------------------------------------------
+    # DELETE /api/admin/injects/templates/<template_id>
+    # -----------------------------------------------------------------------
+    def test_delete_template_requires_auth(self):
+        resp = self.client.delete("/api/admin/injects/templates/1")
+        assert resp.status_code == 302
+
+    def test_delete_template_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.delete("/api/admin/injects/templates/1")
+        assert resp.status_code == 403
+
+    def test_delete_template_not_found(self):
+        self.login("whiteuser")
+        resp = self.client.delete("/api/admin/injects/templates/99999")
+        assert resp.status_code == 400
+
+    def test_delete_template_success(self):
+        template = self._make_template()
+        db.session.commit()
+        tid = template.id
+
+        self.login("whiteuser")
+        resp = self.client.delete(f"/api/admin/injects/templates/{tid}")
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Success"
+        assert db.session.get(Template, tid) is None
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/injects/templates (list all)
+    # -----------------------------------------------------------------------
+    def test_list_templates_requires_auth(self):
+        resp = self.client.get("/api/admin/injects/templates")
+        assert resp.status_code == 302
+
+    def test_list_templates_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/injects/templates")
+        assert resp.status_code == 403
+
+    def test_list_templates_success(self):
+        t1 = self._make_template(title="Inject A")
+        t2 = self._make_template(title="Inject B")
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/injects/templates")
+        assert resp.status_code == 200
+        titles = [t["title"] for t in resp.json["data"]]
+        assert "Inject A" in titles
+        assert "Inject B" in titles
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/inject/<inject_id>/grade
+    # -----------------------------------------------------------------------
+    def test_grade_inject_requires_auth(self):
+        resp = self.client.post("/api/admin/inject/1/grade", json={})
+        assert resp.status_code == 302
+
+    def test_grade_inject_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post("/api/admin/inject/1/grade", json={"rubric_scores": [{"rubric_item_id": 1, "score": 5}]})
+        assert resp.status_code == 403
+
+    def test_grade_inject_missing_scores(self):
+        self.login("whiteuser")
+        template = self._make_template()
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Submitted"
+        db.session.add(inject)
+        db.session.commit()
+
+        resp = self.client.post(f"/api/admin/inject/{inject.id}/grade", json={"rubric_scores": []})
+        assert resp.status_code == 400
+        assert resp.json["status"] == "Invalid Score Provided"
+
+    def test_grade_inject_invalid_inject_id(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/inject/99999/grade",
+            json={"rubric_scores": [{"rubric_item_id": 1, "score": 5}]},
+        )
+        assert resp.status_code == 400
+        assert resp.json["status"] == "Invalid Inject ID"
+
+    def test_grade_inject_invalid_rubric_item(self):
+        self.login("whiteuser")
+        template = self._make_template()
+        ri = RubricItem(title="Quality", points=100, template=template, order=0)
+        db.session.add(ri)
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Submitted"
+        db.session.add(inject)
+        db.session.commit()
+
+        resp = self.client.post(
+            f"/api/admin/inject/{inject.id}/grade",
+            json={"rubric_scores": [{"rubric_item_id": 99999, "score": 50}]},
+        )
+        assert resp.status_code == 400
+        assert resp.json["status"] == "Invalid rubric item ID"
+
+    def test_grade_inject_score_exceeds_max(self):
+        self.login("whiteuser")
+        template = self._make_template()
+        ri = RubricItem(title="Quality", points=100, template=template, order=0)
+        db.session.add(ri)
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Submitted"
+        db.session.add(inject)
+        db.session.commit()
+
+        resp = self.client.post(
+            f"/api/admin/inject/{inject.id}/grade",
+            json={"rubric_scores": [{"rubric_item_id": ri.id, "score": 150}]},
+        )
+        assert resp.status_code == 400
+        assert resp.json["status"] == "Score exceeds rubric item max"
+
+    def test_grade_inject_success(self):
+        self.login("whiteuser")
+        template = self._make_template()
+        ri = RubricItem(title="Quality", points=100, template=template, order=0)
+        db.session.add(ri)
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Submitted"
+        db.session.add(inject)
+        db.session.commit()
+
+        with patch("scoring_engine.web.views.api.admin.update_inject_data"), \
+             patch("scoring_engine.web.views.api.admin.update_inject_comments"), \
+             patch("scoring_engine.web.views.api.admin.update_scoreboard_data"), \
+             patch("scoring_engine.web.views.api.admin.notify_inject_graded"):
+            resp = self.client.post(
+                f"/api/admin/inject/{inject.id}/grade",
+                json={"rubric_scores": [{"rubric_item_id": ri.id, "score": 80}]},
+            )
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Success"
+        db.session.refresh(inject)
+        assert inject.status == "Graded"
+        assert inject.graded is not None
+        assert inject.score == 80
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/inject/<inject_id>/request-revision
+    # -----------------------------------------------------------------------
+    def test_request_revision_requires_auth(self):
+        resp = self.client.post("/api/admin/inject/1/request-revision", json={})
+        assert resp.status_code == 302
+
+    def test_request_revision_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post("/api/admin/inject/1/request-revision", json={})
+        assert resp.status_code == 403
+
+    def test_request_revision_invalid_inject(self):
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/inject/99999/request-revision", json={})
+        assert resp.status_code == 400
+        assert resp.json["status"] == "Invalid Inject ID"
+
+    def test_request_revision_wrong_status(self):
+        self.login("whiteuser")
+        template = self._make_template()
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Draft"
+        db.session.add(inject)
+        db.session.commit()
+
+        resp = self.client.post(f"/api/admin/inject/{inject.id}/request-revision", json={})
+        assert resp.status_code == 400
+        assert resp.json["status"] == "Inject is not in a submittable state"
+
+    def test_request_revision_success(self):
+        self.login("whiteuser")
+        template = self._make_template()
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Submitted"
+        db.session.add(inject)
+        db.session.commit()
+
+        with patch("scoring_engine.web.views.api.admin.update_inject_data"), \
+             patch("scoring_engine.web.views.api.admin.update_inject_comments"), \
+             patch("scoring_engine.web.views.api.admin.notify_revision_requested"):
+            resp = self.client.post(
+                f"/api/admin/inject/{inject.id}/request-revision",
+                json={"reason": "Please fix the formatting"},
+            )
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Success"
+        db.session.refresh(inject)
+        assert inject.status == "Revision Requested"
+
+    def test_request_revision_default_reason(self):
+        self.login("whiteuser")
+        template = self._make_template()
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Submitted"
+        db.session.add(inject)
+        db.session.commit()
+
+        with patch("scoring_engine.web.views.api.admin.update_inject_data"), \
+             patch("scoring_engine.web.views.api.admin.update_inject_comments"), \
+             patch("scoring_engine.web.views.api.admin.notify_revision_requested"):
+            resp = self.client.post(f"/api/admin/inject/{inject.id}/request-revision", json={})
+        assert resp.status_code == 200
+        comments = db.session.query(InjectComment).filter_by(inject_id=inject.id).all()
+        assert any("Revision requested by grader" in c.content for c in comments)
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/injects/template/<template_id>/submissions
+    # -----------------------------------------------------------------------
+    def test_template_submissions_requires_auth(self):
+        resp = self.client.get("/api/admin/injects/template/1/submissions")
+        assert resp.status_code == 302
+
+    def test_template_submissions_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/injects/template/1/submissions")
+        assert resp.status_code == 403
+
+    def test_template_submissions_not_found(self):
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/injects/template/99999/submissions")
+        assert resp.status_code == 404
+
+    def test_template_submissions_success(self):
+        template = self._make_template()
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Submitted"
+        inject.submitted = datetime.now(timezone.utc)
+        db.session.add(inject)
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.get(f"/api/admin/injects/template/{template.id}/submissions")
+        assert resp.status_code == 200
+        data = resp.json["data"]
+        assert len(data) == 1
+        assert data[0]["team"] == "Blue Team"
+        assert data[0]["status"] == "Submitted"
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/injects/templates (create new)
+    # -----------------------------------------------------------------------
+    def test_create_template_requires_auth(self):
+        resp = self.client.post("/api/admin/injects/templates", json={})
+        assert resp.status_code == 302
+
+    def test_create_template_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post("/api/admin/injects/templates", json={})
+        assert resp.status_code == 403
+
+    def test_create_template_missing_data(self):
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/injects/templates", json={"title": "Only title"})
+        assert resp.status_code == 400
+        assert resp.json["message"] == "Missing Data"
+
+    def test_create_template_success(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/injects/templates",
+            json={
+                "title": "New Inject",
+                "scenario": "Do something",
+                "deliverable": "A report",
+                "start_time": "2026-01-01T00:00:00-05:00",
+                "end_time": "2026-12-31T23:59:59-05:00",
+                "rubric_items": [
+                    {"title": "Quality", "points": 50},
+                    {"title": "Completeness", "points": 50, "description": "Was it complete?"},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Success"
+        template = db.session.query(Template).filter_by(title="New Inject").first()
+        assert template is not None
+        assert len(template.rubric_items) == 2
+
+    def test_create_template_with_teams(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/injects/templates",
+            json={
+                "title": "Team Inject",
+                "scenario": "Scenario",
+                "deliverable": "Deliverable",
+                "start_time": "2026-01-01T00:00:00-05:00",
+                "end_time": "2026-12-31T23:59:59-05:00",
+                "selectedTeams": ["Blue Team"],
+            },
+        )
+        assert resp.status_code == 200
+        template = db.session.query(Template).filter_by(title="Team Inject").first()
+        inject = db.session.query(Inject).filter_by(template_id=template.id).first()
+        assert inject is not None
+        assert inject.team.name == "Blue Team"
+
+    def test_create_template_with_status_enabled(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/injects/templates",
+            json={
+                "title": "Enabled Inject",
+                "scenario": "Scenario",
+                "deliverable": "Deliverable",
+                "start_time": "2026-01-01T00:00:00-05:00",
+                "end_time": "2026-12-31T23:59:59-05:00",
+                "status": "Enabled",
+            },
+        )
+        assert resp.status_code == 200
+        template = db.session.query(Template).filter_by(title="Enabled Inject").first()
+        assert template.enabled is True
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/injects/templates/import
+    # -----------------------------------------------------------------------
+    def test_import_templates_requires_auth(self):
+        resp = self.client.post("/api/admin/injects/templates/import", json=[])
+        assert resp.status_code == 302
+
+    def test_import_templates_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post("/api/admin/injects/templates/import", json=[])
+        assert resp.status_code == 403
+
+    def test_import_templates_empty_data(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/injects/templates/import",
+            data=json.dumps(None),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_import_templates_create_new(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/injects/templates/import",
+            json=[
+                {
+                    "title": "Imported Inject",
+                    "scenario": "Import scenario",
+                    "deliverable": "Import deliverable",
+                    "start_time": "2026-01-01T00:00:00-05:00",
+                    "end_time": "2026-12-31T23:59:59-05:00",
+                    "enabled": True,
+                    "teams": ["Blue Team"],
+                    "rubric_items": [{"title": "Quality", "points": 100}],
+                }
+            ],
+        )
+        assert resp.status_code == 200
+        template = db.session.query(Template).filter_by(title="Imported Inject").first()
+        assert template is not None
+        assert len(template.rubric_items) == 1
+
+    def test_import_templates_update_existing(self):
+        template = self._make_template(title="Existing")
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/injects/templates/import",
+            json=[
+                {
+                    "id": template.id,
+                    "title": "Updated Existing",
+                    "scenario": "Updated scenario",
+                    "deliverable": "Updated deliverable",
+                    "start_time": "2026-06-01T00:00:00-05:00",
+                    "end_time": "2026-12-31T23:59:59-05:00",
+                    "enabled": True,
+                    "teams": [],
+                }
+            ],
+        )
+        assert resp.status_code == 200
+        db.session.refresh(template)
+        assert template.title == "Updated Existing"
+
+    def test_import_templates_nonexistent_id_creates_new(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/injects/templates/import",
+            json=[
+                {
+                    "id": 99999,
+                    "title": "FallThrough",
+                    "scenario": "Scenario",
+                    "deliverable": "Deliverable",
+                    "start_time": "2026-01-01T00:00:00-05:00",
+                    "end_time": "2026-12-31T23:59:59-05:00",
+                    "enabled": True,
+                    "teams": [],
+                }
+            ],
+        )
+        assert resp.status_code == 200
+        template = db.session.query(Template).filter_by(title="FallThrough").first()
+        assert template is not None
+
+    def test_import_templates_with_score_fallback(self):
+        """Test backward compat: if 'score' exists but no rubric_items, creates default rubric item."""
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/injects/templates/import",
+            json=[
+                {
+                    "title": "Legacy Inject",
+                    "scenario": "Scenario",
+                    "deliverable": "Deliverable",
+                    "start_time": "2026-01-01T00:00:00-05:00",
+                    "end_time": "2026-12-31T23:59:59-05:00",
+                    "enabled": True,
+                    "teams": [],
+                    "score": 200,
+                }
+            ],
+        )
+        assert resp.status_code == 200
+        template = db.session.query(Template).filter_by(title="Legacy Inject").first()
+        assert template is not None
+        assert len(template.rubric_items) == 1
+        assert template.rubric_items[0].title == "Overall Quality"
+        assert template.rubric_items[0].points == 200
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/injects/scores
+    # -----------------------------------------------------------------------
+    def test_inject_scores_requires_auth(self):
+        resp = self.client.get("/api/admin/injects/scores")
+        assert resp.status_code == 302
+
+    def test_inject_scores_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/injects/scores")
+        assert resp.status_code == 403
+
+    def test_inject_scores_success(self):
+        template = self._make_template()
+        ri = RubricItem(title="Quality", points=100, template=template, order=0)
+        db.session.add(ri)
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Graded"
+        db.session.add(inject)
+        db.session.flush()
+        score = InjectRubricScore(score=80, inject=inject, rubric_item=ri, grader=self.white_user)
+        db.session.add(score)
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/injects/scores")
+        assert resp.status_code == 200
+        data = resp.json["data"]
+        assert len(data) >= 1
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/injects/get_bar_chart
+    # -----------------------------------------------------------------------
+    def test_inject_bar_chart_requires_auth(self):
+        resp = self.client.get("/api/admin/injects/get_bar_chart")
+        assert resp.status_code == 302
+
+    def test_inject_bar_chart_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/injects/get_bar_chart")
+        assert resp.status_code == 403
+
+    def test_inject_bar_chart_success(self):
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/injects/get_bar_chart")
+        assert resp.status_code == 200
+        assert "labels" in resp.json
+        assert "inject_scores" in resp.json
+
+    def test_inject_bar_chart_with_data(self):
+        template = self._make_template()
+        ri = RubricItem(title="Quality", points=100, template=template, order=0)
+        db.session.add(ri)
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Graded"
+        db.session.add(inject)
+        db.session.flush()
+        score = InjectRubricScore(score=75, inject=inject, rubric_item=ri, grader=self.white_user)
+        db.session.add(score)
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/injects/get_bar_chart")
+        assert resp.status_code == 200
+        assert "Blue Team" in resp.json["labels"]
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/admin_update_template
+    # -----------------------------------------------------------------------
+    def test_admin_update_template_requires_auth(self):
+        resp = self.client.post("/api/admin/admin_update_template")
+        assert resp.status_code == 302
+
+    def test_admin_update_template_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post("/api/admin/admin_update_template", data={"pk": 1, "name": "template_state", "value": "x"})
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_admin_update_template_not_found(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/admin_update_template", data={"pk": 99999, "name": "template_state", "value": "x"}
+        )
+        assert resp.json["error"] == "Template Not Found"
+
+    def test_admin_update_template_state(self):
+        template = self._make_template()
+        db.session.commit()
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/admin_update_template",
+            data={"pk": template.id, "name": "template_state", "value": "Active"},
+        )
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Updated Property Information"
+
+    def test_admin_update_template_points(self):
+        template = self._make_template()
+        db.session.commit()
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/admin_update_template",
+            data={"pk": template.id, "name": "template_points", "value": "500"},
+        )
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Updated Property Information"
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/get_teams
+    # -----------------------------------------------------------------------
+    def test_get_teams_requires_auth(self):
+        resp = self.client.get("/api/admin/get_teams")
+        assert resp.status_code == 302
+
+    def test_get_teams_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/get_teams")
+        assert resp.status_code == 403
+
+    def test_get_teams_success(self):
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/get_teams")
+        assert resp.status_code == 200
+        data = resp.json["data"]
+        team_names = [t["name"] for t in data]
+        assert "White Team" in team_names
+        assert "Blue Team" in team_names
+        assert "Red Team" in team_names
+        # Verify users are included
+        blue = next(t for t in data if t["name"] == "Blue Team")
+        assert "blueuser" in blue["users"]
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/update_password
+    # -----------------------------------------------------------------------
+    def test_update_password_requires_auth(self):
+        resp = self.client.post("/api/admin/update_password")
+        assert resp.status_code == 302
+
+    def test_update_password_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/admin/update_password",
+            data={"user_id": self.blue_user.id, "password": "newpass"},
+        )
+        assert resp.status_code == 403
+
+    def test_update_password_success(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_password",
+            data={"user_id": self.blue_user.id, "password": "newpassword"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        # Verify user can login with new password
+        self.logout()
+        resp = self.login("blueuser", "newpassword")
+        assert resp.status_code == 200
+
+    def test_update_password_missing_fields(self):
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/update_password", data={}, follow_redirects=True)
+        assert resp.status_code == 200  # Redirects with flash
+
+    def test_update_password_invalid_user(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/update_password",
+            data={"user_id": 99999, "password": "newpass"},
+            follow_redirects=True,
+        )
+        # Should redirect to login when user not found
+        assert resp.status_code == 200
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/add_user
+    # -----------------------------------------------------------------------
+    def test_add_user_requires_auth(self):
+        resp = self.client.post("/api/admin/add_user")
+        assert resp.status_code == 302
+
+    def test_add_user_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/admin/add_user",
+            data={"username": "newuser", "password": "pass", "team_id": self.blue_team.id},
+        )
+        assert resp.status_code == 403
+
+    def test_add_user_success(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/add_user",
+            data={"username": "newblue", "password": "testpass", "team_id": self.blue_team.id},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        user = db.session.query(User).filter_by(username="newblue").first()
+        assert user is not None
+        assert user.team.id == self.blue_team.id
+
+    def test_add_user_missing_fields(self):
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/add_user", data={"username": "partial"}, follow_redirects=True)
+        assert resp.status_code == 200  # Redirects with flash
+
+    # -----------------------------------------------------------------------
+    # POST /api/admin/add_team
+    # -----------------------------------------------------------------------
+    def test_add_team_requires_auth(self):
+        resp = self.client.post("/api/admin/add_team")
+        assert resp.status_code == 302
+
+    def test_add_team_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.post("/api/admin/add_team", data={"name": "New", "color": "Blue"})
+        assert resp.status_code == 403
+
+    def test_add_team_success(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/admin/add_team",
+            data={"name": "New Blue Team", "color": "Blue"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        team = db.session.query(Team).filter_by(name="New Blue Team").first()
+        assert team is not None
+        assert team.color == "Blue"
+
+    def test_add_team_missing_fields(self):
+        self.login("whiteuser")
+        resp = self.client.post("/api/admin/add_team", data={"name": "Only Name"}, follow_redirects=True)
+        assert resp.status_code == 200  # Redirects with flash
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/get_engine_stats
+    # -----------------------------------------------------------------------
+    def test_get_engine_stats_requires_auth(self):
+        resp = self.client.get("/api/admin/get_engine_stats")
+        assert resp.status_code == 302
+
+    def test_get_engine_stats_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/get_engine_stats")
+        assert resp.status_code == 403
+
+    def test_get_engine_stats_success(self):
+        svc = self._make_service()
+        rnd = Round(number=1)
+        db.session.add(rnd)
+        db.session.flush()
+        c1 = Check(service=svc, round=rnd, result=True, output="ok")
+        c2 = Check(service=svc, round=rnd, result=False, output="fail")
+        db.session.add_all([c1, c2])
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/get_engine_stats")
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["round_number"] == 1
+        assert data["num_passed_checks"] == 1
+        assert data["num_failed_checks"] == 1
+        assert data["total_checks"] == 2
+
+    def test_get_engine_stats_no_rounds(self):
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/get_engine_stats")
+        assert resp.status_code == 200
+        assert resp.json["round_number"] == 0
+        assert resp.json["total_checks"] == 0
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/get_worker_stats
+    # -----------------------------------------------------------------------
+    def test_get_worker_stats_requires_auth(self):
+        resp = self.client.get("/api/admin/get_worker_stats")
+        assert resp.status_code == 302
+
+    def test_get_worker_stats_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/get_worker_stats")
+        assert resp.status_code == 403
+
+    def test_get_worker_stats_success(self):
+        self.login("whiteuser")
+        with patch("scoring_engine.web.views.api.admin.CeleryStats") as mock_cs:
+            mock_cs.get_worker_stats.return_value = {"worker1": {"status": "active"}}
+            resp = self.client.get("/api/admin/get_worker_stats")
+        assert resp.status_code == 200
+        assert resp.json["data"] == {"worker1": {"status": "active"}}
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/get_queue_stats
+    # -----------------------------------------------------------------------
+    def test_get_queue_stats_requires_auth(self):
+        resp = self.client.get("/api/admin/get_queue_stats")
+        assert resp.status_code == 302
+
+    def test_get_queue_stats_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/get_queue_stats")
+        assert resp.status_code == 403
+
+    def test_get_queue_stats_success(self):
+        self.login("whiteuser")
+        with patch("scoring_engine.web.views.api.admin.CeleryStats") as mock_cs:
+            mock_cs.get_queue_stats.return_value = {"default": 5}
+            resp = self.client.get("/api/admin/get_queue_stats")
+        assert resp.status_code == 200
+        assert resp.json["data"] == {"default": 5}
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/get_competition_summary
+    # -----------------------------------------------------------------------
+    def test_get_competition_summary_requires_auth(self):
+        resp = self.client.get("/api/admin/get_competition_summary")
+        assert resp.status_code == 302
+
+    def test_get_competition_summary_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/get_competition_summary")
+        assert resp.status_code == 403
+
+    def test_get_competition_summary_empty(self):
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/get_competition_summary")
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["blue_teams"] == 1  # From three_teams fixture
+        assert data["total_services"] == 0
+        assert data["overall_uptime"] == 0.0
+        assert data["currently_passing"] == 0
+
+    def test_get_competition_summary_with_data(self):
+        svc = self._make_service()
+        rnd = Round(number=1)
+        db.session.add(rnd)
+        db.session.flush()
+        c1 = Check(service=svc, round=rnd, result=True, output="ok")
+        c2 = Check(service=svc, round=rnd, result=False, output="fail")
+        db.session.add_all([c1, c2])
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/get_competition_summary")
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["blue_teams"] == 1
+        assert data["total_services"] == 1
+        assert data["overall_uptime"] == 50.0
+        assert data["currently_passing"] == 1
+
+    # -----------------------------------------------------------------------
+    # GET /api/admin/welcome/config
+    # -----------------------------------------------------------------------
+    def test_get_welcome_config_requires_auth(self):
+        resp = self.client.get("/api/admin/welcome/config")
+        assert resp.status_code == 302
+
+    def test_get_welcome_config_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/welcome/config")
+        assert resp.status_code == 403
+
+    def test_get_welcome_config_success(self):
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/welcome/config")
+        assert resp.status_code == 200
+        data = resp.json["data"]
+        assert "welcome_message" in data
+        assert "sponsor_tiers" in data
+
+    # -----------------------------------------------------------------------
+    # PUT /api/admin/welcome/config
+    # -----------------------------------------------------------------------
+    def test_put_welcome_config_requires_auth(self):
+        resp = self.client.put("/api/admin/welcome/config", json={})
+        assert resp.status_code == 302
+
+    def test_put_welcome_config_requires_white_team(self):
+        self.login("blueuser")
+        resp = self.client.put("/api/admin/welcome/config", json={})
+        assert resp.status_code == 403
+
+    def test_put_welcome_config_no_data(self):
+        self.login("whiteuser")
+        # Send empty dict which is falsy in `if not data` check
+        resp = self.client.put(
+            "/api/admin/welcome/config",
+            json={},
+        )
+        assert resp.status_code == 400
+        assert resp.json["status"] == "Error"
+
+    def test_put_welcome_config_success(self):
+        self.login("whiteuser")
+        resp = self.client.put(
+            "/api/admin/welcome/config",
+            json={
+                "welcome_message": "<h1>Hello</h1>",
+                "sponsor_tiers": [
+                    {"name": "Gold", "display_order": 1, "sponsors": [{"name": "Acme Corp"}]},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Success"
+        assert resp.json["data"]["welcome_message"] == "<h1>Hello</h1>"
+
+    def test_put_welcome_config_invalid_structure(self):
+        self.login("whiteuser")
+        resp = self.client.put(
+            "/api/admin/welcome/config",
+            json={
+                "welcome_message": "Hello",
+                "sponsor_tiers": [
+                    "not a dict",
+                ],
+            },
+        )
+        assert resp.status_code == 400
+        assert resp.json["status"] == "Error"

--- a/tests/scoring_engine/web/views/api/test_notifications_api.py
+++ b/tests/scoring_engine/web/views/api/test_notifications_api.py
@@ -1,0 +1,183 @@
+"""Tests for Notifications API endpoints."""
+
+import datetime
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.notifications import Notification
+
+
+class TestNotificationsAPI:
+    """Tests for /api/notifications endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.teams = three_teams
+        self.blue_team = three_teams["blue_team"]
+        self.red_team = three_teams["red_team"]
+
+    def login(self, username):
+        self.client.post("/login", data={"username": username, "password": "testpass"}, follow_redirects=True)
+
+    def _create_notification(self, team, message="Test notification", target="/services", is_read=False):
+        n = Notification(
+            message=message,
+            target=target,
+            team_id=team.id,
+            is_read=is_read,
+            created=datetime.datetime.now(datetime.UTC),
+        )
+        db.session.add(n)
+        db.session.commit()
+        return n
+
+    # --- GET /api/notifications ---
+
+    def test_notifications_requires_auth(self):
+        resp = self.client.get("/api/notifications")
+        assert resp.status_code == 302
+
+    def test_notifications_returns_all(self):
+        self._create_notification(self.blue_team, "Unread msg", is_read=False)
+        self._create_notification(self.blue_team, "Read msg", is_read=True)
+
+        self.login("blueuser")
+        resp = self.client.get("/api/notifications")
+        assert resp.status_code == 200
+        data = resp.json
+        assert len(data) == 2
+        # Should include is_read field
+        assert all("is_read" in n for n in data)
+
+    def test_notifications_only_own_team(self):
+        self._create_notification(self.blue_team, "Blue notification")
+        self._create_notification(self.red_team, "Red notification")
+
+        self.login("blueuser")
+        resp = self.client.get("/api/notifications")
+        data = resp.json
+        assert len(data) == 1
+        assert data[0]["message"] == "Blue notification"
+
+    def test_notifications_ordered_desc(self):
+        self._create_notification(self.blue_team, "First")
+        self._create_notification(self.blue_team, "Second")
+
+        self.login("blueuser")
+        resp = self.client.get("/api/notifications")
+        data = resp.json
+        assert data[0]["message"] == "Second"
+        assert data[1]["message"] == "First"
+
+    def test_notification_fields(self):
+        self._create_notification(self.blue_team, "Check fields", target="/overview")
+
+        self.login("blueuser")
+        resp = self.client.get("/api/notifications")
+        data = resp.json
+        assert len(data) == 1
+        n = data[0]
+        assert "id" in n
+        assert n["message"] == "Check fields"
+        assert n["target"] == "/overview"
+        assert "created" in n
+
+    # --- GET /api/notifications/read ---
+
+    def test_notifications_read_requires_auth(self):
+        resp = self.client.get("/api/notifications/read")
+        assert resp.status_code == 302
+
+    def test_notifications_read_filter(self):
+        self._create_notification(self.blue_team, "Unread", is_read=False)
+        self._create_notification(self.blue_team, "Read", is_read=True)
+
+        self.login("blueuser")
+        resp = self.client.get("/api/notifications/read")
+        data = resp.json
+        assert len(data) == 1
+        assert data[0]["message"] == "Read"
+
+    # --- GET /api/notifications/unread ---
+
+    def test_notifications_unread_requires_auth(self):
+        resp = self.client.get("/api/notifications/unread")
+        assert resp.status_code == 302
+
+    def test_notifications_unread_filter(self):
+        self._create_notification(self.blue_team, "Unread", is_read=False)
+        self._create_notification(self.blue_team, "Read", is_read=True)
+
+        self.login("blueuser")
+        resp = self.client.get("/api/notifications/unread")
+        data = resp.json
+        assert len(data) == 1
+        assert data[0]["message"] == "Unread"
+
+    def test_notifications_empty_when_none(self):
+        self.login("blueuser")
+        resp = self.client.get("/api/notifications/unread")
+        assert resp.json == []
+
+    # --- POST /api/notifications/<id>/read ---
+
+    def test_mark_read_requires_auth(self):
+        resp = self.client.post("/api/notifications/1/read")
+        assert resp.status_code == 302
+
+    def test_mark_read_success(self):
+        n = self._create_notification(self.blue_team, "To read", is_read=False)
+
+        self.login("blueuser")
+        resp = self.client.post(f"/api/notifications/{n.id}/read")
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Success"
+        db.session.refresh(n)
+        assert n.is_read is True
+
+    def test_mark_read_nonexistent(self):
+        self.login("blueuser")
+        resp = self.client.post("/api/notifications/99999/read")
+        assert resp.status_code == 403
+        assert resp.json["status"] == "Unauthorized"
+
+    def test_mark_read_other_teams_notification(self):
+        n = self._create_notification(self.red_team, "Red only")
+
+        self.login("blueuser")
+        resp = self.client.post(f"/api/notifications/{n.id}/read")
+        assert resp.status_code == 403
+        assert resp.json["status"] == "Unauthorized"
+
+    # --- POST /api/notifications/read-all ---
+
+    def test_read_all_requires_auth(self):
+        resp = self.client.post("/api/notifications/read-all")
+        assert resp.status_code == 302
+
+    def test_read_all_marks_all_unread(self):
+        self._create_notification(self.blue_team, "Msg1", is_read=False)
+        self._create_notification(self.blue_team, "Msg2", is_read=False)
+        self._create_notification(self.blue_team, "Msg3", is_read=True)
+
+        self.login("blueuser")
+        resp = self.client.post("/api/notifications/read-all")
+        assert resp.status_code == 200
+        assert resp.json["status"] == "Success"
+
+        # Verify all are now read
+        resp = self.client.get("/api/notifications/unread")
+        assert resp.json == []
+
+    def test_read_all_does_not_affect_other_teams(self):
+        self._create_notification(self.blue_team, "Blue unread", is_read=False)
+        red_n = self._create_notification(self.red_team, "Red unread", is_read=False)
+
+        self.login("blueuser")
+        self.client.post("/api/notifications/read-all")
+
+        # Red team's notification should still be unread
+        db.session.refresh(red_n)
+        assert red_n.is_read is False

--- a/tests/scoring_engine/web/views/api/test_overview_api.py
+++ b/tests/scoring_engine/web/views/api/test_overview_api.py
@@ -1,0 +1,376 @@
+"""Tests for Overview API endpoints."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.check import Check
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+from scoring_engine.web.views.api.overview import calculate_ranks
+
+
+class TestCalculateRanks:
+    def test_empty_dict_returns_empty(self):
+        assert calculate_ranks({}) == {}
+
+    def test_single_entry(self):
+        assert calculate_ranks({1: 100}) == {1: 1}
+
+    def test_distinct_scores(self):
+        result = calculate_ranks({1: 300, 2: 200, 3: 100})
+        assert result == {1: 1, 2: 2, 3: 3}
+
+    def test_tied_scores(self):
+        result = calculate_ranks({1: 200, 2: 200, 3: 100})
+        assert result == {1: 1, 2: 1, 3: 3}
+
+
+class TestOverviewAPI:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, db_session):
+        self.client = test_client
+
+        # Create teams
+        self.white_team = Team(name="White Team", color="White")
+        self.blue_team = Team(name="Blue Team", color="Blue")
+        self.blue_team2 = Team(name="Blue Team 2", color="Blue")
+        self.red_team = Team(name="Red Team", color="Red")
+        db.session.add_all([self.white_team, self.blue_team, self.blue_team2, self.red_team])
+        db.session.commit()
+
+        # Create users
+        self.white_user = User(username="whiteuser", password="testpass", team=self.white_team)
+        self.blue_user = User(username="blueuser", password="testpass", team=self.blue_team)
+        self.red_user = User(username="reduser", password="testpass", team=self.red_team)
+        db.session.add_all([self.white_user, self.blue_user, self.red_user])
+        db.session.commit()
+
+    def _login(self, username):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": "testpass"},
+            follow_redirects=True,
+        )
+
+    def _create_round_with_checks(self, round_number, services, results):
+        """Helper to create a round with checks for given services."""
+        now = datetime.now(timezone.utc)
+        round_obj = Round(
+            number=round_number,
+            round_start=now - timedelta(seconds=60),
+            round_end=now,
+        )
+        db.session.add(round_obj)
+        db.session.flush()
+        for svc, result in zip(services, results):
+            check = Check(service=svc, round=round_obj, result=result, output="", completed=True)
+            db.session.add(check)
+        db.session.commit()
+        return round_obj
+
+    # --- get_anonymize_mode (via /api/overview/get_columns endpoint) ---
+
+    def test_anonymize_disabled_returns_real_names(self):
+        """When anonymize_team_names is False, columns show real team names."""
+        resp = self.client.get("/api/overview/get_columns")
+        assert resp.status_code == 200
+        columns = resp.json["columns"]
+        team_names = [c["title"] for c in columns[1:]]
+        assert "Blue Team" in team_names
+
+    def test_anonymize_enabled_white_team_sees_both_names(self):
+        """White team sees 'RealName (Codename)' format when anonymize is enabled."""
+        setting = Setting.get_setting("anonymize_team_names")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("anonymize_team_names")
+
+        self._login("whiteuser")
+        resp = self.client.get("/api/overview/get_columns")
+        assert resp.status_code == 200
+        columns = resp.json["columns"]
+        # White team should see both names (real name with codename)
+        assert len(columns) >= 2
+        # Columns should contain team entries with show_both format
+        team_titles = [c["title"] for c in columns[1:]]
+        # At least one title should exist and be non-empty
+        assert all(len(t) > 0 for t in team_titles)
+
+    def test_anonymize_enabled_blue_team_sees_anonymous(self):
+        """Blue team sees only anonymous names when anonymize is enabled."""
+        setting = Setting.get_setting("anonymize_team_names")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("anonymize_team_names")
+
+        self._login("blueuser")
+        resp = self.client.get("/api/overview/get_columns")
+        assert resp.status_code == 200
+        columns = resp.json["columns"]
+        team_titles = [c["title"] for c in columns[1:]]
+        # Blue team should NOT see real team names
+        assert "Blue Team" not in team_titles
+        assert "Blue Team 2" not in team_titles
+
+    def test_anonymize_enabled_unauthenticated_sees_anonymous(self):
+        """Unauthenticated users see only anonymous names when anonymize is enabled."""
+        setting = Setting.get_setting("anonymize_team_names")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("anonymize_team_names")
+
+        resp = self.client.get("/api/overview/get_columns")
+        assert resp.status_code == 200
+        columns = resp.json["columns"]
+        team_titles = [c["title"] for c in columns[1:]]
+        # Should NOT see real team names
+        assert "Blue Team" not in team_titles
+        assert "Blue Team 2" not in team_titles
+
+    # --- /api/overview/get_round_data ---
+
+    def test_get_round_data_no_rounds(self):
+        resp = self.client.get("/api/overview/get_round_data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["number"] == 0
+        assert data["round_start"] == ""
+        assert "engine_paused" in data
+
+    def test_get_round_data_with_round(self):
+        now = datetime.now(timezone.utc)
+        round_obj = Round(number=3, round_start=now - timedelta(seconds=60), round_end=now)
+        db.session.add(round_obj)
+        db.session.commit()
+
+        resp = self.client.get("/api/overview/get_round_data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["number"] == 3
+        assert data["round_start"] != ""
+        assert data["engine_paused"] is False
+
+    # --- /api/overview/data ---
+
+    def test_overview_data_empty(self):
+        resp = self.client.get("/api/overview/data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert data == {}
+
+    def test_overview_data_with_services_and_checks(self):
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", port=22, team=self.blue_team)
+        svc2 = Service(name="HTTP", check_name="HTTPCheck", host="10.0.0.2", port=80, team=self.blue_team2)
+        db.session.add_all([svc1, svc2])
+        db.session.commit()
+
+        self._create_round_with_checks(1, [svc1, svc2], [True, False])
+
+        resp = self.client.get("/api/overview/data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert len(data) > 0
+
+    # --- /api/overview/get_columns ---
+
+    def test_get_columns_no_blue_teams_has_empty_header(self):
+        db.session.query(Team).filter(Team.color == "Blue").delete()
+        db.session.commit()
+
+        resp = self.client.get("/api/overview/get_columns")
+        assert resp.status_code == 200
+        columns = resp.json["columns"]
+        assert columns[0]["title"] == ""
+        assert len(columns) == 1
+
+    def test_get_columns_with_blue_teams(self):
+        resp = self.client.get("/api/overview/get_columns")
+        assert resp.status_code == 200
+        columns = resp.json["columns"]
+        # Empty header + 2 blue teams
+        assert len(columns) == 3
+        assert columns[0]["title"] == ""
+        team_names = [c["title"] for c in columns[1:]]
+        assert "Blue Team" in team_names
+        assert "Blue Team 2" in team_names
+
+    def test_get_columns_include_color(self):
+        resp = self.client.get("/api/overview/get_columns")
+        assert resp.status_code == 200
+        columns = resp.json["columns"]
+        # Each team column should have a color
+        for col in columns[1:]:
+            assert col["color"] is not None
+
+    # --- /api/overview/get_data ---
+
+    def test_get_data_no_blue_teams(self):
+        db.session.query(Team).filter(Team.color == "Blue").delete()
+        db.session.commit()
+
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        assert resp.data == b"{}"
+
+    def test_get_data_with_blue_teams_no_checks(self):
+        now = datetime.now(timezone.utc)
+        round_obj = Round(number=1, round_start=now - timedelta(seconds=60), round_end=now)
+        db.session.add(round_obj)
+        db.session.commit()
+
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        data = resp.json
+        rows = data["data"]
+        assert len(rows) >= 3
+        assert rows[0][0] == "Current Score"
+        assert rows[1][0] == "Current Place"
+        assert rows[2][0] == "Up/Down Ratio"
+
+    def test_get_data_with_checks_and_scores(self):
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", port=22, team=self.blue_team, points=100)
+        svc2 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.2", port=22, team=self.blue_team2, points=100)
+        db.session.add_all([svc1, svc2])
+        db.session.commit()
+
+        self._create_round_with_checks(1, [svc1, svc2], [True, False])
+
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        data = resp.json
+        rows = data["data"]
+
+        # Current Score row
+        scores_row = rows[0]
+        assert scores_row[0] == "Current Score"
+        assert scores_row[1] == "100"
+        assert scores_row[2] == "0"
+
+        # Current Place row
+        places_row = rows[1]
+        assert places_row[0] == "Current Place"
+        assert places_row[1] == "1"
+
+        # Up/Down Ratio row
+        ratio_row = rows[2]
+        assert ratio_row[0] == "Up/Down Ratio"
+        assert "arrow-up" in ratio_row[1]
+        assert "arrow-down" in ratio_row[2]
+
+        # Service row (SSH)
+        assert any(row[0] == "SSH" for row in rows)
+
+    def test_get_data_with_sla_enabled(self):
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", port=22, team=self.blue_team, points=100)
+        svc2 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.2", port=22, team=self.blue_team2, points=100)
+        db.session.add_all([svc1, svc2])
+        db.session.commit()
+
+        self._create_round_with_checks(1, [svc1, svc2], [True, True])
+
+        # Enable SLA
+        sla_setting = Setting.get_setting("sla_enabled")
+        sla_setting.value = True
+        db.session.commit()
+        Setting.clear_cache("sla_enabled")
+
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        data = resp.json
+        rows = data["data"]
+
+        row_labels = [row[0] for row in rows]
+        assert "Current Score" in row_labels
+        assert "Current Place" in row_labels
+        assert "SLA Penalties" in row_labels
+        assert "Up/Down Ratio" in row_labels
+
+    def test_get_data_with_sla_penalties_shown(self):
+        """Test that SLA penalties appear when a team exceeds the failure threshold."""
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", port=22, team=self.blue_team, points=100)
+        db.session.add(svc1)
+        db.session.commit()
+
+        # Create enough rounds with failures to exceed SLA threshold (default=5)
+        for i in range(1, 7):
+            self._create_round_with_checks(i, [svc1], [False])
+
+        # Enable SLA
+        sla_setting = Setting.get_setting("sla_enabled")
+        sla_setting.value = True
+        db.session.commit()
+        Setting.clear_cache("sla_enabled")
+
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        data = resp.json
+        rows = data["data"]
+
+        # Find SLA Penalties row
+        sla_rows = [row for row in rows if row[0] == "SLA Penalties"]
+        assert len(sla_rows) == 1
+        sla_row = sla_rows[0]
+        # blue_team (index 1) should have a penalty displayed
+        # Penalty is calculated from consecutive failures exceeding threshold
+        # With 6 failures and threshold of 5, there should be a penalty
+        assert len(sla_row) >= 2
+
+    def test_get_data_sla_with_scores_uses_adjusted(self):
+        """When SLA is enabled, current scores reflect penalty deductions."""
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", port=22, team=self.blue_team, points=100)
+        svc2 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.2", port=22, team=self.blue_team2, points=100)
+        db.session.add_all([svc1, svc2])
+        db.session.commit()
+
+        # Round 1: both pass
+        self._create_round_with_checks(1, [svc1, svc2], [True, True])
+
+        # Enable SLA
+        sla_setting = Setting.get_setting("sla_enabled")
+        sla_setting.value = True
+        db.session.commit()
+        Setting.clear_cache("sla_enabled")
+
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        data = resp.json
+        rows = data["data"]
+        scores_row = rows[0]
+        assert scores_row[0] == "Current Score"
+        # Both teams passed, so scores should be present
+        assert len(scores_row) == 3
+
+    def test_get_data_sla_allow_negative(self):
+        """Test SLA with allow_negative setting."""
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", port=22, team=self.blue_team, points=100)
+        db.session.add(svc1)
+        db.session.commit()
+
+        # Create rounds with failures to generate penalties
+        for i in range(1, 7):
+            self._create_round_with_checks(i, [svc1], [False])
+
+        # Enable SLA with allow_negative
+        sla_setting = Setting.get_setting("sla_enabled")
+        sla_setting.value = True
+        db.session.commit()
+        Setting.clear_cache("sla_enabled")
+
+        allow_neg = Setting.get_setting("sla_allow_negative")
+        allow_neg.value = True
+        db.session.commit()
+        Setting.clear_cache("sla_allow_negative")
+
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        data = resp.json
+        rows = data["data"]
+        assert rows[0][0] == "Current Score"
+        # With allow_negative=True and no passing checks, score could be negative
+        score_val = int(rows[0][1])
+        assert score_val <= 0

--- a/tests/scoring_engine/web/views/api/test_profile_api.py
+++ b/tests/scoring_engine/web/views/api/test_profile_api.py
@@ -1,0 +1,140 @@
+"""Tests for Profile API endpoints."""
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.user import User
+
+
+class TestProfileUpdatePassword:
+    """Tests for POST /api/profile/update_password."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.teams = three_teams
+        self.blue_user = three_teams["blue_user"]
+
+    def login(self, username):
+        self.client.post("/login", data={"username": username, "password": "testpass"}, follow_redirects=True)
+
+    def test_requires_auth(self):
+        resp = self.client.post("/api/profile/update_password")
+        assert resp.status_code == 302
+
+    def test_successful_password_update(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/profile/update_password",
+            data={
+                "user_id": str(self.blue_user.id),
+                "currentpassword": "testpass",
+                "password": "newpass123",
+                "confirmedpassword": "newpass123",
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        # After password change, verify the new password works
+        db.session.refresh(self.blue_user)
+        assert self.blue_user.check_password("newpass123")
+
+    def test_wrong_current_password(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/profile/update_password",
+            data={
+                "user_id": str(self.blue_user.id),
+                "currentpassword": "wrongpassword",
+                "password": "newpass123",
+                "confirmedpassword": "newpass123",
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        # Password should not have changed
+        db.session.refresh(self.blue_user)
+        assert self.blue_user.check_password("testpass")
+
+    def test_passwords_do_not_match(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/profile/update_password",
+            data={
+                "user_id": str(self.blue_user.id),
+                "currentpassword": "testpass",
+                "password": "newpass123",
+                "confirmedpassword": "different456",
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        # Password should not have changed
+        db.session.refresh(self.blue_user)
+        assert self.blue_user.check_password("testpass")
+
+    def test_password_too_long_for_bcrypt(self):
+        self.login("blueuser")
+        long_password = "a" * 73  # 73 bytes, exceeds 72 byte limit
+        resp = self.client.post(
+            "/api/profile/update_password",
+            data={
+                "user_id": str(self.blue_user.id),
+                "currentpassword": "testpass",
+                "password": long_password,
+                "confirmedpassword": long_password,
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        # Password should not have changed
+        db.session.refresh(self.blue_user)
+        assert self.blue_user.check_password("testpass")
+
+    def test_password_at_max_length(self):
+        self.login("blueuser")
+        max_password = "b" * 72  # Exactly 72 bytes, should be accepted
+        resp = self.client.post(
+            "/api/profile/update_password",
+            data={
+                "user_id": str(self.blue_user.id),
+                "currentpassword": "testpass",
+                "password": max_password,
+                "confirmedpassword": max_password,
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        db.session.refresh(self.blue_user)
+        assert self.blue_user.check_password(max_password)
+
+    def test_user_id_mismatch(self):
+        """Cannot update another user's password."""
+        self.login("blueuser")
+        white_user = self.teams["white_user"]
+        resp = self.client.post(
+            "/api/profile/update_password",
+            data={
+                "user_id": str(white_user.id),
+                "currentpassword": "testpass",
+                "password": "newpass123",
+                "confirmedpassword": "newpass123",
+            },
+        )
+        assert resp.status_code == 403
+        assert resp.json["status"] == "Unauthorized"
+
+    def test_missing_form_fields(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/profile/update_password",
+            data={"user_id": str(self.blue_user.id)},
+        )
+        assert resp.status_code == 403
+        assert resp.json["status"] == "Unauthorized"
+
+    def test_missing_all_fields(self):
+        self.login("blueuser")
+        resp = self.client.post("/api/profile/update_password", data={})
+        assert resp.status_code == 403
+        assert resp.json["status"] == "Unauthorized"

--- a/tests/scoring_engine/web/views/api/test_scoreboard_api.py
+++ b/tests/scoring_engine/web/views/api/test_scoreboard_api.py
@@ -1,0 +1,359 @@
+"""Tests for Scoreboard API endpoints."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.check import Check
+from scoring_engine.models.inject import Inject, InjectRubricScore, RubricItem, Template
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+
+
+class TestScoreboardAPI:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, db_session):
+        self.client = test_client
+
+        # Create teams
+        self.white_team = Team(name="White Team", color="White")
+        self.blue_team = Team(name="Blue Team", color="Blue")
+        self.blue_team2 = Team(name="Blue Team 2", color="Blue")
+        self.red_team = Team(name="Red Team", color="Red")
+        db.session.add_all([self.white_team, self.blue_team, self.blue_team2, self.red_team])
+        db.session.flush()
+
+        # Create users
+        self.white_user = User(username="whiteuser", password="testpass", team=self.white_team)
+        self.blue_user = User(username="blueuser", password="testpass", team=self.blue_team)
+        self.red_user = User(username="reduser", password="testpass", team=self.red_team)
+        db.session.add_all([self.white_user, self.blue_user, self.red_user])
+        db.session.commit()
+
+    def login(self, username, password="testpass"):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def _create_round_with_checks(self, round_number, services, results):
+        """Helper to create a round with checks for given services."""
+        now = datetime.now(timezone.utc)
+        round_obj = Round(
+            number=round_number,
+            round_start=now - timedelta(seconds=60),
+            round_end=now,
+        )
+        db.session.add(round_obj)
+        db.session.flush()
+        for svc, result in zip(services, results):
+            check = Check(service=svc, round=round_obj, result=result, output="")
+            db.session.add(check)
+        db.session.commit()
+        return round_obj
+
+    # -----------------------------------------------------------------------
+    # /api/scoreboard/get_bar_data
+    # -----------------------------------------------------------------------
+
+    def test_get_bar_data_empty(self):
+        """Bar data with no checks returns empty lists for blue teams."""
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["labels"] == ["Blue Team", "Blue Team 2"]
+        assert data["service_scores"] == ["0", "0"]
+        assert data["inject_scores"] == ["0", "0"]
+        assert data["sla_penalties"] == ["0", "0"]
+        assert data["adjusted_scores"] == ["0", "0"]
+        assert data["sla_enabled"] is False
+
+    def test_get_bar_data_with_checks(self):
+        """Bar data includes service scores from passing checks."""
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", team=self.blue_team, points=100)
+        svc2 = Service(name="HTTP", check_name="HTTPCheck", host="10.0.0.2", team=self.blue_team2, points=150)
+        db.session.add_all([svc1, svc2])
+        db.session.commit()
+
+        self._create_round_with_checks(1, [svc1, svc2], [True, True])
+        self._create_round_with_checks(2, [svc1, svc2], [True, False])
+
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = resp.json
+        # blue_team: 2 passing checks * 100 points = 200
+        # blue_team2: 1 passing check * 150 points = 150
+        assert data["service_scores"] == ["200", "150"]
+        assert data["adjusted_scores"] == ["200", "150"]
+        assert len(data["colors"]) == 2
+
+    def test_get_bar_data_with_sla_penalties(self):
+        """Bar data shows SLA penalties when SLA is enabled."""
+        svc = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", team=self.blue_team, points=100)
+        db.session.add(svc)
+        db.session.commit()
+
+        # Create enough rounds with failures to trigger SLA penalty
+        # Default threshold is 5 consecutive failures, penalty is 10%
+        for i in range(1, 8):
+            self._create_round_with_checks(i, [svc], [False])
+
+        # Enable SLA
+        setting = Setting.get_setting("sla_enabled")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("sla_enabled")
+
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["sla_enabled"] is True
+        # Service score is 0 (all checks failed), so adjusted should be 0
+        assert data["service_scores"][0] == "0"
+
+    def test_get_bar_data_with_inject_scores_visible(self):
+        """Bar data includes inject scores when inject_scores_visible is True."""
+        # Enable inject_scores_visible
+        setting = Setting.get_setting("inject_scores_visible")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("inject_scores_visible")
+
+        # Create inject data
+        now = datetime.now(timezone.utc)
+        template = Template(
+            title="Test Inject",
+            scenario="Test scenario",
+            deliverable="Test deliverable",
+            start_time=now - timedelta(hours=1),
+            end_time=now + timedelta(hours=1),
+        )
+        db.session.add(template)
+        db.session.flush()
+
+        rubric_item = RubricItem(title="Criteria 1", points=50, template=template)
+        db.session.add(rubric_item)
+        db.session.flush()
+
+        inject = Inject(team=self.blue_team, template=template)
+        inject.status = "Graded"
+        db.session.add(inject)
+        db.session.flush()
+
+        score = InjectRubricScore(score=40, inject=inject, rubric_item=rubric_item, grader=self.white_user)
+        db.session.add(score)
+        db.session.commit()
+
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = resp.json
+        # Blue Team has 40 inject points, Blue Team 2 has 0
+        assert data["inject_scores"][0] == "40"
+        assert data["inject_scores"][1] == "0"
+        assert data["adjusted_scores"][0] == "40"
+
+    def test_get_bar_data_sla_allow_negative(self):
+        """When allow_negative is True, adjusted scores can go below zero."""
+        svc = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", team=self.blue_team, points=100)
+        db.session.add(svc)
+        db.session.commit()
+
+        # 1 passing check = 100 points
+        self._create_round_with_checks(1, [svc], [True])
+        # Then many failures to accumulate large penalty
+        for i in range(2, 20):
+            self._create_round_with_checks(i, [svc], [False])
+
+        # Enable SLA with allow_negative
+        setting = Setting.get_setting("sla_enabled")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("sla_enabled")
+
+        setting = Setting.get_setting("sla_allow_negative")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("sla_allow_negative")
+
+        # Set high penalty to ensure it exceeds score
+        setting = Setting.get_setting("sla_penalty_percent")
+        setting.value = "100"
+        db.session.commit()
+        Setting.clear_cache("sla_penalty_percent")
+
+        setting = Setting.get_setting("sla_penalty_max_percent")
+        setting.value = "10000"
+        db.session.commit()
+        Setting.clear_cache("sla_penalty_max_percent")
+
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert data["sla_enabled"] is True
+        adjusted = int(data["adjusted_scores"][0])
+        # With allow_negative=True, adjusted can be negative
+        # (or at least the code path allowing negative is exercised)
+        assert isinstance(adjusted, int)
+
+    # -----------------------------------------------------------------------
+    # /api/scoreboard/get_line_data
+    # -----------------------------------------------------------------------
+
+    def test_get_line_data_empty(self):
+        """Line data with no rounds returns empty team list."""
+        resp = self.client.get("/api/scoreboard/get_line_data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert "team" in data
+        assert "rounds" in data
+        # Should have "Round 0" since last_round_num is 0
+        assert data["rounds"] == ["Round 0"]
+        # Should have entries for both blue teams
+        assert len(data["team"]) == 2
+
+    def test_get_line_data_with_rounds(self):
+        """Line data includes cumulative scores per round."""
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", team=self.blue_team, points=100)
+        svc2 = Service(name="HTTP", check_name="HTTPCheck", host="10.0.0.2", team=self.blue_team2, points=50)
+        db.session.add_all([svc1, svc2])
+        db.session.commit()
+
+        self._create_round_with_checks(1, [svc1, svc2], [True, True])
+        self._create_round_with_checks(2, [svc1, svc2], [True, False])
+        self._create_round_with_checks(3, [svc1, svc2], [False, True])
+
+        resp = self.client.get("/api/scoreboard/get_line_data")
+        assert resp.status_code == 200
+        data = resp.json
+
+        assert len(data["rounds"]) == 4  # Round 0, 1, 2, 3
+        assert data["rounds"] == ["Round 0", "Round 1", "Round 2", "Round 3"]
+
+        # Find blue_team and blue_team2 entries
+        team1_data = None
+        team2_data = None
+        for t in data["team"]:
+            if t["name"] == "Blue Team":
+                team1_data = t
+            elif t["name"] == "Blue Team 2":
+                team2_data = t
+
+        assert team1_data is not None
+        assert team2_data is not None
+
+        # Scores are cumulative over rounds with passing checks
+        # Blue Team: passed round 1 (100) and round 2 (100)
+        # Cumulative: [0, 100, 200]
+        assert team1_data["scores"] == [0, 100, 200]
+
+        # Blue Team 2: passed round 1 (50) and round 3 (50)
+        # Cumulative: [0, 50, 100]
+        assert team2_data["scores"] == [0, 50, 100]
+
+        assert "color" in team1_data
+        assert "color" in team2_data
+
+    def test_get_line_data_cumulative_scores(self):
+        """Line data scores accumulate correctly across rounds."""
+        svc = Service(name="DNS", check_name="DNSCheck", host="10.0.0.1", team=self.blue_team, points=200)
+        db.session.add(svc)
+        db.session.commit()
+
+        self._create_round_with_checks(1, [svc], [True])
+        self._create_round_with_checks(2, [svc], [True])
+
+        resp = self.client.get("/api/scoreboard/get_line_data")
+        assert resp.status_code == 200
+        data = resp.json
+
+        team_data = data["team"][0]
+        # Cumulative: [0, 200, 400]
+        assert team_data["scores"] == [0, 200, 400]
+
+    # -----------------------------------------------------------------------
+    # Anonymize mode tests
+    # -----------------------------------------------------------------------
+
+    def test_get_bar_data_anonymize_blue_team(self):
+        """Blue team sees anonymous names when anonymize is enabled."""
+        setting = Setting.get_setting("anonymize_team_names")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("anonymize_team_names")
+
+        self.login("blueuser")
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = resp.json
+        # Blue team should see anonymous names, not real names
+        for label in data["labels"]:
+            assert "Blue Team" not in label
+
+    def test_get_bar_data_anonymize_white_team(self):
+        """White team sees both real and anonymous names when anonymize is enabled."""
+        setting = Setting.get_setting("anonymize_team_names")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("anonymize_team_names")
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = resp.json
+        # White team sees both names (show_both=True)
+        # Labels should contain real team names
+        label_str = " ".join(data["labels"])
+        assert "Blue Team" in label_str
+
+    def test_get_line_data_anonymize_blue_team(self):
+        """Blue team sees anonymous names in line data when anonymize is enabled."""
+        setting = Setting.get_setting("anonymize_team_names")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("anonymize_team_names")
+
+        svc = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", team=self.blue_team, points=100)
+        db.session.add(svc)
+        db.session.commit()
+        self._create_round_with_checks(1, [svc], [True])
+
+        self.login("blueuser")
+        resp = self.client.get("/api/scoreboard/get_line_data")
+        assert resp.status_code == 200
+        data = resp.json
+        for team in data["team"]:
+            assert "Blue Team" not in team["name"]
+
+    def test_get_line_data_anonymize_white_team(self):
+        """White team sees both names in line data when anonymize is enabled."""
+        setting = Setting.get_setting("anonymize_team_names")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("anonymize_team_names")
+
+        svc = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", team=self.blue_team, points=100)
+        db.session.add(svc)
+        db.session.commit()
+        self._create_round_with_checks(1, [svc], [True])
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/scoreboard/get_line_data")
+        assert resp.status_code == 200
+        data = resp.json
+        # White team should see real names
+        names = [t["name"] for t in data["team"]]
+        name_str = " ".join(names)
+        assert "Blue Team" in name_str
+
+    def test_get_bar_data_no_anonymize(self):
+        """With anonymize disabled, real names are shown."""
+        resp = self.client.get("/api/scoreboard/get_bar_data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert "Blue Team" in data["labels"]
+        assert "Blue Team 2" in data["labels"]

--- a/tests/scoring_engine/web/views/api/test_service_api.py
+++ b/tests/scoring_engine/web/views/api/test_service_api.py
@@ -1,0 +1,451 @@
+"""Tests for Service API endpoints (update_account, update_host, update_port)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.account import Account
+from scoring_engine.models.environment import Environment
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+
+
+class TestUpdateServiceAccount:
+    """Tests for POST /api/service/update_account."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.teams = three_teams
+        self.blue_team = three_teams["blue_team"]
+        self.white_team = three_teams["white_team"]
+        self.red_team = three_teams["red_team"]
+
+        # Create a service with an account for the blue team
+        self.service = Service(
+            name="TestSSH", check_name="SSH Check", host="10.0.0.1", team=self.blue_team
+        )
+        db.session.add(self.service)
+        db.session.flush()
+        self.account = Account(username="admin", password="secret", service_id=self.service.id)
+        db.session.add(self.account)
+        db.session.commit()
+
+    def login(self, username):
+        self.client.post("/login", data={"username": username, "password": "testpass"}, follow_redirects=True)
+
+    def test_requires_auth(self):
+        resp = self.client.post("/api/service/update_account")
+        assert resp.status_code == 302
+
+    def test_red_team_denied(self):
+        self.login("reduser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": "newuser"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_blue_team_update_username(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": "newuser"},
+        )
+        assert resp.json["status"] == "Updated Account Information"
+        db.session.refresh(self.account)
+        assert self.account.username == "newuser"
+
+    def test_blue_team_update_password(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "password", "value": "newpass123"},
+        )
+        assert resp.json["status"] == "Updated Account Information"
+        db.session.refresh(self.account)
+        assert self.account.password == "newpass123"
+
+    def test_white_team_update_username(self):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": "whitechanged"},
+        )
+        assert resp.json["status"] == "Updated Account Information"
+
+    def test_blue_team_denied_when_username_update_disabled(self):
+        setting = Setting.get_setting("blue_team_update_account_usernames")
+        setting.value = False
+        db.session.commit()
+        Setting.clear_cache("blue_team_update_account_usernames")
+
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": "blocked"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_blue_team_denied_when_password_update_disabled(self):
+        setting = Setting.get_setting("blue_team_update_account_passwords")
+        setting.value = False
+        db.session.commit()
+        Setting.clear_cache("blue_team_update_account_passwords")
+
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "password", "value": "blocked"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_white_team_bypasses_disabled_settings(self):
+        """White team can update even when blue team settings are disabled."""
+        setting = Setting.get_setting("blue_team_update_account_usernames")
+        setting.value = False
+        db.session.commit()
+        Setting.clear_cache("blue_team_update_account_usernames")
+
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": "allowed"},
+        )
+        assert resp.json["status"] == "Updated Account Information"
+
+    def test_invalid_characters_rejected(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": "bad<>chars"},
+        )
+        assert "Invalid characters" in resp.json["error"]
+
+    def test_value_with_leading_space_rejected(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": " leading"},
+        )
+        assert "Invalid characters" in resp.json["error"]
+
+    def test_value_with_trailing_space_rejected(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": "trailing "},
+        )
+        assert "Invalid characters" in resp.json["error"]
+
+    def test_missing_form_fields(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_blue_team_cannot_update_other_teams_account(self):
+        """Blue team cannot modify another team's service account."""
+        other_service = Service(
+            name="OtherSSH", check_name="SSH Check", host="10.0.0.2", team=self.white_team
+        )
+        db.session.add(other_service)
+        db.session.flush()
+        other_account = Account(username="other", password="pass", service_id=other_service.id)
+        db.session.add(other_account)
+        db.session.commit()
+
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": other_account.id, "name": "username", "value": "hacked"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_nonexistent_account(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": 99999, "name": "username", "value": "noexist"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_xss_escaped_in_username(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": "user(test)"},
+        )
+        assert resp.json["status"] == "Updated Account Information"
+
+
+class TestUpdateServiceHost:
+    """Tests for POST /api/service/update_host."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.teams = three_teams
+        self.blue_team = three_teams["blue_team"]
+        self.white_team = three_teams["white_team"]
+
+        self.service = Service(
+            name="TestHTTP", check_name="HTTP Check", host="10.0.0.1", team=self.blue_team
+        )
+        db.session.add(self.service)
+        db.session.commit()
+
+    def login(self, username):
+        self.client.post("/login", data={"username": username, "password": "testpass"}, follow_redirects=True)
+
+    def test_requires_auth(self):
+        resp = self.client.post("/api/service/update_host")
+        assert resp.status_code == 302
+
+    def test_red_team_denied(self):
+        self.login("reduser")
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": self.service.id, "name": "host", "value": "10.0.0.2"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    @patch("scoring_engine.web.views.api.service.update_overview_data")
+    @patch("scoring_engine.web.views.api.service.update_services_data")
+    @patch("scoring_engine.web.views.api.service.update_service_data")
+    def test_blue_team_update_host(self, mock_svc, mock_svcs, mock_overview):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": self.service.id, "name": "host", "value": "10.0.0.2"},
+        )
+        assert resp.json["status"] == "Updated Service Information"
+        db.session.refresh(self.service)
+        assert self.service.host == "10.0.0.2"
+        mock_overview.assert_called_once()
+        mock_svcs.assert_called_once_with(self.blue_team.id)
+        mock_svc.assert_called_once_with(self.service.id)
+
+    @patch("scoring_engine.web.views.api.service.update_overview_data")
+    @patch("scoring_engine.web.views.api.service.update_services_data")
+    @patch("scoring_engine.web.views.api.service.update_service_data")
+    def test_white_team_update_host(self, mock_svc, mock_svcs, mock_overview):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": self.service.id, "name": "host", "value": "192.168.1.1"},
+        )
+        assert resp.json["status"] == "Updated Service Information"
+
+    def test_blue_team_denied_when_hostname_update_disabled(self):
+        setting = Setting.get_setting("blue_team_update_hostname")
+        setting.value = False
+        db.session.commit()
+        Setting.clear_cache("blue_team_update_hostname")
+
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": self.service.id, "name": "host", "value": "10.0.0.2"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    @patch("scoring_engine.web.views.api.service.update_overview_data")
+    @patch("scoring_engine.web.views.api.service.update_services_data")
+    @patch("scoring_engine.web.views.api.service.update_service_data")
+    def test_white_team_bypasses_disabled_hostname_setting(self, mock_svc, mock_svcs, mock_overview):
+        setting = Setting.get_setting("blue_team_update_hostname")
+        setting.value = False
+        db.session.commit()
+        Setting.clear_cache("blue_team_update_hostname")
+
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": self.service.id, "name": "host", "value": "10.0.0.99"},
+        )
+        assert resp.json["status"] == "Updated Service Information"
+
+    def test_invalid_hostname_characters_rejected(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": self.service.id, "name": "host", "value": "bad host!"},
+        )
+        assert "Invalid characters" in resp.json["error"]
+
+    def test_wrong_name_field_denied(self):
+        """Sending name != 'host' should not update."""
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": self.service.id, "name": "nothost", "value": "10.0.0.2"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_blue_team_cannot_update_other_teams_host(self):
+        other_service = Service(
+            name="OtherHTTP", check_name="HTTP Check", host="10.0.0.5", team=self.white_team
+        )
+        db.session.add(other_service)
+        db.session.commit()
+
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": other_service.id, "name": "host", "value": "10.0.0.6"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_nonexistent_service(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": 99999, "name": "host", "value": "10.0.0.2"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_missing_form_fields(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": self.service.id},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+
+class TestUpdateServicePort:
+    """Tests for POST /api/service/update_port."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.teams = three_teams
+        self.blue_team = three_teams["blue_team"]
+        self.white_team = three_teams["white_team"]
+
+        self.service = Service(
+            name="TestHTTP", check_name="HTTP Check", host="10.0.0.1", port=80, team=self.blue_team
+        )
+        db.session.add(self.service)
+        db.session.commit()
+
+    def login(self, username):
+        self.client.post("/login", data={"username": username, "password": "testpass"}, follow_redirects=True)
+
+    def test_requires_auth(self):
+        resp = self.client.post("/api/service/update_port")
+        assert resp.status_code == 302
+
+    def test_red_team_denied(self):
+        self.login("reduser")
+        resp = self.client.post(
+            "/api/service/update_port",
+            data={"pk": self.service.id, "name": "port", "value": "8080"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    @patch("scoring_engine.web.views.api.service.update_overview_data")
+    @patch("scoring_engine.web.views.api.service.update_services_data")
+    @patch("scoring_engine.web.views.api.service.update_service_data")
+    def test_blue_team_update_port(self, mock_svc, mock_svcs, mock_overview):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_port",
+            data={"pk": self.service.id, "name": "port", "value": "8080"},
+        )
+        assert resp.json["status"] == "Updated Service Information"
+        db.session.refresh(self.service)
+        assert self.service.port == 8080
+        mock_overview.assert_called_once()
+        mock_svcs.assert_called_once_with(self.blue_team.id)
+        mock_svc.assert_called_once_with(self.service.id)
+
+    @patch("scoring_engine.web.views.api.service.update_overview_data")
+    @patch("scoring_engine.web.views.api.service.update_services_data")
+    @patch("scoring_engine.web.views.api.service.update_service_data")
+    def test_white_team_update_port(self, mock_svc, mock_svcs, mock_overview):
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/service/update_port",
+            data={"pk": self.service.id, "name": "port", "value": "443"},
+        )
+        assert resp.json["status"] == "Updated Service Information"
+
+    def test_blue_team_denied_when_port_update_disabled(self):
+        setting = Setting.get_setting("blue_team_update_port")
+        setting.value = False
+        db.session.commit()
+        Setting.clear_cache("blue_team_update_port")
+
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_port",
+            data={"pk": self.service.id, "name": "port", "value": "8080"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    @patch("scoring_engine.web.views.api.service.update_overview_data")
+    @patch("scoring_engine.web.views.api.service.update_services_data")
+    @patch("scoring_engine.web.views.api.service.update_service_data")
+    def test_white_team_bypasses_disabled_port_setting(self, mock_svc, mock_svcs, mock_overview):
+        setting = Setting.get_setting("blue_team_update_port")
+        setting.value = False
+        db.session.commit()
+        Setting.clear_cache("blue_team_update_port")
+
+        self.login("whiteuser")
+        resp = self.client.post(
+            "/api/service/update_port",
+            data={"pk": self.service.id, "name": "port", "value": "9090"},
+        )
+        assert resp.json["status"] == "Updated Service Information"
+
+    def test_non_numeric_port_rejected(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_port",
+            data={"pk": self.service.id, "name": "port", "value": "abc"},
+        )
+        assert "Invalid input" in resp.json["error"] or "Port must be a number" in resp.json["error"]
+
+    def test_wrong_name_field_denied(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_port",
+            data={"pk": self.service.id, "name": "notport", "value": "8080"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_blue_team_cannot_update_other_teams_port(self):
+        other_service = Service(
+            name="OtherHTTP", check_name="HTTP Check", host="10.0.0.5", port=80, team=self.white_team
+        )
+        db.session.add(other_service)
+        db.session.commit()
+
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_port",
+            data={"pk": other_service.id, "name": "port", "value": "9999"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_nonexistent_service(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_port",
+            data={"pk": 99999, "name": "port", "value": "8080"},
+        )
+        assert resp.json["error"] == "Incorrect permissions"
+
+    def test_missing_form_fields(self):
+        self.login("blueuser")
+        resp = self.client.post(
+            "/api/service/update_port",
+            data={"pk": self.service.id},
+        )
+        assert resp.json["error"] == "Incorrect permissions"

--- a/tests/scoring_engine/web/views/api/test_sla_api.py
+++ b/tests/scoring_engine/web/views/api/test_sla_api.py
@@ -1,0 +1,496 @@
+"""Tests for SLA API endpoints."""
+
+from unittest.mock import patch
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.round import Round
+from scoring_engine.models.setting import Setting
+
+
+class TestSlaPublicAPI:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.white_team = three_teams["white_team"]
+        self.blue_team = three_teams["blue_team"]
+        self.red_team = three_teams["red_team"]
+        self.white_user = three_teams["white_user"]
+        self.blue_user = three_teams["blue_user"]
+        self.red_user = three_teams["red_user"]
+
+    def login(self, username, password="testpass"):
+        return self.client.post("/login", data={"username": username, "password": password}, follow_redirects=True)
+
+    def test_sla_summary_requires_auth(self):
+        resp = self.client.get("/api/sla/summary")
+        assert resp.status_code == 302
+
+    def test_sla_summary_returns_data(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get("/api/sla/summary")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "sla_enabled" in data
+        assert "penalty_threshold" in data
+        assert "penalty_mode" in data
+        assert "teams" in data
+
+    def test_sla_team_detail_requires_auth(self):
+        resp = self.client.get(f"/api/sla/team/{self.blue_team.id}")
+        assert resp.status_code == 302
+
+    def test_sla_team_detail_not_found(self):
+        self.login(self.white_user.username)
+        resp = self.client.get("/api/sla/team/99999")
+        assert resp.status_code == 404
+
+    def test_sla_team_detail_unauthorized_other_team(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/sla/team/{self.red_team.id}")
+        assert resp.status_code == 403
+
+    def test_sla_team_detail_own_team(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/sla/team/{self.blue_team.id}")
+        assert resp.status_code == 200
+
+    def test_sla_team_detail_white_team(self):
+        self.login(self.white_user.username)
+        resp = self.client.get(f"/api/sla/team/{self.blue_team.id}")
+        assert resp.status_code == 200
+
+    def test_sla_config_requires_auth(self):
+        resp = self.client.get("/api/sla/config")
+        assert resp.status_code == 302
+
+    def test_sla_config_requires_white_team(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get("/api/sla/config")
+        assert resp.status_code == 403
+
+    def test_sla_config_white_team_success(self):
+        self.login(self.white_user.username)
+        resp = self.client.get("/api/sla/config")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "sla_enabled" in data
+        assert "penalty_threshold" in data
+        assert "penalty_percent" in data
+        assert "penalty_max_percent" in data
+        assert "penalty_mode" in data
+        assert "allow_negative" in data
+
+    def test_dynamic_scoring_info_requires_auth(self):
+        resp = self.client.get("/api/sla/dynamic-scoring")
+        assert resp.status_code == 302
+
+    def test_dynamic_scoring_info_returns_data(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get("/api/sla/dynamic-scoring")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "current_round" in data
+        assert "current_multiplier" in data
+        assert "current_phase" in data
+
+    def test_dynamic_scoring_early_phase(self):
+        self.login(self.blue_user.username)
+        # No rounds = round 0, which is <= early_rounds, so "early"
+        resp = self.client.get("/api/sla/dynamic-scoring")
+        data = resp.get_json()
+        assert data["current_phase"] == "early"
+
+    def test_dynamic_scoring_normal_phase(self):
+        # Default early_rounds=10, late_start_round=50
+        # Create 15 rounds to be past early but before late
+        for i in range(1, 16):
+            r = Round(number=i)
+            db.session.add(r)
+        db.session.commit()
+        # Set early_rounds low so we're clearly in normal phase
+        setting = Setting.get_setting("dynamic_scoring_early_rounds")
+        setting.value = "3"
+        db.session.commit()
+        Setting.clear_cache("dynamic_scoring_early_rounds")
+        self.login(self.blue_user.username)
+        resp = self.client.get("/api/sla/dynamic-scoring")
+        data = resp.get_json()
+        assert data["current_phase"] == "normal"
+
+    def test_dynamic_scoring_late_phase(self):
+        # Create enough rounds to be in late phase
+        for i in range(1, 55):
+            r = Round(number=i)
+            db.session.add(r)
+        db.session.commit()
+        self.login(self.blue_user.username)
+        resp = self.client.get("/api/sla/dynamic-scoring")
+        data = resp.get_json()
+        assert data["current_phase"] == "late"
+
+
+class TestSlaAdminAPI:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.white_user = three_teams["white_user"]
+        self.blue_user = three_teams["blue_user"]
+
+    def login(self, username, password="testpass"):
+        return self.client.post("/login", data={"username": username, "password": password}, follow_redirects=True)
+
+    # --- SLA Enabled ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_toggle_sla_enabled_requires_white(self, mock_cache):
+        self.login(self.blue_user.username)
+        resp = self.client.post("/api/admin/update_sla_enabled")
+        assert resp.status_code == 403
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_toggle_sla_enabled_success(self, mock_cache):
+        self.login(self.white_user.username)
+        setting = Setting.get_setting("sla_enabled")
+        original = setting.value
+        resp = self.client.post("/api/admin/update_sla_enabled", follow_redirects=False)
+        assert resp.status_code == 302
+        Setting.clear_cache("sla_enabled")
+        setting = Setting.get_setting("sla_enabled")
+        assert setting.value != original
+
+    # --- Penalty Threshold ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_threshold_requires_white(self, mock_cache):
+        self.login(self.blue_user.username)
+        resp = self.client.post("/api/admin/update_sla_penalty_threshold", data={"sla_penalty_threshold": "5"})
+        assert resp.status_code == 403
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_threshold_success(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_sla_penalty_threshold",
+            data={"sla_penalty_threshold": "5"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        Setting.clear_cache("sla_penalty_threshold")
+        assert Setting.get_setting("sla_penalty_threshold").value == "5"
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_threshold_non_integer(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_sla_penalty_threshold",
+            data={"sla_penalty_threshold": "abc"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_threshold_zero(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_sla_penalty_threshold",
+            data={"sla_penalty_threshold": "0"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_threshold_missing_field(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post("/api/admin/update_sla_penalty_threshold", follow_redirects=False)
+        assert resp.status_code == 302
+
+    # --- Penalty Percent ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_percent_success(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_sla_penalty_percent",
+            data={"sla_penalty_percent": "10"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        Setting.clear_cache("sla_penalty_percent")
+        assert Setting.get_setting("sla_penalty_percent").value == "10"
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_percent_invalid(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_sla_penalty_percent",
+            data={"sla_penalty_percent": "abc"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_percent_missing(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post("/api/admin/update_sla_penalty_percent", follow_redirects=False)
+        assert resp.status_code == 302
+
+    # --- Penalty Max Percent ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_max_percent_success(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_sla_penalty_max_percent",
+            data={"sla_penalty_max_percent": "50"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        Setting.clear_cache("sla_penalty_max_percent")
+        assert Setting.get_setting("sla_penalty_max_percent").value == "50"
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_max_percent_invalid(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_sla_penalty_max_percent",
+            data={"sla_penalty_max_percent": "nope"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_max_percent_missing(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post("/api/admin/update_sla_penalty_max_percent", follow_redirects=False)
+        assert resp.status_code == 302
+
+    # --- Penalty Mode ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_mode_success(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_sla_penalty_mode",
+            data={"sla_penalty_mode": "exponential"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        Setting.clear_cache("sla_penalty_mode")
+        assert Setting.get_setting("sla_penalty_mode").value == "exponential"
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_mode_all_valid_modes(self, mock_cache):
+        self.login(self.white_user.username)
+        for mode in ["additive", "flat", "exponential", "next_check_reduction"]:
+            resp = self.client.post(
+                "/api/admin/update_sla_penalty_mode",
+                data={"sla_penalty_mode": mode},
+                follow_redirects=False,
+            )
+            assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_mode_invalid(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_sla_penalty_mode",
+            data={"sla_penalty_mode": "invalid_mode"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_penalty_mode_missing(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post("/api/admin/update_sla_penalty_mode", follow_redirects=False)
+        assert resp.status_code == 302
+
+    # --- Allow Negative ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_toggle_allow_negative_requires_white(self, mock_cache):
+        self.login(self.blue_user.username)
+        resp = self.client.post("/api/admin/update_sla_allow_negative")
+        assert resp.status_code == 403
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_toggle_allow_negative_success(self, mock_cache):
+        self.login(self.white_user.username)
+        setting = Setting.get_setting("sla_allow_negative")
+        original = setting.value
+        resp = self.client.post("/api/admin/update_sla_allow_negative", follow_redirects=False)
+        assert resp.status_code == 302
+        Setting.clear_cache("sla_allow_negative")
+        setting = Setting.get_setting("sla_allow_negative")
+        assert setting.value != original
+
+    # --- Dynamic Scoring Enabled ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_toggle_dynamic_scoring_requires_white(self, mock_cache):
+        self.login(self.blue_user.username)
+        resp = self.client.post("/api/admin/update_dynamic_scoring_enabled")
+        assert resp.status_code == 403
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_toggle_dynamic_scoring_success(self, mock_cache):
+        self.login(self.white_user.username)
+        setting = Setting.get_setting("dynamic_scoring_enabled")
+        original = setting.value
+        resp = self.client.post("/api/admin/update_dynamic_scoring_enabled", follow_redirects=False)
+        assert resp.status_code == 302
+        Setting.clear_cache("dynamic_scoring_enabled")
+        setting = Setting.get_setting("dynamic_scoring_enabled")
+        assert setting.value != original
+
+    # --- Dynamic Scoring Early Rounds ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_early_rounds_success(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_early_rounds",
+            data={"dynamic_scoring_early_rounds": "3"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        Setting.clear_cache("dynamic_scoring_early_rounds")
+        assert Setting.get_setting("dynamic_scoring_early_rounds").value == "3"
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_early_rounds_invalid(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_early_rounds",
+            data={"dynamic_scoring_early_rounds": "abc"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_early_rounds_missing(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post("/api/admin/update_dynamic_scoring_early_rounds", follow_redirects=False)
+        assert resp.status_code == 302
+
+    # --- Dynamic Scoring Early Multiplier ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_early_multiplier_success(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_early_multiplier",
+            data={"dynamic_scoring_early_multiplier": "1.5"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        Setting.clear_cache("dynamic_scoring_early_multiplier")
+        assert Setting.get_setting("dynamic_scoring_early_multiplier").value == "1.5"
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_early_multiplier_invalid(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_early_multiplier",
+            data={"dynamic_scoring_early_multiplier": "abc"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_early_multiplier_zero(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_early_multiplier",
+            data={"dynamic_scoring_early_multiplier": "0"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_early_multiplier_negative(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_early_multiplier",
+            data={"dynamic_scoring_early_multiplier": "-1"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_early_multiplier_missing(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post("/api/admin/update_dynamic_scoring_early_multiplier", follow_redirects=False)
+        assert resp.status_code == 302
+
+    # --- Dynamic Scoring Late Start Round ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_late_start_round_success(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_late_start_round",
+            data={"dynamic_scoring_late_start_round": "15"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        Setting.clear_cache("dynamic_scoring_late_start_round")
+        assert Setting.get_setting("dynamic_scoring_late_start_round").value == "15"
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_late_start_round_invalid(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_late_start_round",
+            data={"dynamic_scoring_late_start_round": "abc"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_late_start_round_missing(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post("/api/admin/update_dynamic_scoring_late_start_round", follow_redirects=False)
+        assert resp.status_code == 302
+
+    # --- Dynamic Scoring Late Multiplier ---
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_late_multiplier_success(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_late_multiplier",
+            data={"dynamic_scoring_late_multiplier": "2.0"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        Setting.clear_cache("dynamic_scoring_late_multiplier")
+        assert Setting.get_setting("dynamic_scoring_late_multiplier").value == "2.0"
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_late_multiplier_invalid(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_late_multiplier",
+            data={"dynamic_scoring_late_multiplier": "abc"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_late_multiplier_negative(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post(
+            "/api/admin/update_dynamic_scoring_late_multiplier",
+            data={"dynamic_scoring_late_multiplier": "-0.5"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+    @patch("scoring_engine.web.views.api.sla._clear_scoring_cache")
+    def test_update_late_multiplier_missing(self, mock_cache):
+        self.login(self.white_user.username)
+        resp = self.client.post("/api/admin/update_dynamic_scoring_late_multiplier", follow_redirects=False)
+        assert resp.status_code == 302

--- a/tests/scoring_engine/web/views/api/test_team_api.py
+++ b/tests/scoring_engine/web/views/api/test_team_api.py
@@ -1,0 +1,302 @@
+"""Tests for Team API endpoints."""
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.account import Account
+from scoring_engine.models.check import Check
+from scoring_engine.models.environment import Environment
+from scoring_engine.models.property import Property
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.web.views.api.team import calculate_ranks
+
+
+class TestCalculateRanks:
+    def test_normal_scores(self):
+        scores = {1: 100, 2: 90, 3: 80}
+        ranks = calculate_ranks(scores)
+        assert ranks == {1: 1, 2: 2, 3: 3}
+
+    def test_ties(self):
+        scores = {1: 100, 2: 90, 3: 90, 4: 80}
+        ranks = calculate_ranks(scores)
+        assert ranks == {1: 1, 2: 2, 3: 2, 4: 4}
+
+    def test_all_tied(self):
+        scores = {1: 50, 2: 50, 3: 50}
+        ranks = calculate_ranks(scores)
+        assert ranks == {1: 1, 2: 1, 3: 1}
+
+    def test_empty_dict(self):
+        assert calculate_ranks({}) == {}
+
+    def test_single_entry(self):
+        scores = {1: 100}
+        ranks = calculate_ranks(scores)
+        assert ranks == {1: 1}
+
+
+class TestTeamStatsAPI:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.white_team = three_teams["white_team"]
+        self.blue_team = three_teams["blue_team"]
+        self.red_team = three_teams["red_team"]
+        self.white_user = three_teams["white_user"]
+        self.blue_user = three_teams["blue_user"]
+        self.red_user = three_teams["red_user"]
+
+    def login(self, username, password="testpass"):
+        return self.client.post("/login", data={"username": username, "password": password}, follow_redirects=True)
+
+    def test_requires_auth(self):
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/stats")
+        assert resp.status_code == 302
+
+    def test_blue_team_own_stats(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/stats")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "place" in data
+        assert "current_score" in data
+
+    def test_blue_team_cannot_see_other_team(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.red_team.id}/stats")
+        assert resp.status_code == 403
+
+    def test_white_team_denied(self):
+        self.login(self.white_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/stats")
+        assert resp.status_code == 403
+
+    def test_red_team_denied(self):
+        self.login(self.red_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/stats")
+        assert resp.status_code == 403
+
+    def test_nonexistent_team(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get("/api/team/99999/stats")
+        assert resp.status_code == 403
+
+
+class TestTeamServicesAPI:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.white_team = three_teams["white_team"]
+        self.blue_team = three_teams["blue_team"]
+        self.red_team = three_teams["red_team"]
+        self.white_user = three_teams["white_user"]
+        self.blue_user = three_teams["blue_user"]
+        self.red_user = three_teams["red_user"]
+
+    def login(self, username, password="testpass"):
+        return self.client.post("/login", data={"username": username, "password": password}, follow_redirects=True)
+
+    def _create_service(self, team, name="TestSSH", host="10.0.0.1", port=22, check_name="SSHCheck"):
+        service = Service(name=name, team=team, check_name=check_name, host=host, port=port)
+        db.session.add(service)
+        db.session.flush()
+        env = Environment(service=service, matching_content=".*")
+        db.session.add(env)
+        db.session.flush()
+        prop = Property(name="username", value="root", environment=env)
+        db.session.add(prop)
+        account = Account(username="root", password="toor", service=service)
+        db.session.add(account)
+        db.session.commit()
+        return service
+
+    def test_requires_auth(self):
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services")
+        assert resp.status_code == 302
+
+    def test_blue_team_cannot_see_other_team(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.red_team.id}/services")
+        assert resp.status_code == 403
+
+    def test_empty_services(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["data"] == []
+
+    def test_service_with_no_checks(self):
+        self._create_service(self.blue_team)
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services")
+        assert resp.status_code == 200
+        data = resp.get_json()["data"]
+        assert len(data) == 1
+        assert data[0]["check"] == "Undetermined"
+        assert data[0]["service_name"] == "TestSSH"
+        assert data[0]["host"] == "10.0.0.1"
+        assert data[0]["port"] == "22"
+
+    def test_service_with_passing_check(self):
+        service = self._create_service(self.blue_team)
+        round_obj = Round(number=1)
+        db.session.add(round_obj)
+        db.session.flush()
+        check = Check(service=service, round=round_obj, result=True, output="OK")
+        db.session.add(check)
+        db.session.commit()
+
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services")
+        data = resp.get_json()["data"]
+        assert data[0]["check"] == "UP"
+
+    def test_service_with_failing_check(self):
+        service = self._create_service(self.blue_team)
+        round_obj = Round(number=1)
+        db.session.add(round_obj)
+        db.session.flush()
+        check = Check(service=service, round=round_obj, result=False, output="FAIL")
+        db.session.add(check)
+        db.session.commit()
+
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services")
+        data = resp.get_json()["data"]
+        assert data[0]["check"] == "DOWN"
+
+    def test_service_response_fields(self):
+        service = self._create_service(self.blue_team, name="SSH", host="10.0.0.5", port=2222)
+        round_obj = Round(number=1)
+        db.session.add(round_obj)
+        db.session.flush()
+        check = Check(service=service, round=round_obj, result=True, output="OK")
+        db.session.add(check)
+        db.session.commit()
+
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services")
+        data = resp.get_json()["data"][0]
+        assert data["service_id"] == str(service.id)
+        assert data["service_name"] == "SSH"
+        assert data["host"] == "10.0.0.5"
+        assert data["port"] == "2222"
+        assert "rank" in data
+        assert "score_earned" in data
+        assert "max_score" in data
+        assert "percent_earned" in data
+        assert "pts_per_check" in data
+        assert "last_ten_checks" in data
+
+    def test_multiple_services(self):
+        self._create_service(self.blue_team, name="SSH", host="10.0.0.1", port=22)
+        self._create_service(self.blue_team, name="HTTP", host="10.0.0.1", port=80, check_name="HTTPCheck")
+
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services")
+        data = resp.get_json()["data"]
+        assert len(data) == 2
+
+    def test_dynamic_scoring_enabled(self):
+        """When dynamic scoring is enabled, scores use round multipliers."""
+        setting = Setting.get_setting("dynamic_scoring_enabled")
+        setting.value = True
+        db.session.commit()
+        Setting.clear_cache("dynamic_scoring_enabled")
+
+        service = self._create_service(self.blue_team, name="SSH", host="10.0.0.1", port=22)
+        service.points = 100
+        db.session.commit()
+
+        # Create rounds in early phase (default early_multiplier=2.0, early_rounds=10)
+        for i in range(1, 4):
+            r = Round(number=i)
+            db.session.add(r)
+            db.session.flush()
+            check = Check(service=service, round=r, result=True, output="OK")
+            db.session.add(check)
+        db.session.commit()
+
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services")
+        data = resp.get_json()["data"]
+        assert len(data) == 1
+        # With 2.0 multiplier, 3 checks * 100pts * 2.0 = 600
+        assert data[0]["score_earned"] == "600"
+        assert data[0]["max_score"] == "600"
+
+
+class TestTeamServicesStatusAPI:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, three_teams):
+        self.client = test_client
+        self.blue_team = three_teams["blue_team"]
+        self.red_team = three_teams["red_team"]
+        self.blue_user = three_teams["blue_user"]
+
+    def login(self, username, password="testpass"):
+        return self.client.post("/login", data={"username": username, "password": password}, follow_redirects=True)
+
+    def test_requires_auth(self):
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services/status")
+        assert resp.status_code == 302
+
+    def test_blue_team_cannot_see_other_team(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.red_team.id}/services/status")
+        assert resp.status_code == 403
+
+    def test_no_rounds_returns_empty(self):
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services/status")
+        assert resp.status_code == 200
+
+    def test_returns_service_status(self):
+        service = Service(name="SSH", team=self.blue_team, check_name="SSHCheck", host="10.0.0.1", port=22)
+        db.session.add(service)
+        db.session.flush()
+        env = Environment(service=service, matching_content=".*")
+        db.session.add(env)
+        round_obj = Round(number=1)
+        db.session.add(round_obj)
+        db.session.flush()
+        check = Check(service=service, round=round_obj, result=True, output="OK")
+        db.session.add(check)
+        db.session.commit()
+
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services/status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "SSH" in data
+        assert data["SSH"]["result"] == "True"
+        assert data["SSH"]["check_name"] == "SSHCheck"
+        assert data["SSH"]["host"] == "10.0.0.1"
+
+    def test_returns_latest_round_only(self):
+        service = Service(name="SSH", team=self.blue_team, check_name="SSHCheck", host="10.0.0.1", port=22)
+        db.session.add(service)
+        db.session.flush()
+        env = Environment(service=service, matching_content=".*")
+        db.session.add(env)
+
+        round1 = Round(number=1)
+        round2 = Round(number=2)
+        db.session.add_all([round1, round2])
+        db.session.flush()
+
+        check1 = Check(service=service, round=round1, result=False, output="FAIL")
+        check2 = Check(service=service, round=round2, result=True, output="OK")
+        db.session.add_all([check1, check2])
+        db.session.commit()
+
+        self.login(self.blue_user.username)
+        resp = self.client.get(f"/api/team/{self.blue_team.id}/services/status")
+        data = resp.get_json()
+        # Should show round 2 (latest) result
+        assert data["SSH"]["result"] == "True"

--- a/tests/scoring_engine/web/views/test_admin.py
+++ b/tests/scoring_engine/web/views/test_admin.py
@@ -1,6 +1,9 @@
+from datetime import datetime, timezone
+
 import pytest
 
 from scoring_engine.db import db
+from scoring_engine.models.inject import Inject, Template
 from scoring_engine.models.service import Service
 from scoring_engine.models.team import Team
 from scoring_engine.models.user import User
@@ -13,6 +16,11 @@ ADMIN_PATHS = [
     "/admin/manage",
     "/admin/permissions",
     "/admin/settings",
+    "/admin/injects/templates",
+    "/admin/injects/scores",
+    "/admin/announcements",
+    "/admin/welcome",
+    "/admin/sla",
 ]
 
 
@@ -78,5 +86,63 @@ class TestAdmin:
         db.session.commit()
         self.client.post("/login", data={"username": "testuser_red", "password": "testpass_red"})
         resp = self.client.get("/admin/service/3")
+        assert resp.status_code == 302
+        assert "unauthorized" in str(resp.data)
+
+    def test_inject_detail_auth_and_access(self):
+        blue_team = Team(name="Blue Team", color="Blue")
+        db.session.add(blue_team)
+        db.session.flush()
+        template = Template(
+            title="Test",
+            scenario="Test scenario",
+            deliverable="Test deliverable",
+            start_time=datetime.now(timezone.utc),
+            end_time=datetime.now(timezone.utc),
+        )
+        db.session.add(template)
+        db.session.flush()
+        inject = Inject(team=blue_team, template=template)
+        db.session.add(inject)
+        db.session.commit()
+
+        # Requires auth
+        resp = self.client.get(f"/admin/injects/{inject.id}")
+        assert resp.status_code == 302
+        assert "/login?" in resp.location
+
+        # White team can access
+        resp = self._auth_and_get_path(f"/admin/injects/{inject.id}")
+        assert resp.status_code == 200
+
+    def test_inject_detail_unauthorized_non_white(self):
+        red_team = Team(name="Red Team", color="Red")
+        db.session.add(red_team)
+        user = User(username="testuser_red2", password="testpass_red", team=red_team)
+        db.session.add(user)
+        db.session.commit()
+        self.client.post("/login", data={"username": "testuser_red2", "password": "testpass_red"})
+        resp = self.client.get("/admin/injects/1")
+        assert resp.status_code == 302
+        assert "unauthorized" in str(resp.data)
+
+    def test_template_submissions_auth_and_access(self):
+        # Requires auth
+        resp = self.client.get("/admin/injects/template/1/submissions")
+        assert resp.status_code == 302
+        assert "/login?" in resp.location
+
+        # White team can access
+        resp = self._auth_and_get_path("/admin/injects/template/1/submissions")
+        assert resp.status_code == 200
+
+    def test_template_submissions_unauthorized_non_white(self):
+        red_team = Team(name="Red Team", color="Red")
+        db.session.add(red_team)
+        user = User(username="testuser_red3", password="testpass_red", team=red_team)
+        db.session.add(user)
+        db.session.commit()
+        self.client.post("/login", data={"username": "testuser_red3", "password": "testpass_red"})
+        resp = self.client.get("/admin/injects/template/1/submissions")
         assert resp.status_code == 302
         assert "unauthorized" in str(resp.data)


### PR DESCRIPTION
## Summary
- **Centralize image versions** in `.env.example` — Python, Redis, MariaDB, Nginx versions defined once, referenced via ARGs in Dockerfiles and `${VAR:-default}` in docker-compose.yml. Fixes mismatch where airgapped script exported `python:3.14.1` but Dockerfile used `3.14.3`, and compose used `nginx:1.23.1` but Dockerfile used `1.27.3`.
- **Add BuildKit cache mounts** (`--mount=type=cache`) for apt and pip across base, worker, and tester Dockerfiles. Rebuilds reuse cached packages instead of re-downloading.
- **Fix tester layer order** — install `requirements.txt` before copying `tests/` so changing test files doesn't invalidate the pip layer.
- **Alphabetize apt package lists**, pin engine user UID, use exec form for worker CMD, add `# syntax=docker/dockerfile:1` directive.

## Test plan
- [ ] `docker compose build` completes successfully
- [ ] `docker compose up` starts all services
- [ ] Verify `.env.example` values match Dockerfile ARG defaults
- [ ] Verify rebuild is faster on second `docker compose build` (cache mounts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)