### PR TITLE
Add admin check navigation and sidebar search filter

### DIFF
--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -59,7 +59,7 @@
             {% for service in team.services %}
             <a href="/admin/service/{{service.id}}"
               class="sidebar-link sub {% if service and request.path == '/admin/service/{0}'.format(service.id) %}active{% endif %}">
-              <i class="bi bi-chevron-right"></i> {{service.name}}</a>
+              <i class="bi bi-dash"></i> {{service.name}}</a>
             {% endfor %}
           </div>
           {% endfor %}

--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -48,8 +48,10 @@
 
         <div class="sidebar-section">
           <div class="sidebar-section-title">Services</div>
+          <input type="text" id="service-search" class="form-control form-control-sm"
+                 placeholder="Filter services..." style="margin: 0.25rem 0.5rem; width: calc(100% - 1rem);">
           {% for team in blue_teams %}
-          <a href="#" class="sidebar-link" data-bs-toggle="collapse" data-bs-target="#services_team{{team.id}}">
+          <a href="#" class="sidebar-link sidebar-team-link" data-bs-toggle="collapse" data-bs-target="#services_team{{team.id}}">
             <i class="bi bi-chevron-right"></i> {{team.name}}</a>
           <div id="services_team{{team.id}}"
             class="collapse {% if service and team.id == service.team.id %}show{% endif %}">
@@ -117,6 +119,45 @@
       type: 'POST',
       success: function (data) {
         getEngineStatus();
+      }
+    });
+  });
+
+  // Sidebar service search/filter
+  $('#service-search').on('input', function() {
+    var query = $(this).val().toLowerCase().trim();
+    if (!query) {
+      // Reset: show all teams/services, collapse all
+      $('.sidebar-team-link').show();
+      $('.sidebar-link.sub').show();
+      $('.sidebar-team-link').each(function() {
+        var target = $(this).data('bs-target');
+        $(target).removeClass('show');
+      });
+      return;
+    }
+    $('.sidebar-team-link').each(function() {
+      var $teamLink = $(this);
+      var teamName = $teamLink.text().trim().toLowerCase();
+      var target = $teamLink.data('bs-target');
+      var $collapse = $(target);
+      var $services = $collapse.find('.sidebar-link.sub');
+      var teamMatch = teamName.indexOf(query) !== -1;
+      var anyServiceMatch = false;
+
+      $services.each(function() {
+        var serviceName = $(this).text().trim().toLowerCase();
+        var match = teamMatch || serviceName.indexOf(query) !== -1;
+        $(this).toggle(match);
+        if (match) anyServiceMatch = true;
+      });
+
+      var showTeam = teamMatch || anyServiceMatch;
+      $teamLink.toggle(showTeam);
+      if (showTeam) {
+        $collapse.addClass('show');
+      } else {
+        $collapse.removeClass('show');
       }
     });
   });

--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -50,6 +50,7 @@
           <div class="sidebar-section-title">Services</div>
           <input type="text" id="service-search" class="form-control form-control-sm"
                  placeholder="Filter services..." style="margin: 0.25rem 0.5rem; width: calc(100% - 1rem);">
+          <div id="service-list" style="max-height: 60vh; overflow-y: auto;">
           {% for team in blue_teams %}
           <a href="#" class="sidebar-link sidebar-team-link" data-bs-toggle="collapse" data-bs-target="#services_team{{team.id}}">
             <i class="bi bi-chevron-right"></i> {{team.name}}</a>
@@ -62,6 +63,7 @@
             {% endfor %}
           </div>
           {% endfor %}
+          </div>
         </div>
       </nav>
     </div>

--- a/scoring_engine/web/templates/admin/service.html
+++ b/scoring_engine/web/templates/admin/service.html
@@ -529,6 +529,42 @@ $(document).ready(function() {
         $('#' + id + ' td.details-control').trigger('click');
       });
     });
