### PR TITLE
Add Alembic migrations and enforce service input length limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ Many competitions run offline. Use `./bin/create-airgapped-package.sh`. All deps
 ## Structure
 
 ```
+alembic/                # Database migrations (Alembic)
+├── versions/           # Migration scripts
 scoring_engine/
 ├── checks/           # Service check implementations (SSH, HTTP, DNS, etc.)
 ├── engine/           # Core: engine.py, basic_check.py, job.py (Celery tasks)
@@ -47,7 +49,7 @@ scoring_engine/
 └── cache_helper.py   # Redis cache invalidation helpers
 tests/                # Mirrors main structure; plain classes + pytest fixtures
 docker/               # Container build files
-bin/                  # Entry points: setup, engine, web, worker
+bin/                  # Entry points: setup, engine, web, worker, migrate
 ```
 
 ## Team Roles
@@ -83,10 +85,49 @@ Priority: `SCORINGENGINE_*` env vars → `SCORINGENGINE_CONFIG_FILE` → `engine
 - `SCORINGENGINE_OVERWRITE_DB=true` — reset database
 - `SCORINGENGINE_EXAMPLE=true` — load example data
 
+## Database Migrations (Alembic)
+
+Schema changes use Alembic for safe, versioned migrations.
+
+```
+alembic/
+├── env.py              # Flask app context integration
+├── script.py.mako      # Migration template
+└── versions/           # Migration scripts (001_, 002_, ...)
+```
+
+**Key flows:**
+- **Fresh install** (`bin/setup`): `create_all()` builds schema, then stamps Alembic to head — no migrations run
+- **Upgrade existing DB** (`bin/migrate`): runs all pending Alembic migrations
+- **Check for pending** (`bin/migrate --check`): exits 1 if migrations are pending (useful for CI)
+
+**Creating a new migration:**
+```bash
+# Auto-generate from model changes (review the output!):
+alembic revision --autogenerate -m "description of change"
+
+# Or write manually:
+alembic revision -m "description of change"
+# Then edit alembic/versions/<rev>_description_of_change.py
+```
+
+**Migration best practices:**
+- Always provide both `upgrade()` and `downgrade()`
+- Use `batch_alter_table` for SQLite compatibility in tests
+- Test migrations against both fresh DB (stamp) and existing DB (upgrade)
+- Name files with sequential prefixes: `001_`, `002_`, etc.
+
+**Helper functions** (in `scoring_engine/db.py`):
+- `init_db()` — creates all tables + stamps Alembic head
+- `run_migrations()` — runs `alembic upgrade head`
+- `stamp_alembic_head()` — marks DB at latest revision without running migrations
+
 ## Commands
 
 ```bash
 docker compose up                              # Start all services
