### PR TITLE
Fix relationship warning, inject cache staleness, and overview disclaimer

### DIFF
--- a/scoring_engine/cache_helper.py
+++ b/scoring_engine/cache_helper.py
@@ -38,13 +38,15 @@ def update_all_cache(app_or_ctx=None):
 
 def update_overview_data():
     from scoring_engine.web.views.api.overview import (
-        overview_get_data,
         overview_get_round_data,
         _get_overview_data_cached,
         _get_table_columns_cached,
     )
 
-    cache.delete_memoized(overview_get_data)
+    # overview_get_data uses @cache.cached with make_cache_key (per-role keys)
+    if not isinstance(cache.cache, NullCache):
+        for key in cache.cache._write_client.scan_iter(match="*/api/overview/get_data_*"):
+            cache.delete(key.decode("utf-8").removeprefix(cache.cache.key_prefix))
     cache.delete_memoized(overview_get_round_data)
     cache.delete_memoized(_get_overview_data_cached)
     cache.delete_memoized(_get_table_columns_cached)

--- a/scoring_engine/models/inject.py
+++ b/scoring_engine/models/inject.py
@@ -132,7 +132,7 @@ class InjectRubricScore(Base):
     inject = relationship("Inject", back_populates="rubric_scores")
 
     rubric_item_id = Column(Integer, ForeignKey("rubric_item.id"))
-    rubric_item = relationship("RubricItem")
+    rubric_item = relationship("RubricItem", back_populates="scores")
 
     grader_id = Column(Integer, ForeignKey("users.id"))
     grader = relationship("User")

--- a/scoring_engine/web/templates/inject.html
+++ b/scoring_engine/web/templates/inject.html
@@ -130,6 +130,9 @@
     // Load files and update every 30 seconds
     updateFiles();
     setInterval(updateFiles, 30000);
+
+    // Refresh inject detail every 30 seconds
+    setInterval(loadInjectDetail, 30000);
   });
 
   function loadInjectDetail() {

--- a/scoring_engine/web/templates/injects.html
+++ b/scoring_engine/web/templates/injects.html
@@ -140,6 +140,11 @@
             'ordering': false,
         });
 
+        // Refresh data every 30 seconds to pick up status changes
+        setInterval(function () {
+            dt.ajax.reload(null, false);
+        }, 30000);
+
         // Live countdown – redraw the Time Remaining column every second
         setInterval(function () {
             dt.rows().every(function () {

--- a/scoring_engine/web/templates/overview.html
+++ b/scoring_engine/web/templates/overview.html
@@ -36,6 +36,11 @@
         </div>
     </div>
 
+    <!-- Inject scores disclaimer -->
+    <div id="inject-scores-disclaimer" class="alert alert-info" style="display:none;">
+        <i class="bi bi-info-circle"></i> Inject scores are currently hidden. Scores shown do not include inject points.
+    </div>
+
     <!-- Service Status Matrix -->
     <h3 class="section-header">Service Status</h3>
     <div class="chart-card animate-in" style="padding:0; overflow:hidden; animation-delay:200ms;">
@@ -135,6 +140,12 @@
                         }
                     }
                 }
+            }
+
+            // Show/hide inject scores disclaimer
+            var disclaimer = document.getElementById('inject-scores-disclaimer');
+            if (disclaimer) {
+                disclaimer.style.display = json.inject_scores_hidden ? '' : 'none';
             }
 
             document.getElementById('overview-body').innerHTML = html;

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1201,6 +1201,7 @@ def admin_toggle_inject_scores_visible():
         Setting.clear_cache("inject_scores_visible")
         update_scoreboard_data()
         update_all_inject_data()
+        update_overview_data()
         return {"status": "Success"}
     else:
         return {"status": "Unauthorized"}, 403

--- a/scoring_engine/web/views/api/injects.py
+++ b/scoring_engine/web/views/api/injects.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime, timezone
 
 import pytz
-from flask import abort, g, jsonify, request, send_file
+from flask import abort, jsonify, request, send_file
 from flask_login import current_user, login_required
 from sqlalchemy.orm import joinedload
 from werkzeug.utils import secure_filename
@@ -15,6 +15,7 @@ from scoring_engine.models.inject import Inject, InjectComment, InjectFile, Temp
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
 from scoring_engine.models.user import User
+from scoring_engine.cache_helper import update_inject_comments, update_inject_data, update_inject_files
 from scoring_engine.notifications import notify_inject_comment, notify_inject_submitted
 
 from . import make_cache_key, mod
@@ -87,8 +88,8 @@ def api_injects_submit(inject_id):
     db.session.add(comment)
     db.session.commit()
 
-    cache.delete(f"/api/inject/{inject_id}/comments_{g.user.team.id}")
-    cache.delete(f"/api/inject/{inject_id}_{g.user.team.id}")
+    update_inject_data(inject_id, current_user.team.id)
+    update_inject_comments(inject_id, current_user.team.id)
     notify_inject_submitted(inject)
 
     return jsonify(data=[])
@@ -110,8 +111,8 @@ def api_injects_resubmit(inject_id):
     db.session.add(comment)
     db.session.commit()
 
