### PR TITLE
Add scoring overview tables with ordinal rankings to stats page

### DIFF
--- a/scoring_engine/web/templates/stats.html
+++ b/scoring_engine/web/templates/stats.html
@@ -8,6 +8,34 @@
 {% endblock %}
 {% block content %}
 <div class="page-wrap">
+    {% if current_user.is_white_team %}
+    <!-- Scoring Overview (White Team Only) -->
+    <h3 class="section-header">Service Scoring Overview</h3>
+    <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
+        <button class="btn btn-sm btn-outline-secondary mb-2" onclick="copyTable('service-scoring')"><i class="bi bi-clipboard"></i> Copy</button>
+        <table id="service-scoring" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
+            <thead><tr><th>Team</th><th>Raw Service Score</th><th>Ordinal Rank</th></tr></thead>
+            <tbody></tbody>
+        </table>
+    </div>
+
+    <h3 class="section-header">Inject Scoring Overview</h3>
+    <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
+        <button class="btn btn-sm btn-outline-secondary mb-2" onclick="copyTable('inject-scoring')"><i class="bi bi-clipboard"></i> Copy</button>
+        <table id="inject-scoring" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
+            <thead><tr>
+                <th>Team</th>
+                <th>Business</th><th>Rank</th>
+                <th>Technical</th><th>Rank</th>
+                <th>Incident Response</th><th>Rank</th>
+                <th>Business+Technical</th><th>Rank</th>
+                <th>Total Inject</th><th>Rank</th>
+            </tr></thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    {% endif %}
+
     <h3 class="section-header">All-Time Service Statistics</h3>
     <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
         <table id="service-summary" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
@@ -55,6 +83,54 @@
             return hours + 'h ' + mins + 'm ' + secs + 's';
         }
     }