+python bin/migrate                             # Run pending DB migrations
+python bin/migrate --check                     # Check for pending migrations
 make run-tests                                 # Tests with coverage
 make run-integration-tests                     # Integration tests (requires testbed)
 pre-commit run --all-files                     # Lint (black, isort, flake8)

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,40 @@
+[alembic]
+# Path to migration scripts
+script_location = alembic
+
+# The DB URL is set programmatically in env.py from the app config.
+# This placeholder is never used at runtime but keeps `alembic check` happy.
+sqlalchemy.url = sqlite:///placeholder
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,63 @@
+"""Alembic environment configuration.
+
+Uses the Flask application context so migrations share the same DB URI
+and SQLAlchemy metadata as the rest of the scoring engine.
+"""
+
+import sys
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+
+# Ensure the project root is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scoring_engine.web import create_app
+from scoring_engine.db import db
+
+# Interpret the config file for Python logging.
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Import all models so metadata is fully populated
+import scoring_engine.models  # noqa: F401
+
+target_metadata = db.metadata
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode — emit SQL to stdout."""
+    from scoring_engine.config import config as app_config
+
+    context.configure(
+        url=app_config.db_uri,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations inside the Flask app context."""
+    app = create_app()
+    with app.app_context():
+        connectable = db.engine
+
+        with connectable.connect() as connection:
+            context.configure(
+                connection=connection,
+                target_metadata=target_metadata,
+            )
+            with context.begin_transaction():
+                context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/001_expand_account_username_and_service_host.py
+++ b/alembic/versions/001_expand_account_username_and_service_host.py
@@ -1,0 +1,51 @@
+"""Expand account username and service host columns to 256 chars
+
+Revision ID: 001
+Revises: None
+Create Date: 2026-03-24
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Account.username: String(50) -> String(256)
+    op.alter_column(
+        "accounts",
+        "username",
+        existing_type=sa.String(50),
+        type_=sa.String(256),
+        existing_nullable=False,
+    )
+    # Service.host: String(50) -> String(256)
+    op.alter_column(
+        "services",
+        "host",
+        existing_type=sa.String(50),
+        type_=sa.String(256),
+        existing_nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "accounts",
+        "username",
+        existing_type=sa.String(256),
+        type_=sa.String(50),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "services",
+        "host",
+        existing_type=sa.String(256),
+        type_=sa.String(50),
+        existing_nullable=False,
+    )

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""Run pending Alembic database migrations.
+
+Usage:
+    python bin/migrate            # upgrade to latest
+    python bin/migrate --check    # exit 1 if migrations are pending
+"""
+import optparse
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scoring_engine.db import db, run_migrations, verify_db_ready
+from scoring_engine.logger import logger
+from scoring_engine.web import create_app
+
+parser = optparse.OptionParser()
+parser.add_option("--check", action="store_true", default=False, help="Check for pending migrations without applying")
+options, arguments = parser.parse_args()
+
+app = create_app()
+
+with app.app_context():
+    if not verify_db_ready():
+        logger.error("Database is not accessible. Run bin/setup first for a fresh install.")
+        sys.exit(1)
+
+    if options.check:
+        from alembic.config import Config
+        from alembic import command, script
+        from alembic.runtime.migration import MigrationContext
+
+        alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "..", "alembic.ini"))
+        alembic_cfg.set_main_option("script_location", os.path.join(os.path.dirname(__file__), "..", "alembic"))
+
+        script_dir = script.ScriptDirectory.from_config(alembic_cfg)
+        head = script_dir.get_current_head()
+
+        with db.engine.connect() as conn:
+            migration_context = MigrationContext.configure(conn)
+            current = migration_context.get_current_revision()
+
+        if current == head:
+            logger.info("Database is up to date (revision: %s)", current)
+            sys.exit(0)
+        else:
+            logger.warning("Pending migrations: current=%s, head=%s", current, head)
+            sys.exit(1)
+    else:
+        logger.info("Running database migrations...")
+        run_migrations()
+        logger.info("Migrations complete.")

--- a/docker/bootstrap/Dockerfile
+++ b/docker/bootstrap/Dockerfile
@@ -2,7 +2,11 @@ ARG BASE_IMAGE=ghcr.io/scoringengine/scoringengine/base:latest
 FROM ${BASE_IMAGE}
 
 COPY bin/setup /app/bin/setup
+COPY bin/migrate /app/bin/migrate
 COPY bin/competition.yaml /app/bin/competition.yaml
+
+COPY alembic.ini /app/alembic.ini
+COPY alembic /app/alembic
 
 COPY scoring_engine /app/scoring_engine
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "python-dateutil==2.9.0.post0",
   "pytz==2026.1.post1",
   "PyYAML==6.0.3",
+  "alembic==1.16.2",
   "Werkzeug==3.1.5",
   "uWSGI==2.0.31",
   "mammoth==1.9.0",

--- a/scoring_engine/db.py
+++ b/scoring_engine/db.py
@@ -25,8 +25,37 @@ def delete_db():
 
 
 def init_db():
-    """Create all database tables"""
+    """Create all database tables and stamp Alembic to head revision."""
     db.create_all()
+    stamp_alembic_head()
+
+
+def stamp_alembic_head():
+    """Mark the database as being at the latest Alembic revision.
+
+    Called after ``create_all()`` so that fresh databases start with the
+    full migration history already applied (no need to run upgrades).
+    """
+    import os
+
+    from alembic import command
+    from alembic.config import Config
+
+    alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "..", "alembic.ini"))
+    alembic_cfg.set_main_option("script_location", os.path.join(os.path.dirname(__file__), "..", "alembic"))
+    command.stamp(alembic_cfg, "head")
+
+
+def run_migrations():
+    """Run any pending Alembic migrations to bring the schema up to date."""
+    import os
+
+    from alembic import command
+    from alembic.config import Config
+
+    alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "..", "alembic.ini"))
+    alembic_cfg.set_main_option("script_location", os.path.join(os.path.dirname(__file__), "..", "alembic"))
+    command.upgrade(alembic_cfg, "head")
 
 
 def verify_db_ready():

