### PR TITLE
Fix apt lock contention in worker Dockerfile

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -6,8 +6,8 @@ USER root
 
 # Install system dependencies in a single layer to reduce image size
 # This consolidates all apt-get operations to minimize layers
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     curl \
@@ -27,8 +27,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
 # Install Microsoft SQL Server tools and freerdp in single layer
 # freerdp2-x11 was renamed to freerdp3-x11 on newer distributions
 # Some distributions ship only a generic "freerdp" package
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt/lists \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     curl -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb && \
     dpkg -i /tmp/packages-microsoft-prod.deb && \
     rm /tmp/packages-microsoft-prod.deb && \


### PR DESCRIPTION
## Summary
Same fix as #1190 but for the worker Dockerfile. Add `sharing=locked` to all 4 apt cache mounts so multi-platform builds (amd64/arm64) serialize access instead of racing for `/var/lib/apt/lists/lock`.

This was the cause of the latest CI failure: https://github.com/scoringengine/scoringengine/actions/runs/23825093742

## Test plan
- [ ] CI multi-platform build passes