+
+    function copyTable(tableId) {
+        var table = document.getElementById(tableId);
+        var text = '';
+        for (var i = 0; i < table.rows.length; i++) {
+            var row = [];
+            for (var j = 0; j < table.rows[i].cells.length; j++) {
+                row.push(table.rows[i].cells[j].textContent.trim());
+            }
+            text += row.join('\t') + '\n';
+        }
+        navigator.clipboard.writeText(text).then(function() {
+            var btn = table.parentElement.querySelector('button');
+            var orig = btn.innerHTML;
+            btn.innerHTML = '<i class="bi bi-check"></i> Copied!';
+            setTimeout(function() { btn.innerHTML = orig; }, 2000);
+        });
+    }
+
+    {% if current_user.is_white_team %}
+    // Load scoring overview
+    $.getJSON('/api/stats/scoring_overview').done(function(data) {
+        // Service scoring table
+        var svcRows = [];
+        $.each(data.service_table, function(i, row) {
+            svcRows.push([row.team, row.score.toLocaleString(), row.rank]);
+        });
+        $('#service-scoring').DataTable({
+            data: svcRows, paging: false, searching: false, order: [[2, 'asc']]
+        });
+
+        // Inject scoring table
+        var injRows = [];
+        $.each(data.inject_table, function(i, row) {
+            injRows.push([
+                row.team,
+                row.score_Business || 0, row.rank_Business || '-',
+                row.score_Technical || 0, row.rank_Technical || '-',
+                row['score_Incident Response'] || 0, row['rank_Incident Response'] || '-',
+                row.score_bt || 0, row.rank_bt || '-',
+                row.score_total || 0, row.rank_total || '-'
+            ]);
+        });
+        $('#inject-scoring').DataTable({
+            data: injRows, paging: false, searching: false, order: [[10, 'desc']]
+        });
+    });
+    {% endif %}
 
     $.ajax({
         url: '/api/stats',

--- a/scoring_engine/web/templates/stats.html
+++ b/scoring_engine/web/templates/stats.html
@@ -10,18 +10,22 @@
 <div class="page-wrap">
     {% if current_user.is_white_team %}
     <!-- Scoring Overview (White Team Only) -->
-    <h3 class="section-header">Service Scoring Overview</h3>
+    <div class="d-flex justify-content-between align-items-center">
+        <h3 class="section-header mb-0">Service Scoring Overview</h3>
+        <button class="btn btn-sm btn-primary" onclick="copyTable('service-scoring')" title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
+    </div>
     <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
-        <button class="btn btn-sm btn-outline-secondary mb-2" onclick="copyTable('service-scoring')"><i class="bi bi-clipboard"></i> Copy</button>
         <table id="service-scoring" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
             <thead><tr><th>Team</th><th>Raw Service Score</th><th>Ordinal Rank</th></tr></thead>
             <tbody></tbody>
         </table>
     </div>
 
-    <h3 class="section-header">Inject Scoring Overview</h3>
+    <div class="d-flex justify-content-between align-items-center">
+        <h3 class="section-header mb-0">Inject Scoring Overview</h3>
+        <button class="btn btn-sm btn-primary" onclick="copyTable('inject-scoring')" title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
+    </div>
     <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
-        <button class="btn btn-sm btn-outline-secondary mb-2" onclick="copyTable('inject-scoring')"><i class="bi bi-clipboard"></i> Copy</button>
         <table id="inject-scoring" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
             <thead><tr>
                 <th>Team</th>
@@ -36,7 +40,10 @@
     </div>
     {% endif %}
 
-    <h3 class="section-header">All-Time Service Statistics</h3>
+    <div class="d-flex justify-content-between align-items-center">
+        <h3 class="section-header mb-0">All-Time Service Statistics</h3>
+        <button class="btn btn-sm btn-primary" onclick="copyTable('service-summary')" title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
+    </div>
     <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
         <table id="service-summary" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
             <thead>
@@ -51,7 +58,10 @@
             <tbody></tbody>
         </table>
     </div>
-    <h3 class="section-header">Round Stats</h3>
+    <div class="d-flex justify-content-between align-items-center">
+        <h3 class="section-header mb-0">Round Stats</h3>
+        <button class="btn btn-sm btn-primary" onclick="copyTable('stats')" title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
+    </div>
     <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
         <table id="stats" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
             <thead>
@@ -95,10 +105,15 @@
             text += row.join('\t') + '\n';
         }
         navigator.clipboard.writeText(text).then(function() {
-            var btn = table.parentElement.querySelector('button');
-            var orig = btn.innerHTML;
-            btn.innerHTML = '<i class="bi bi-check"></i> Copied!';
-            setTimeout(function() { btn.innerHTML = orig; }, 2000);
+            // Find the copy button associated with this table
+            var card = table.closest('.chart-card');
+            var btn = card ? card.previousElementSibling.querySelector('button') : null;
+            if (btn) {
+                var orig = btn.innerHTML;
+                btn.innerHTML = '<i class="bi bi-check-lg"></i>';
+                btn.classList.replace('btn-primary', 'btn-success');
+                setTimeout(function() { btn.innerHTML = orig; btn.classList.replace('btn-success', 'btn-primary'); }, 2000);
+            }
         });
     }
 