+
+    // Deep-link: scroll to and expand a specific check via URL hash (#check-<id>)
+    function handleCheckHash() {
+      var hash = window.location.hash;
+      var match = hash.match(/^#check-(\d+)$/);
+      if (!match) return;
+      var checkId = parseInt(match[1]);
+
+      // Find the row with this check ID in the DataTable
+      dt.rows().every(function() {
+        var rowData = this.data();
+        if (rowData && rowData.id === checkId) {
+          // Navigate to the page containing this row
+          var pageInfo = dt.page.info();
+          var rowIndex = this.index();
+          var allIndexes = dt.rows({ order: 'applied' }).indexes().toArray();
+          var sortedPosition = allIndexes.indexOf(rowIndex);
+          var targetPage = Math.floor(sortedPosition / pageInfo.length);
+          if (targetPage !== pageInfo.page) {
+            dt.page(targetPage).draw(false);
+          }
+          // Expand and scroll to the row
+          var $tr = $(this.node());
+          $tr.find('td.details-control').trigger('click');
+          $tr.addClass('table-warning');
+          setTimeout(function() {
+            $tr[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }, 100);
+        }
+      });
+    }
+
+    // Run after initial data load
+    dt.on('init', function() {
+      handleCheckHash();
+    });
   });
 </script>
 {% endblock %}

--- a/scoring_engine/web/templates/overview.html
+++ b/scoring_engine/web/templates/overview.html
@@ -58,6 +58,7 @@
 <script>
     var _upCount = 0, _downCount = 0;
     var _columns = [];
+    var _serviceIds = null; // populated for white team
 
     function refreshRound() {
         $.getJSON('/api/overview/get_round_data').done(function(data) {
@@ -77,7 +78,7 @@
         });
     }
 
