### PR TITLE
Tune uWSGI and nginx for high-load reliability

### DIFF
--- a/docker/nginx/files/web.conf
+++ b/docker/nginx/files/web.conf
@@ -1,3 +1,9 @@
+# Keepalive connection pool to uWSGI
+upstream uwsgi_backend {
+    server web:5000;
+    keepalive 16;
+}
+
 # Redirect to https
 server {
     listen 80;
@@ -14,17 +20,24 @@ server {
   client_max_body_size 25m;
   client_body_buffer_size 1m;
 
+  # Gzip compression for API responses and static assets
+  gzip on;
+  gzip_types application/json text/css application/javascript text/plain;
+  gzip_min_length 256;
+  gzip_vary on;
+
   # Serve static files directly from /app/static
   location /static/ {
       root /usr/share/nginx/html/;
       expires 30d;
       add_header Cache-Control "public, max-age=2592000, no-transform";
+      gzip_static on;
   }
 
   # Main application proxy to Flask
   location / {
     include            uwsgi_params;
-    uwsgi_pass         web:5000;
+    uwsgi_pass         uwsgi_backend;
 
     uwsgi_buffer_size 64k;
     uwsgi_buffers 8 64k;

--- a/docker/nginx/files/web.conf
+++ b/docker/nginx/files/web.conf
@@ -12,6 +12,7 @@ server {
   ssl_certificate_key /etc/nginx/scoringengine.key;
 
   client_max_body_size 25m;
+  client_body_buffer_size 1m;
 
   # Serve static files directly from /app/static
   location /static/ {
@@ -24,11 +25,15 @@ server {
   location / {
     include            uwsgi_params;
     uwsgi_pass         web:5000;
-  
+
     uwsgi_buffer_size 64k;
     uwsgi_buffers 8 64k;
     uwsgi_busy_buffers_size 128k;
     uwsgi_max_temp_file_size 0;
+
+    uwsgi_read_timeout 60s;
+    uwsgi_send_timeout 60s;
+    uwsgi_connect_timeout 10s;
 
     proxy_redirect     off;
     proxy_set_header   Host $host;

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -11,6 +11,15 @@ USER engine
 
 COPY bin/web /app/bin/web
 
-CMD ["uwsgi", "--socket", ":5000", "--wsgi-file", "bin/web", "--master", "--processes", "4", "--threads", "2", "--stats", "0.0.0.0:9191", "--stats-http", "--buffer-size", "32768", "--post-buffering", "8192"]
+CMD ["uwsgi", "--socket", ":5000", "--wsgi-file", "bin/web", "--master", \
+     "--processes", "4", "--threads", "2", \
+     "--listen", "256", \
+     "--harakiri", "60", \
+     "--harakiri-verbose", \
+     "--ignore-sigpipe", \
+     "--ignore-write-errors", \
+     "--disable-write-exception", \
+     "--stats", "0.0.0.0:9191", "--stats-http", \
+     "--buffer-size", "32768", "--post-buffering", "8192"]
 
 EXPOSE 5000

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -19,6 +19,7 @@ CMD ["uwsgi", "--socket", ":5000", "--wsgi-file", "bin/web", "--master", \
      "--ignore-sigpipe", \
      "--ignore-write-errors", \
      "--disable-write-exception", \
+     "--thunder-lock", \
      "--stats", "0.0.0.0:9191", "--stats-http", \
      "--buffer-size", "32768", "--post-buffering", "8192"]
 


### PR DESCRIPTION
## Summary
- Increase uWSGI listen queue from 100 → 256 to handle request bursts without "listen queue full" errors
- Add `harakiri=60s` to kill stuck workers instead of permanently blocking queue slots
- Suppress broken pipe log noise (`ignore-sigpipe`, `ignore-write-errors`, `disable-write-exception`) when clients disconnect during long polls
- Add `client_body_buffer_size 1m` to nginx so inject uploads (typically <1MB) stay in memory instead of spilling to temp files
- Add `uwsgi_read_timeout`, `uwsgi_send_timeout`, `uwsgi_connect_timeout` for faster failure on stuck upstreams

## Test plan
- [x] Deploy under load and verify no "listen queue full" messages
- [x] Upload inject attachments — no "buffered to temporary file" warnings in nginx logs
- [x] Broken pipe errors no longer spam uWSGI logs when clients disconnect

Closes #1167