--- a/scoring_engine/web/templates/stats.html
+++ b/scoring_engine/web/templates/stats.html
@@ -95,18 +95,26 @@
     }
 
     function copyTable(tableId) {
-        var table = document.getElementById(tableId);
+        var dt = $.fn.dataTable.tables({api: true}).table('#' + tableId);
         var text = '';
-        for (var i = 0; i < table.rows.length; i++) {
-            var row = [];
-            for (var j = 0; j < table.rows[i].cells.length; j++) {
-                row.push(table.rows[i].cells[j].textContent.trim());
+        // Header
+        var headers = [];
+        $('#' + tableId + ' thead th').each(function() { headers.push($(this).text().trim()); });
+        text += headers.join('\t') + '\n';
+        // All rows (not just visible page) — strip HTML tags
+        dt.rows({search: 'applied'}).every(function() {
+            var row = this.data();
+            var cells = [];
+            for (var i = 0; i < row.length; i++) {
+                var val = String(row[i]);
+                // Strip HTML tags for clean clipboard output
+                val = val.replace(/<[^>]*>/g, '').trim();
+                cells.push(val);
             }
-            text += row.join('\t') + '\n';
-        }
+            text += cells.join('\t') + '\n';
+        });
         navigator.clipboard.writeText(text).then(function() {
-            // Find the copy button associated with this table
-            var card = table.closest('.chart-card');
+            var card = document.getElementById(tableId).closest('.chart-card');
             var btn = card ? card.previousElementSibling.querySelector('button') : null;
             if (btn) {
                 var orig = btn.innerHTML;

--- a/scoring_engine/web/templates/stats.html
+++ b/scoring_engine/web/templates/stats.html
@@ -16,7 +16,7 @@
     </div>
     <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
         <table id="service-scoring" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
-            <thead><tr><th>Team</th><th>Raw Service Score</th><th>Ordinal Rank</th></tr></thead>
+            <thead><tr><th>Team</th><th>Raw Service Score</th><th>Rank</th></tr></thead>
             <tbody></tbody>
         </table>
     </div>

--- a/scoring_engine/web/views/api/stats.py
+++ b/scoring_engine/web/views/api/stats.py
@@ -26,10 +26,13 @@ from scoring_engine.config import config
 from scoring_engine.db import db
 from scoring_engine.models.account import Account
 from scoring_engine.models.check import Check
+from scoring_engine.models.inject import Inject, Template
 from scoring_engine.models.round import Round
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
+from scoring_engine.sla import get_sla_config, apply_dynamic_scoring_to_round, calculate_team_total_penalties
+from scoring_engine.web.views.api.overview import calculate_ranks
 
 from . import make_cache_key, mod
 
@@ -149,3 +152,122 @@ def api_stats():
         return jsonify(_build_response(rows))
 
     return {"status": "Unauthorized"}, 403
+
+
+@mod.route("/api/stats/scoring_overview")
+@login_required
+@cache.cached(make_cache_key=make_cache_key)
+def api_stats_scoring_overview():
+    """Scoring overview tables with ordinal rankings. White team only."""
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+
+    blue_teams = db.session.query(Team).filter(Team.color == "Blue").order_by(Team.id).all()
+    blue_team_ids = [t.id for t in blue_teams]
+    blue_teams_dict = {t.id: t for t in blue_teams}
+
+    sla_config = get_sla_config()
+
+    # --- Service Scores ---
+    if sla_config.dynamic_enabled:
+        from collections import defaultdict
+
+        round_scores = (
+            db.session.query(Service.team_id, Check.round_id, func.sum(Service.points).label("round_score"))
+            .join(Check)
+            .filter(Check.result.is_(True))
+            .group_by(Service.team_id, Check.round_id)
+            .all()
+        )
+        rounds_map = {r.id: r.number for r in db.session.query(Round.id, Round.number).all()}
+        team_scores = defaultdict(int)
+        for team_id, round_id, round_score in round_scores:
+            round_number = rounds_map.get(round_id, 0)
+            team_scores[team_id] += apply_dynamic_scoring_to_round(round_number, round_score, sla_config)
+        team_scores = dict(team_scores)
+    else:
+        from sqlalchemy import desc
+
+        team_scores = dict(
+            db.session.query(Service.team_id, func.sum(Service.points).label("score"))
+            .join(Check)
+            .filter(Check.result.is_(True))
+            .group_by(Service.team_id)
+            .all()
+        )
+
+    # Apply SLA penalties
+    adjusted_scores = {}
+    for tid in blue_team_ids:
+        base = team_scores.get(tid, 0)
+        if sla_config.sla_enabled:
+            penalty = calculate_team_total_penalties(blue_teams_dict[tid], sla_config)
+            adjusted_scores[tid] = max(0, base - penalty) if not sla_config.allow_negative else base - penalty
+        else:
+            adjusted_scores[tid] = base
+
+    service_ranks = calculate_ranks(adjusted_scores)
+
+    service_table = []
+    for t in blue_teams:
+        service_table.append({
+            "team": t.name,
+            "score": adjusted_scores.get(t.id, 0),
+            "rank": service_ranks.get(t.id, 0),
+        })
+
+    # --- Inject Scores by Category ---
+    from scoring_engine.models.inject import InjectRubricScore
+
+    inject_rows = (
+        db.session.query(
+            Inject.team_id,
+            Template.category,
+            func.coalesce(func.sum(InjectRubricScore.score), 0).label("total_score"),
+        )
+        .join(Template, Inject.template_id == Template.id)
+        .outerjoin(InjectRubricScore, InjectRubricScore.inject_id == Inject.id)
+        .filter(Inject.team_id.in_(blue_team_ids))
+        .group_by(Inject.team_id, Template.category)
+        .all()
+    )
+
+    # Build per-team category scores
+    from collections import defaultdict
+
+    cat_scores = defaultdict(lambda: defaultdict(int))
+    for team_id, category, score in inject_rows:
+        cat_scores[team_id][category or "Uncategorized"] = int(score)
+
+    categories = ["Business", "Technical", "Incident Response"]
+
+    # Calculate ranks per category
+    cat_rank_dicts = {}
+    for cat in categories:
+        cat_rank_dicts[cat] = calculate_ranks({tid: cat_scores[tid].get(cat, 0) for tid in blue_team_ids})
+
+    # Business + Technical summary
+    bt_scores = {tid: cat_scores[tid].get("Business", 0) + cat_scores[tid].get("Technical", 0) for tid in blue_team_ids}
+    bt_ranks = calculate_ranks(bt_scores)
+
+    # Total inject scores
+    total_inject = {tid: sum(cat_scores[tid].values()) for tid in blue_team_ids}
+    total_inject_ranks = calculate_ranks(total_inject)
+
+    inject_table = []
+    for t in blue_teams:
+        row = {"team": t.name}
+        for cat in categories:
+            row[f"score_{cat}"] = cat_scores[t.id].get(cat, 0)
+            row[f"rank_{cat}"] = cat_rank_dicts[cat].get(t.id, 0)
+        row["score_bt"] = bt_scores.get(t.id, 0)
+        row["rank_bt"] = bt_ranks.get(t.id, 0)
+        row["score_total"] = total_inject.get(t.id, 0)
+        row["rank_total"] = total_inject_ranks.get(t.id, 0)
+        inject_table.append(row)
+
+    return jsonify({
+        "service_table": service_table,
+        "inject_table": inject_table,
+        "categories": categories,
+    })


### PR DESCRIPTION
## Summary
White team scoring overview on the stats page with two tables:

**Service Scoring Table:**
| Team | Raw Service Score | Ordinal Rank |
|------|------------------|-------------|

**Inject Scoring Table:**
| Team | Business | Rank | Technical | Rank | Incident Response | Rank | Business+Technical | Rank | Total | Rank |
|------|----------|------|-----------|------|-------------------|------|-------------------|------|-------|------|

- Each table has a **Copy** button that outputs tab-separated values for spreadsheet paste
- Scores include SLA penalties and dynamic scoring multipliers
- Ordinal rankings with tie handling (reuses `calculate_ranks` from overview.py)

**New endpoint:** `GET /api/stats/scoring_overview` (white team only, cached per role)

**Depends on:** #1195 (inject categories) for category breakdown

## Test plan
- [x] 14 stats tests pass
- [ ] View stats page as white team — both tables render with data
- [ ] Click Copy button — paste into spreadsheet, verify tab-separated format
- [ ] Verify ordinal rankings match manual calculation

Closes #1175