### PR TITLE
Allow admins to grade injects without team submission

### DIFF
--- a/scoring_engine/web/templates/admin/inject.html
+++ b/scoring_engine/web/templates/admin/inject.html
@@ -29,12 +29,17 @@
 
 {% block admincontent %}
 
-{% if inject.status in ('Submitted', 'Resubmitted') %}
+{% if inject.status in ('Draft', 'Submitted', 'Resubmitted', 'Revision Requested') %}
 <div class="chart-card mt-3">
+  {% if inject.status == 'Draft' %}
+  <div class="alert alert-info mb-3"><i class="bi bi-info-circle"></i> This inject has not been submitted by the team. You can still record a grade (e.g. for verbal presentations).</div>
+  {% endif %}
   <div id="rubric-grade-form"></div>
   <div class="d-flex gap-2">
     <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#submitGradeConfirmation">Submit Grade</button>
+    {% if inject.status in ('Submitted', 'Resubmitted') %}
     <button type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#requestRevisionModal">Request Revision</button>
+    {% endif %}
   </div>
 </div>
 {% elif inject.status == 'Graded' %}

--- a/scoring_engine/web/templates/admin/injects.html
+++ b/scoring_engine/web/templates/admin/injects.html
@@ -119,7 +119,7 @@
           } else if (data['status'] == 'Revision Requested') {
             return '<a href="/admin/injects/' + data['id'] + '"><span class="badge bg-info text-white">Revision Req.</span></a>';
           } else if (data['status'] == 'Draft') {
-            return '<span class="badge bg-secondary">Draft</span>';
+            return '<a href="/admin/injects/' + data['id'] + '"><span class="badge bg-secondary">Draft</span></a>';
           } else {
             return '<span class="badge bg-secondary">' + (data['status'] || 'Not Submitted') + '</span>';
           }

--- a/scoring_engine/web/templates/admin/injects.html
+++ b/scoring_engine/web/templates/admin/injects.html
@@ -127,33 +127,39 @@
       },
       {% endfor %}
       ],
-      "initComplete": function () {
-        // Compute summary stats from the loaded data
-        var tableData = dt.data();
-        var needsGrading = 0, graded = 0, revision = 0, notSubmitted = 0;
-        var teamNames = [{% for team in blue_teams %}"{{ team.name }}",{% endfor %}];
-        tableData.each(function (row) {
-          teamNames.forEach(function (team) {
-            var cell = row[team];
-            if (cell == null || cell['status'] == null) {
-              notSubmitted++;
-            } else if (cell['status'] == 'Submitted' || cell['status'] == 'Resubmitted') {
-              needsGrading++;
-            } else if (cell['status'] == 'Graded') {
-              graded++;
-            } else if (cell['status'] == 'Revision Requested') {
-              revision++;
-            } else {
-              notSubmitted++;
-            }
-          });
-        });
-        $('#stat-needs-grading').text(needsGrading);
-        $('#stat-graded').text(graded);
-        $('#stat-revision').text(revision);
-        $('#stat-not-submitted').text(notSubmitted);
-      }
+      "initComplete": function () { updateStats(); }
     });
+
+    function updateStats() {
+      var tableData = dt.data();
+      var needsGrading = 0, graded = 0, revision = 0, notSubmitted = 0;
+      var teamNames = [{% for team in blue_teams %}"{{ team.name }}",{% endfor %}];
+      tableData.each(function (row) {
+        teamNames.forEach(function (team) {
+          var cell = row[team];
+          if (cell == null || cell['status'] == null) {
+            notSubmitted++;
+          } else if (cell['status'] == 'Submitted' || cell['status'] == 'Resubmitted') {
+            needsGrading++;
+          } else if (cell['status'] == 'Graded') {
+            graded++;
+          } else if (cell['status'] == 'Revision Requested') {
+            revision++;
+          } else {
+            notSubmitted++;
+          }
+        });
+      });
+      $('#stat-needs-grading').text(needsGrading);
+      $('#stat-graded').text(graded);
+      $('#stat-revision').text(revision);
+      $('#stat-not-submitted').text(notSubmitted);
+    }
+
+    // Refresh data every 30 seconds
+    setInterval(function () {
+      dt.ajax.reload(function () { updateStats(); }, false);
+    }, 30000);
 
     // Live countdown – redraw the Time Left column every second
     setInterval(function () {


### PR DESCRIPTION
## Summary
- Show rubric grading form for Draft and Revision Requested injects, not just Submitted/Resubmitted
- Supports scenarios like verbal presentations where white team records scores directly
- Draft injects show an info banner: "This inject has not been submitted by the team. You can still record a grade (e.g. for verbal presentations)."
- Draft badges in the admin injects list are now clickable links to the grading page
- Request Revision button only shown for Submitted/Resubmitted (makes no sense for Draft)

## Test plan
- [x] 87 inject-related tests pass
- [x] Login as admin, navigate to a Draft inject, verify grading form appears with info banner
- [x] Submit a grade on a Draft inject — status changes to Graded, score recorded
- [x] Verify Draft badges in admin injects list are clickable

Closes #1169