### PR TITLE
Add inject category field (Business/Technical/Incident Response)

### DIFF
--- a/alembic/versions/002_add_template_category.py
+++ b/alembic/versions/002_add_template_category.py
@@ -1,0 +1,26 @@
+"""Add category column to template table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-04-01
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "002"
+down_revision = "001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("template") as batch_op:
+        batch_op.add_column(sa.Column("category", sa.String(50), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("template") as batch_op:
+        batch_op.drop_column("category")

--- a/bin/setup
+++ b/bin/setup
@@ -243,13 +243,15 @@ with app.app_context():
         # Simulate Injects
         num_injects = randint(5, 15)
         logger.info("Simulating " + str(num_injects) + " Injects")
-        for _ in range(num_injects):
+        inject_categories = ["Business", "Technical", "Incident Response"]
+        for i in range(num_injects):
             template = Template(
                 title="Journey to Mordor",
                 scenario="You have the ring, take it to be destroyed!",
                 deliverable="Word document in at least 3 volumes with journalistic evidence of each step of your journey and the destruction of the ring.",
                 start_time=datetime.now() - timedelta(hours=randint(0, 24), minutes=randint(0, 60)),
                 end_time=datetime.now() + timedelta(hours=randint(0, 24), minutes=randint(0, 60)),
+                category=inject_categories[i % len(inject_categories)],
             )
             db.session.add(template)
             db.session.flush()

--- a/scoring_engine/models/inject.py
+++ b/scoring_engine/models/inject.py
@@ -19,12 +19,16 @@ def _ensure_utc_aware(dt):
 
 
 
+INJECT_CATEGORIES = ["Business", "Technical", "Incident Response"]
+
+
 class Template(Base):
     __tablename__ = "template"
     id = Column(Integer, primary_key=True)
     title = Column(Unicode(255), nullable=False)
     scenario = Column(UnicodeText, nullable=False)
     deliverable = Column(UnicodeText, nullable=False)
+    category = Column(String(50), nullable=True)
     start_time = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     end_time = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     enabled = Column(Boolean, nullable=False, default=True)
@@ -35,13 +39,14 @@ class Template(Base):
         "RubricItem", back_populates="template", cascade="all, delete", lazy="joined", order_by="RubricItem.order"
     )
 
-    def __init__(self, title, scenario, deliverable, start_time, end_time, enabled=True):
+    def __init__(self, title, scenario, deliverable, start_time, end_time, enabled=True, category=None):
         self.title = title
         self.scenario = scenario
         self.deliverable = deliverable
         self.start_time = start_time
         self.end_time = end_time
         self.enabled = enabled
+        self.category = category
 
     @property
     def max_score(self):

--- a/scoring_engine/web/templates/admin/templates.html
+++ b/scoring_engine/web/templates/admin/templates.html
@@ -65,6 +65,15 @@
             <input type="text" class="form-control" id="inputTitle" placeholder="Journey to Mordor">
           </div>
           <div class="mb-3">
+            <label for="inputCategory" class="form-label">Category</label>
+            <select class="form-select" id="inputCategory">
+              <option value="">— None —</option>
+              <option value="Business">Business</option>
+              <option value="Technical">Technical</option>
+              <option value="Incident Response">Incident Response</option>
+            </select>
+          </div>
+          <div class="mb-3">
             <label for="inputScenario" class="form-label">Scenario</label>
             <textarea class="form-control" id="inputScenario" rows="3"
               placeholder="Supports Markdown formatting"></textarea>
@@ -169,6 +178,15 @@
           <div class="mb-3">
             <label for="inputUpdateTitle" class="form-label">Title</label>
             <input type="text" class="form-control" id="inputUpdateTitle" placeholder="Journey to Mordor">
+          </div>
+          <div class="mb-3">
+            <label for="inputUpdateCategory" class="form-label">Category</label>
+            <select class="form-select" id="inputUpdateCategory">
+              <option value="">— None —</option>
+              <option value="Business">Business</option>
+              <option value="Technical">Technical</option>
+              <option value="Incident Response">Incident Response</option>
+            </select>
           </div>
           <div class="mb-3">
             <label for="inputUpdateScenario" class="form-label">Scenario</label>
@@ -444,6 +462,7 @@
         .done(function (data) {
           $('#updateTemplateId').val(data['id']);
           $('#inputUpdateTitle').val(data['title']);
+          $('#inputUpdateCategory').val(data['category'] || '');
           $('#inputUpdateScenario').val(data['scenario']);
           $('#inputUpdateDeliverable').val(data['deliverable']);
           $('#inputUpdateStartTime').val(isoToDatetimeLocal(data['start_time']));
@@ -555,6 +574,7 @@
       var templateData = {};
 
       templateData['title'] = $('#inputTitle').val();
+      templateData['category'] = $('#inputCategory').val() || null;
       templateData['scenario'] = $('#inputScenario').val();
       templateData['deliverable'] = $('#inputDeliverable').val();
       templateData['start_time'] = datetimeLocalToISO($('#inputStartTime').val());
@@ -614,6 +634,7 @@
       const templateId = $('#updateTemplateId').val();
 
       templateData['title'] = $('#inputUpdateTitle').val();
+      templateData['category'] = $('#inputUpdateCategory').val() || null;
       templateData['scenario'] = $('#inputUpdateScenario').val();
       templateData['deliverable'] = $('#inputUpdateDeliverable').val();
       templateData['start_time'] = datetimeLocalToISO($('#inputUpdateStartTime').val());

--- a/scoring_engine/web/templates/inject.html
+++ b/scoring_engine/web/templates/inject.html
@@ -147,6 +147,9 @@
         } else if (r.status == 'Draft') {
           headerHtml += '<span class="badge bg-warning text-dark">' + r.status + '</span>';
         }
+        if (r.category) {
+          headerHtml += ' <span class="badge bg-secondary">' + r.category + '</span>';
+        }
         headerHtml += '</div>';
         if (r.status == 'Draft' && !r.expired) {
           headerHtml += '<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#submitInjectConfirmation">Submit Inject</button>';

--- a/scoring_engine/web/templates/injects.html
+++ b/scoring_engine/web/templates/injects.html
@@ -20,6 +20,9 @@
                         <div title="Title">Title</div>
                     </th>
                     <th>
+                        <div title="Category">Category</div>
+                    </th>
+                    <th>
                         <div title="Score">Score</div>
                     </th>
                     <th>
@@ -63,11 +66,18 @@
                 },
                 {
                     "data": "title",
-                    "width": "65%",
+                    "width": "50%",
                     "render": function (data, type, row) {
                         return '<a href="/inject/' + row['id'] + '">' + data + '</a>';
                     }
 
+                },
+                {
+                    "data": "category",
+                    "width": "10%",
+                    "render": function (data) {
+                        return data || '<span class="text-muted">—</span>';
+                    }
                 },
                 {
                     "data": "score",

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -495,6 +495,7 @@ def admin_get_inject_templates_id(template_id):
             title=template.title,
             scenario=template.scenario,
             deliverable=template.deliverable,
+            category=template.category,
             max_score=template.max_score,
             start_time=_ensure_utc_aware(template.start_time).astimezone(pytz.timezone(config.timezone)).isoformat(),
             end_time=_ensure_utc_aware(template.end_time).astimezone(pytz.timezone(config.timezone)).isoformat(),
@@ -527,6 +528,8 @@ def admin_put_inject_templates_id(template_id):
                 template.start_time = parse(data["start_time"]).astimezone(pytz.utc).replace(tzinfo=None)
             if data.get("end_time"):
                 template.end_time = parse(data["end_time"]).astimezone(pytz.utc).replace(tzinfo=None)
+            if "category" in data:
+                template.category = data["category"] or None
             # TODO - Fix this to not be string values from javascript select
             if data.get("status") == "Enabled":
                 template.enabled = True
@@ -627,6 +630,7 @@ def admin_get_inject_templates():
                 dict(
                     id=template.id,
                     title=template.title,
+                    category=template.category,
                     scenario=template.scenario,
                     deliverable=template.deliverable,
                     max_score=template.max_score,
@@ -781,6 +785,7 @@ def admin_post_inject_templates():
                 deliverable=data["deliverable"],
                 start_time=parse(data["start_time"]).astimezone(pytz.utc).replace(tzinfo=None),
                 end_time=parse(data["end_time"]).astimezone(pytz.utc).replace(tzinfo=None),
+                category=data.get("category"),
             )
             db.session.add(template)
             db.session.flush()
@@ -892,6 +897,8 @@ def admin_import_inject_templates():
                             t.start_time = parse(d["start_time"]).astimezone(pytz.utc).replace(tzinfo=None)
                         if d.get("end_time"):
                             t.end_time = parse(d["end_time"]).astimezone(pytz.utc).replace(tzinfo=None)
+                        if "category" in d:
+                            t.category = d["category"] or None
                         if d.get("enabled"):
                             t.enabled = True
                         else:

--- a/scoring_engine/web/views/api/injects.py
+++ b/scoring_engine/web/views/api/injects.py
@@ -63,6 +63,7 @@ def api_injects():
                 id=inject.id,
                 template_id=inject.template.id,
                 title=inject.template.title,
+                category=inject.template.category,
                 score=inject.score if scores_visible else None,
                 max_score=inject.template.max_score,
                 status=inject.status,
@@ -205,6 +206,7 @@ def api_inject(inject_id):
     scores_visible = current_user.is_white_team or Setting.get_setting("inject_scores_visible").value
     data["scores_visible"] = scores_visible
     data["title"] = inject.template.title
+    data["category"] = inject.template.category
     data["scenario"] = inject.template.scenario
     data["deliverable"] = inject.template.deliverable
     data["start_time"] = inject.template.start_time.isoformat() if inject.template.start_time else None


### PR DESCRIPTION
## Summary
Add a `category` column to the Template model so organizers can classify injects by purpose: **Business**, **Technical**, or **Incident Response**.

**Model & Migration:**
- `Template.category` — String(50), nullable (backwards compatible)
- `002_add_template_category` migration with `batch_alter_table` for SQLite compatibility

**Admin UI:**
- Category dropdown in create/edit template forms
- Category included in template list API, GET/PUT/POST endpoints, and import
- Category field passed through inject import/export

**Blue Team UI:**
- Category column in inject list table (`/injects`)
- Category badge in inject detail header (`/inject/<id>`)

**Example data:**
- `bin/setup` rotates through all three categories for sample injects

## Test plan
- [x] 155 inject-related tests pass
- [ ] Create template with category in admin UI
- [ ] Edit template category
- [ ] Blue team sees category in inject list and detail
- [ ] Import/export preserves category

Closes #1174