-    function renderCell(value, rowLabel, colIndex) {
+    function renderCell(value, rowLabel, colIndex, serviceRowIndex) {
         if (colIndex === 0) {
             return '<td><span class="fw-bold">' + value + '</span></td>';
         }
@@ -109,7 +110,17 @@
         } else {
             icon = 'bi-question-circle'; cls = 'text-secondary';
         }
-        return '<td><i class="bi ' + icon + ' ' + cls + '"></i></td>';
+        var cellHtml = '<i class="bi ' + icon + ' ' + cls + '"></i>';
+
+        // Admin link: wrap status icon in a link to the admin service page
+        if (_serviceIds && serviceRowIndex !== null && _serviceIds[serviceRowIndex]) {
+            var sid = _serviceIds[serviceRowIndex][colIndex - 1];
+            if (sid) {
+                cellHtml = '<a href="/admin/service/' + sid + '" title="Admin: ' + rowLabel + '">' + cellHtml + '</a>';
+            }
+        }
+
+        return '<td>' + cellHtml + '</td>';
     }
 
     function loadData() {
@@ -118,16 +129,22 @@
             _downCount = 0;
             var leaderName = '-', leaderScore = -Infinity, leaderColor = '';
             var rows = json.data || [];
+            _serviceIds = json.service_ids || null;
             var html = '';
+            var metaRows = ['Current Score', 'Current Place', 'SLA Penalties', 'Up/Down Ratio'];
+            var serviceRowIndex = 0;
 
             for (var r = 0; r < rows.length; r++) {
                 var row = rows[r];
                 var rowLabel = row[0];
+                var isServiceRow = metaRows.indexOf(rowLabel) === -1;
+                var sIdx = isServiceRow ? serviceRowIndex : null;
                 html += '<tr>';
                 for (var c = 0; c < row.length; c++) {
-                    html += renderCell(row[c], rowLabel, c);
+                    html += renderCell(row[c], rowLabel, c, sIdx);
                 }
                 html += '</tr>';
+                if (isServiceRow) serviceRowIndex++;
 
                 // Find leader from Current Score row
                 if (rowLabel === 'Current Score') {

--- a/scoring_engine/web/views/admin.py
+++ b/scoring_engine/web/views/admin.py
@@ -4,6 +4,7 @@ from flask import Blueprint, redirect, render_template, url_for
 from flask_login import current_user, login_required
 
 from scoring_engine.db import db
+from scoring_engine.models.check import Check
 from scoring_engine.models.inject import Inject
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
@@ -97,6 +98,18 @@ def inject_inject(inject_id):
 def template_submissions(template_id):
     if current_user.is_white_team:
         return render_template("admin/template_submissions.html", template_id=template_id)
+    else:
+        return redirect(url_for("auth.unauthorized"))
+
+
+@mod.route("/admin/check/<int:check_id>")
+@login_required
+def check_redirect(check_id):
+    if current_user.is_white_team:
+        check = db.session.get(Check, check_id)
+        if check is None:
+            return redirect(url_for("admin.status"))
+        return redirect(url_for("admin.service", id=check.service_id) + f"#check-{check_id}")
     else:
         return redirect(url_for("auth.unauthorized"))
 

--- a/scoring_engine/web/views/api/overview.py
+++ b/scoring_engine/web/views/api/overview.py
@@ -268,7 +268,7 @@ def overview_get_data():
         data.append(service_ratios)
 
         checks = (
-            db.session.query(Service.name, Check.result)
+            db.session.query(Service.id, Service.name, Check.result)
             .join(Service)
             .join(Round)
             .filter(Round.number == last_round)
@@ -277,15 +277,25 @@ def overview_get_data():
         )
 
         service_dict = defaultdict(list)
+        service_ids_dict = defaultdict(list)
 
-        for service, status in checks:
-            service_dict[service].append(status)
+        for service_id, service_name, status in checks:
+            service_dict[service_name].append(status)
+            service_ids_dict[service_name].append(service_id)
+
+        # Include service IDs for white team admin links
+        is_admin = current_user.is_authenticated and current_user.is_white_team
+        service_ids = [] if is_admin else None
 
         # Loop through dictionary to create datatables formatted list
         for k, v in service_dict.items():
             data.append([k] + v)
+            if is_admin:
+                service_ids.append(service_ids_dict[k])
 
         result = {"data": data}
+        if service_ids is not None:
+            result["service_ids"] = service_ids
         inject_scores_visible = Setting.get_setting("inject_scores_visible")
         if inject_scores_visible and not inject_scores_visible.value:
             result["inject_scores_hidden"] = True

--- a/tests/scoring_engine/web/views/api/test_overview_api.py
+++ b/tests/scoring_engine/web/views/api/test_overview_api.py
@@ -374,3 +374,49 @@ class TestOverviewAPI:
         # With allow_negative=True and no passing checks, score could be negative
         score_val = int(rows[0][1])
         assert score_val <= 0
+
+    def test_get_data_white_team_includes_service_ids(self):
+        """White team gets service_ids in the overview response for admin links."""
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", port=22, team=self.blue_team, points=100)
+        svc2 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.2", port=22, team=self.blue_team2, points=100)
+        db.session.add_all([svc1, svc2])
+        db.session.commit()
+
+        self._create_round_with_checks(1, [svc1, svc2], [True, False])
+
+        self._login("whiteuser")
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert "service_ids" in data
+        assert len(data["service_ids"]) > 0
+        # Each entry should be a list of service IDs matching the blue teams
+        assert svc1.id in data["service_ids"][0]
+        assert svc2.id in data["service_ids"][0]
+
+    def test_get_data_non_white_team_no_service_ids(self):
+        """Non-white team users should not get service_ids."""
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", port=22, team=self.blue_team, points=100)
+        db.session.add(svc1)
+        db.session.commit()
+
+        self._create_round_with_checks(1, [svc1], [True])
+
+        self._login("blueuser")
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert "service_ids" not in data
+
+    def test_get_data_anonymous_no_service_ids(self):
+        """Anonymous users should not get service_ids."""
+        svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", port=22, team=self.blue_team, points=100)
+        db.session.add(svc1)
+        db.session.commit()
+
+        self._create_round_with_checks(1, [svc1], [True])
+
+        resp = self.client.get("/api/overview/get_data")
+        assert resp.status_code == 200
+        data = resp.json
+        assert "service_ids" not in data

--- a/tests/scoring_engine/web/views/test_admin.py
+++ b/tests/scoring_engine/web/views/test_admin.py
@@ -1,9 +1,11 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from scoring_engine.db import db
+from scoring_engine.models.check import Check
 from scoring_engine.models.inject import Inject, Template
+from scoring_engine.models.round import Round
 from scoring_engine.models.service import Service
 from scoring_engine.models.team import Team
 from scoring_engine.models.user import User
@@ -144,5 +146,62 @@ class TestAdmin:
         db.session.commit()
         self.client.post("/login", data={"username": "testuser_red3", "password": "testpass_red"})
         resp = self.client.get("/admin/injects/template/1/submissions")
+        assert resp.status_code == 302
+        assert "unauthorized" in str(resp.data)
+
+
+class TestAdminCheckRedirect:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, db_session):
+        self.client = test_client
+        self.white_team = Team(name="White Team", color="White")
+        self.blue_team = Team(name="Blue Team", color="Blue")
+        db.session.add_all([self.white_team, self.blue_team])
+        db.session.commit()
+
+        self.white_user = User(username="whiteuser", password="testpass", team=self.white_team)
+        db.session.add(self.white_user)
+
+        self.service = Service(name="SSH", check_name="SSH Check", host="10.0.0.1", team=self.blue_team)
+        db.session.add(self.service)
+        db.session.commit()
+
+        now = datetime.now(timezone.utc)
+        self.round = Round(number=1, round_start=now - timedelta(seconds=60), round_end=now)
+        db.session.add(self.round)
+        db.session.flush()
+
+        self.check = Check(service=self.service, round=self.round, result=True, output="ok", completed=True)
+        db.session.add(self.check)
+        db.session.commit()
+
+    def _login_white(self):
+        self.client.post("/login", data={"username": "whiteuser", "password": "testpass"})
+
+    def test_check_redirect_requires_auth(self):
+        resp = self.client.get(f"/admin/check/{self.check.id}")
+        assert resp.status_code == 302
+        assert "/login?" in resp.location
+
+    def test_check_redirect_white_team(self):
+        self._login_white()
+        resp = self.client.get(f"/admin/check/{self.check.id}")
+        assert resp.status_code == 302
+        assert f"/admin/service/{self.service.id}#check-{self.check.id}" in resp.location
+
+    def test_check_redirect_nonexistent(self):
+        self._login_white()
+        resp = self.client.get("/admin/check/99999")
+        assert resp.status_code == 302
+        assert "/admin" in resp.location
+
+    def test_check_redirect_unauthorized_non_white(self):
+        red_team = Team(name="Red Team", color="Red")
+        db.session.add(red_team)
+        red_user = User(username="reduser", password="testpass", team=red_team)
+        db.session.add(red_user)
+        db.session.commit()
+        self.client.post("/login", data={"username": "reduser", "password": "testpass"})
+        resp = self.client.get(f"/admin/check/{self.check.id}")
         assert resp.status_code == 302
         assert "unauthorized" in str(resp.data)


### PR DESCRIPTION
## Summary

Closes #1168

- **Sidebar search filter**: Adds a text input at the top of the admin sidebar Services section that filters teams and services as you type, making it easy to find specific services in competitions with 40+ teams or 60+ services per team
- **Check deep-link route**: New `/admin/check/<id>` endpoint redirects white team users to the service page with a `#check-<id>` hash, which auto-scrolls and highlights the specific check row
- **Overview admin links**: Status icons on the overview page become clickable links to admin service pages for white team users (via `service_ids` in the API response, scoped to white team cache keys only)

## Test plan

- [ ] Verify sidebar filter works: type a team name or service name and confirm the list narrows correctly
- [ ] Verify `/admin/check/<id>` redirects to the correct service page with hash
- [ ] Verify overview status icons link to admin service pages when logged in as white team
- [ ] Verify overview works normally for non-admin users (no links, no service_ids in API)
- [ ] Run `pytest tests/scoring_engine/web/views/test_admin.py tests/scoring_engine/web/views/api/test_overview_api.py` (59 tests pass)