### PR TITLE
Show offline host indicator on flags capture status page

### DIFF
--- a/scoring_engine/web/templates/flags.html
+++ b/scoring_engine/web/templates/flags.html
@@ -27,7 +27,7 @@
     </div>
 
     <h3 class="section-header">Capture Status for Active Flags</h3>
-    <p class="text-muted"><i class='bi bi-dash-lg' style='color: gray'></i> means no capture; <i class='bi bi-person-fill' style='color: #4da6ff'></i> means user level capture; and <i class='bi bi-fire' style='color: red'></i> means root level capture</p>
+    <p class="text-muted"><i class='bi bi-dash-lg' style='color: gray'></i> no capture; <i class='bi bi-person-fill' style='color: #4da6ff'></i> user capture; <i class='bi bi-fire' style='color: red'></i> root capture; <i class='bi bi-x-lg' style='color: black'></i> host offline</p>
     <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
         <table id="solves" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
             <thead>
@@ -87,6 +87,8 @@ $(document).ready(function() {
 			        return "<i class='bi bi-fire' style='color: red'></i>";
 			    } else if(data[0] == 1) {
 			        return "<i class='bi bi-person-fill' style='color: #4da6ff'></i>";
+			    } else if(data[2] == 1) {
+			        return "<i class='bi bi-x-lg' style='color: black'></i>";
 		            } else {
 			        return "<i class='bi bi-dash-lg' style='color: gray'></i>";
 			    }

--- a/scoring_engine/web/views/api/flags.py
+++ b/scoring_engine/web/views/api/flags.py
@@ -5,7 +5,7 @@ from flask_login import current_user, login_required
 from sqlalchemy import case, func
 from sqlalchemy.sql.expression import and_, or_
 
-from scoring_engine.cache import cache
+from scoring_engine.cache import agent_cache, cache
 from scoring_engine.db import db
 from scoring_engine.models.flag import Flag, Perm, Platform, Solve
 from scoring_engine.models.service import Service
@@ -94,7 +94,26 @@ def api_flags_solves():
         .all()
     )
 
+    # Determine offline threshold: 2x agent checkin interval
+    checkin_setting = Setting.get_setting("agent_checkin_interval_sec")
+    checkin_interval = int(checkin_setting.value) if checkin_setting else 60
+    offline_threshold = checkin_interval * 2
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+
+    # Collect all unique hosts and build checkin timestamp map
+    host_set = set()
+    for item in all_hosts:
+        host_set.add(item.host)
+
+    # Batch query agent_cache for all hosts
+    host_checkin = {}
+    for host in host_set:
+        cached = agent_cache.get(host)
+        if cached and isinstance(cached, dict) and "timestamp" in cached:
+            host_checkin[host] = cached["timestamp"]
+
     data = {}
+    host_map = {}  # (team_name, service_name) -> host
     rows = []
     columns = ["Team"]
 
@@ -103,13 +122,26 @@ def api_flags_solves():
             columns.append(item.service_name)
         if not data.get(item.team_name):
             data[item.team_name] = {}
+            host_map[item.team_name] = {}
         if not data[item.team_name].get(item.service_name):
-            data[item.team_name][item.service_name] = [0, 0]
+            # [user_solve, root_solve, offline]
+            data[item.team_name][item.service_name] = [0, 0, 0]
+            host_map[item.team_name][item.service_name] = item.host
         if item.solve_id:
             if item.flag_perm.value == "user":
                 data[item.team_name][item.service_name][0] = 1
             else:
                 data[item.team_name][item.service_name][1] = 1
+
+    # Mark offline hosts (only when no solve — solves take precedence)
+    for team_name, services in data.items():
+        for svc_name, solve_data in services.items():
+            if solve_data[0] == 0 and solve_data[1] == 0:
+                host = host_map.get(team_name, {}).get(svc_name)
+                if host:
+                    last_ts = host_checkin.get(host)
+                    if last_ts is None or (now_ts - last_ts) > offline_threshold:
+                        solve_data[2] = 1
 
     for key, val in data.items():
         new_row = [key]


### PR DESCRIPTION
## Summary
Add a 4th icon (black X) to the flags capture status table for hosts that haven't checked in recently.

**Icon priority:**
1. Fire (red) — root level capture
2. Person (blue) — user level capture  
3. **X (black) — host offline** (new)
4. Dash (gray) — no capture, host online

A host is considered offline when its last agent checkin timestamp is older than 2x the `agent_checkin_interval_sec` setting, or if it has never checked in.

Uses `agent_cache` to batch-lookup last checkin timestamps for all AgentCheck hosts.

## Test plan
- [x] 54 flag-related tests pass
- [ ] Deploy with agent checks — offline hosts show black X
- [ ] Hosts with captures still show fire/person (takes precedence)
- [ ] Hosts that check in transition from X back to dash

Closes #1187