### PR TITLE
Fix apt lock contention in multi-platform Docker builds

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -3,8 +3,8 @@
 ARG PYTHON_VERSION=3.14.3-slim-bookworm
 FROM python:${PYTHON_VERSION} AS builder
 
-RUN --mount=type=cache,id=apt-cache-builder,target=/var/cache/apt \
-    --mount=type=cache,id=apt-lists-builder,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=apt-cache-builder,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-builder,target=/var/lib/apt/lists,sharing=locked \
     set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
@@ -31,8 +31,8 @@ print(' '.join(d['project']['dependencies']))")
 ARG PYTHON_VERSION=3.14.3-slim-bookworm
 FROM python:${PYTHON_VERSION}
 
-RUN --mount=type=cache,id=apt-cache-runtime,target=/var/cache/apt \
-    --mount=type=cache,id=apt-lists-runtime,target=/var/lib/apt/lists \
+RUN --mount=type=cache,id=apt-cache-runtime,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-runtime,target=/var/lib/apt/lists,sharing=locked \
     set -eux; \
     useradd -m -u 1000 engine; \
     apt-get update; \


### PR DESCRIPTION
## Summary
Add `sharing=locked` to all 4 apt cache mounts in the base Dockerfile. When building for amd64 and arm64 in parallel, BuildKit's default `sharing=shared` mode causes both platforms to fight over `/var/lib/apt/lists/lock`, resulting in `Could not get lock` failures.

The `sharing=locked` mode serializes access — one platform finishes its apt operations before the other starts. This is slightly slower than parallel but actually works.

## Test plan
- [x] CI multi-platform build passes without apt lock errors

Fixes the build failure at https://github.com/scoringengine/scoringengine/actions/runs/23803997406