-    cache.delete(f"/api/inject/{inject_id}/comments_{g.user.team.id}")
-    cache.delete(f"/api/inject/{inject_id}_{g.user.team.id}")
+    update_inject_data(inject_id, current_user.team.id)
+    update_inject_comments(inject_id, current_user.team.id)
     notify_inject_submitted(inject)
 
     return jsonify(data=[])
@@ -145,7 +146,7 @@ def api_injects_file_upload(inject_id):
         db.session.add(f)
         db.session.commit()
 
-        cache.delete(f"/api/inject/{inject_id}/files_{g.user.team.id}")
+        update_inject_files(inject_id, current_user.team.id)
 
     return jsonify({"status": "Inject Submitted Successfully"}), 200
 
@@ -180,8 +181,8 @@ def api_inject_delete_file(inject_id, file_id):
     db.session.delete(file_obj)
     db.session.commit()
 
-    cache.delete(f"/api/inject/{inject_id}/files_{g.user.team.id}")
-    cache.delete(f"/api/inject/{inject_id}_{g.user.team.id}")
+    update_inject_files(inject_id, current_user.team.id)
+    update_inject_data(inject_id, current_user.team.id)
 
     return jsonify({"status": "File deleted"}), 200
 
@@ -315,8 +316,8 @@ def api_inject_add_comment(inject_id):
     db.session.add(c)
     db.session.commit()
 
-    cache.delete(f"/api/inject/{inject_id}/comments_{g.user.team.id}")
-    cache.delete(f"/api/inject/{inject_id}_{g.user.team.id}")
+    update_inject_comments(inject_id, current_user.team.id)
+    update_inject_data(inject_id, current_user.team.id)
     notify_inject_comment(inject, current_user)
 
     return jsonify({"status": "Comment added"}), 200

--- a/scoring_engine/web/views/api/overview.py
+++ b/scoring_engine/web/views/api/overview.py
@@ -14,7 +14,7 @@ from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
 from scoring_engine.sla import apply_dynamic_scoring_to_round, calculate_team_total_penalties, get_sla_config
 
-from . import mod
+from . import make_cache_key, mod
 
 
 def get_anonymize_mode():
@@ -136,7 +136,7 @@ def overview_get_columns():
 
 
 @mod.route("/api/overview/get_data")
-@cache.memoize()
+@cache.cached(make_cache_key=make_cache_key)
 def overview_get_data():
     """Get overview table data. This endpoint returns positional data matching columns."""
     data = []
@@ -284,6 +284,11 @@ def overview_get_data():
         # Loop through dictionary to create datatables formatted list
         for k, v in service_dict.items():
             data.append([k] + v)
-        return jsonify(data=data)
+
+        result = {"data": data}
+        inject_scores_visible = Setting.get_setting("inject_scores_visible")
+        if inject_scores_visible and not inject_scores_visible.value:
+            result["inject_scores_hidden"] = True
+        return jsonify(result)
     else:
         return "{}"

--- a/tests/scoring_engine/web/views/api/test_injects_api.py
+++ b/tests/scoring_engine/web/views/api/test_injects_api.py
@@ -704,11 +704,14 @@ class TestInjectsAPI:
 
         self.login("blueuser1")
 
-        with patch("scoring_engine.web.views.api.injects.cache") as mock_cache:
+        with patch("scoring_engine.web.views.api.injects.update_inject_data") as mock_data, patch(
+            "scoring_engine.web.views.api.injects.update_inject_comments"
+        ) as mock_comments:
             resp = self.client.post(f"/api/inject/{inject.id}/submit")
 
         assert resp.status_code == 200
-        mock_cache.delete.assert_called_with(f"/api/inject/{inject.id}_{self.blue_team1.id}")
+        mock_data.assert_called_with(str(inject.id), self.blue_team1.id)
+        mock_comments.assert_called_with(str(inject.id), self.blue_team1.id)
 
     def test_inject_grade_invalidates_cache(self):
         """Test that grading an inject invalidates the cached /api/inject/<id> response"""


### PR DESCRIPTION
## Summary
- **#1166**: Add `back_populates="scores"` to `InjectRubricScore.rubric_item` relationship to fix SQLAlchemy overlapping relationship warning
- **#1170**: Show info banner on Overview page when inject scores are hidden, so teams know scores don't include inject points
- **#1171**: Replace hardcoded `cache.delete()` calls in inject submit/resubmit/upload/comment/delete endpoints with proper `cache_helper` functions (`update_inject_data`, `update_inject_comments`, `update_inject_files`) that generate correct cache keys; switch `overview_get_data` from `@cache.memoize()` to `@cache.cached(make_cache_key=...)` for per-role keys; invalidate overview cache when `inject_scores_visible` is toggled

## Test plan
- [x] All 80 inject + overview API tests pass
- [x] Toggle inject_scores_visible on/off — overview banner appears/disappears correctly
- [x] Submit an inject as blue team — status updates immediately without hard refresh
- [x] Verify no SQLAlchemy relationship warnings in logs

Closes #1166, closes #1170, closes #1171