--- a/scoring_engine/db.py
+++ b/scoring_engine/db.py
@@ -30,32 +30,44 @@ def init_db():
     stamp_alembic_head()
 
 
+def _get_alembic_config():
+    """Return an Alembic Config if the alembic directory exists, else None."""
+    import os
+
+    from alembic.config import Config
+
+    alembic_dir = os.path.join(os.path.dirname(__file__), "..", "alembic")
+    alembic_ini = os.path.join(os.path.dirname(__file__), "..", "alembic.ini")
+    if not os.path.isdir(alembic_dir):
+        return None
+    cfg = Config(alembic_ini)
+    cfg.set_main_option("script_location", alembic_dir)
+    return cfg
+
+
 def stamp_alembic_head():
     """Mark the database as being at the latest Alembic revision.
 
     Called after ``create_all()`` so that fresh databases start with the
     full migration history already applied (no need to run upgrades).
+    Silently skips if the alembic directory is not present (e.g. test containers).
     """
-    import os
-
     from alembic import command
-    from alembic.config import Config
 
-    alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "..", "alembic.ini"))
-    alembic_cfg.set_main_option("script_location", os.path.join(os.path.dirname(__file__), "..", "alembic"))
-    command.stamp(alembic_cfg, "head")
+    cfg = _get_alembic_config()
+    if cfg is None:
+        return
+    command.stamp(cfg, "head")
 
 
 def run_migrations():
     """Run any pending Alembic migrations to bring the schema up to date."""
-    import os
-
     from alembic import command
-    from alembic.config import Config
 
-    alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "..", "alembic.ini"))
-    alembic_cfg.set_main_option("script_location", os.path.join(os.path.dirname(__file__), "..", "alembic"))
-    command.upgrade(alembic_cfg, "head")
+    cfg = _get_alembic_config()
+    if cfg is None:
+        raise RuntimeError("Alembic directory not found — cannot run migrations")
+    command.upgrade(cfg, "head")
 
 
 def verify_db_ready():

--- a/scoring_engine/models/account.py
+++ b/scoring_engine/models/account.py
@@ -7,7 +7,7 @@ from scoring_engine.models.base import Base
 class Account(Base):
     __tablename__ = "accounts"
     id = Column(Integer, primary_key=True)
-    username = Column(String(50), nullable=False)
+    username = Column(String(256), nullable=False)
     password = Column(Text, nullable=False)
     service_id = Column(Integer, ForeignKey("services.id"))
     service = relationship("Service")

--- a/scoring_engine/models/service.py
+++ b/scoring_engine/models/service.py
@@ -38,7 +38,7 @@ class Service(Base):
     accounts = relationship("Account", back_populates="service")
     points = Column(Integer, default=100)
     environments = relationship("Environment", back_populates="service")
-    host = Column(String(50), nullable=False)
+    host = Column(String(256), nullable=False)
     port = Column(Integer, default=0)
     worker_queue = Column(String(50), default="main")
 

--- a/scoring_engine/web/templates/admin/service.html
+++ b/scoring_engine/web/templates/admin/service.html
@@ -139,6 +139,7 @@ $(document).ready(function() {
             <input type="text" class="form-control editable-field"
                    data-pk="{{service.id}}" data-name="host"
                    data-url="{{url_for('api.update_host')}}"
+                   maxlength="256"
                    value="{{service.host}}">
           </div>
         </div>
@@ -170,6 +171,7 @@ $(document).ready(function() {
               <input type="text" class="form-control form-control-sm editable-field"
                      data-pk="{{account.id}}" data-name="username"
                      data-url="{{url_for('api.update_service_account_info')}}"
+                     maxlength="256"
                      value="{{account.username}}">
             </td>
             <td>
@@ -177,6 +179,7 @@ $(document).ready(function() {
                 <input type="password" class="form-control form-control-sm editable-field password-field"
                        data-pk="{{account.id}}" data-name="password"
                        data-url="{{url_for('api.update_service_account_info')}}"
+                       maxlength="256"
                        value="{{account.password}}">
                 <button class="btn btn-outline-secondary btn-sm toggle-password" type="button">
                   <i class="bi bi-eye"></i>

--- a/scoring_engine/web/templates/service.html
+++ b/scoring_engine/web/templates/service.html
@@ -40,6 +40,7 @@
           <input type="text" class="form-control form-control-sm editable-field text-center"
                  data-pk="{{service.id}}" data-name="host"
                  data-url="{{url_for('api.update_host')}}"
+                 maxlength="256"
                  value="{{service.host}}">
           {% else %}
           <div class="stat-value" style="font-size:1rem">{{service.host}}</div>
@@ -76,6 +77,7 @@
                 <input type="text" class="form-control form-control-sm editable-field"
                        data-pk="{{account.id}}" data-name="username"
                        data-url="{{url_for('api.update_service_account_info')}}"
+                       maxlength="256"
                        value="{{account.username}}">
                 {% else %}
                 <span class="form-control-plaintext">{{account.username}}</span>
@@ -87,6 +89,7 @@
                   <input type="password" class="form-control form-control-sm editable-field password-field"
                          data-pk="{{account.id}}" data-name="password"
                          data-url="{{url_for('api.update_service_account_info')}}"
+                         maxlength="256"
                          value="{{account.password}}">
                   <button class="btn btn-outline-secondary btn-sm toggle-password" type="button">
                     <i class="bi bi-eye"></i>

--- a/scoring_engine/web/views/api/service.py
+++ b/scoring_engine/web/views/api/service.py
@@ -16,6 +16,10 @@ from scoring_engine.sla import calculate_round_multiplier, calculate_sla_penalty
 
 from . import make_cache_key, mod
 
+MAX_USERNAME_LENGTH = 256
+MAX_PASSWORD_LENGTH = 256
+MAX_HOST_LENGTH = 256
+
 
 def is_valid_user_input(string, only_hostname, only_number):
     if only_hostname:
@@ -111,12 +115,19 @@ def update_service_account_info():
     if current_user.is_white_team or current_user.is_blue_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
             if is_valid_user_input(request.form["value"], False, False):
-                if request.form["name"] == "username":
+                field_name = request.form["name"]
+                value = request.form["value"]
+
+                if field_name == "username":
+                    if len(value) > MAX_USERNAME_LENGTH:
+                        return jsonify({"error": f"Username must be {MAX_USERNAME_LENGTH} characters or fewer."})
                     modify_usernames_setting = Setting.get_setting("blue_team_update_account_usernames")
                     if modify_usernames_setting.value is False and current_user.is_blue_team:
                         return jsonify({"error": "Incorrect permissions"})
 
-                elif request.form["name"] == "password":
+                elif field_name == "password":
+                    if len(value) > MAX_PASSWORD_LENGTH:
+                        return jsonify({"error": f"Password must be {MAX_PASSWORD_LENGTH} characters or fewer."})
                     modify_passwords_setting = Setting.get_setting("blue_team_update_account_passwords")
                     if modify_passwords_setting.value is False and current_user.is_blue_team:
                         return jsonify({"error": "Incorrect permissions"})
@@ -124,10 +135,10 @@ def update_service_account_info():
                 account = db.session.query(Account).get(int(request.form["pk"]))
                 if account:
                     if current_user.team == account.service.team or current_user.is_white_team:
-                        if request.form["name"] == "username":
-                            account.username = html.escape(request.form["value"])
-                        elif request.form["name"] == "password":
-                            account.password = html.escape(request.form["value"])
+                        if field_name == "username":
+                            account.username = html.escape(value)
+                        elif field_name == "password":
+                            account.password = html.escape(value)
                         db.session.add(account)
                         db.session.commit()
                         return jsonify({"status": "Updated Account Information"})
@@ -143,6 +154,8 @@ def update_host():
     if current_user.is_white_team or current_user.is_blue_team:
         if "name" in request.form and "value" in request.form and "pk" in request.form:
             if is_valid_user_input(request.form["value"], True, False):
+                if len(request.form["value"]) > MAX_HOST_LENGTH:
+                    return jsonify({"error": f"Hostname must be {MAX_HOST_LENGTH} characters or fewer."})
                 modify_hostname_setting = Setting.get_setting("blue_team_update_hostname")
                 if modify_hostname_setting.value is False and current_user.is_blue_team:
                     return jsonify({"error": "Incorrect permissions"})

--- a/tests/scoring_engine/web/views/api/test_service_input_validation.py
+++ b/tests/scoring_engine/web/views/api/test_service_input_validation.py
@@ -1,0 +1,91 @@
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.account import Account
+from scoring_engine.models.service import Service
+from scoring_engine.web.views.api.service import MAX_HOST_LENGTH, MAX_PASSWORD_LENGTH, MAX_USERNAME_LENGTH
+
+
+class TestUpdateAccountLengthValidation:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, db_session, blue_login):
+        self.client, self.teams = blue_login
+        self.service = Service(
+            name="TestSSH",
+            check_name="SSHCheck",
+            host="10.0.0.1",
+            port=22,
+            team=self.teams["blue_team"],
+        )
+        db.session.add(self.service)
+        db.session.flush()
+        self.account = Account(username="admin", password="secret", service=self.service)
+        db.session.add(self.account)
+        db.session.commit()
+
+    def test_username_at_max_length(self):
+        value = "a" * MAX_USERNAME_LENGTH
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": value},
+        )
+        assert resp.json.get("status") == "Updated Account Information"
+
+    def test_username_exceeds_max_length(self):
+        value = "a" * (MAX_USERNAME_LENGTH + 1)
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "username", "value": value},
+        )
+        assert "error" in resp.json
+        assert str(MAX_USERNAME_LENGTH) in resp.json["error"]
+
+    def test_password_at_max_length(self):
+        value = "a" * MAX_PASSWORD_LENGTH
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "password", "value": value},
+        )
+        assert resp.json.get("status") == "Updated Account Information"
+
+    def test_password_exceeds_max_length(self):
+        value = "a" * (MAX_PASSWORD_LENGTH + 1)
+        resp = self.client.post(
+            "/api/service/update_account",
+            data={"pk": self.account.id, "name": "password", "value": value},
+        )
+        assert "error" in resp.json
+        assert str(MAX_PASSWORD_LENGTH) in resp.json["error"]
+
+
+class TestUpdateHostLengthValidation:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, db_session, blue_login):
+        self.client, self.teams = blue_login
+        self.service = Service(
+            name="TestSSH",
+            check_name="SSHCheck",
+            host="10.0.0.1",
+            port=22,
+            team=self.teams["blue_team"],
+        )
+        db.session.add(self.service)
+        db.session.commit()
+
+    def test_host_at_max_length(self):
+        # Build a valid hostname at exactly MAX_HOST_LENGTH
+        value = "a" * MAX_HOST_LENGTH
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": self.service.id, "name": "host", "value": value},
+        )
+        assert resp.json.get("status") == "Updated Service Information"
+
+    def test_host_exceeds_max_length(self):
+        value = "a" * (MAX_HOST_LENGTH + 1)
+        resp = self.client.post(
+            "/api/service/update_host",
+            data={"pk": self.service.id, "name": "host", "value": value},
+        )
+        assert "error" in resp.json
+        assert str(MAX_HOST_LENGTH) in resp.json["error"]


### PR DESCRIPTION
## Summary
- Adds **Alembic** for versioned database schema migrations. Fresh installs stamp to head; existing DBs upgrade via `bin/migrate`. Includes Flask app context integration, Docker support, and CLAUDE.md docs.
- **Fixes #1165**: Expands `Account.username` and `Service.host` columns from `String(50)` to `String(256)`. Adds server-side length validation (256 chars for username/password/host) with clear error messages, and `maxlength` attributes on all frontend input fields.

## Test plan
- [x] 6 new tests for boundary and over-limit cases (username, password, host)
- [x] Full test suite passes (729 passed)
- [ ] Verify `bin/migrate` upgrades an existing v2.0.0 database
- [ ] Verify `bin/setup` stamps Alembic head on fresh install
- [ ] Manual test: enter >256 char username in UI, confirm client-side prevents it
- [ ] Manual test: POST >256 char username via API, confirm server returns error JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)