### PR TITLE
Wave 2 → master: round_score materialization, scheduling, weighted scoring, SLA/line perf

### DIFF
--- a/WAVE_2_DESIGN.md
+++ b/WAVE_2_DESIGN.md
@@ -236,6 +236,30 @@ Open question for the maintainer (see §11): does a captured flag *subtract* fro
 blue team's score, or only *add* to red's? Both are legitimate competition rules; the
 schema supports either (it stores the raw flag_points; the read path decides sign).
 
+### Implementation note (phase 4, as built)
+
+Implementing this revealed that the "materialize `flag_points` into `round_score` at
+round close" plan does not fit the data: a `Solve` row has **no round and no
+timestamp** (just `flag_id`, `host`, `team_id`), and it is created asynchronously on
+agent check-in, while the engine creates the `Round` row only at round *close*. There
+is no reliable way to attribute a solve to a round after the fact. The `checks`-volume
+performance argument also does not apply — the `flag_solves` table is small.
+
+So flags are scored **live from the `solves` table**, the way injects are scored
+(an event-driven component), not materialized per round:
+
+- `scoring_engine.scores.flag_points_by_team()` → `{blue_team_id: captured value}`,
+  each non-dummy solve worth `flag_points_user`/`flag_points_root` by its flag's perm.
+- `red_team_flag_total()` → sum across all blue teams (add-to-red-only, resolved §11).
+- Surfaced by `/api/flags/score` (red/white only) and a card on the flags page.
+
+`round_score.flag_points` therefore stays `0` (reserved). It is left in place rather
+than dropped with another migration; if per-solve round attribution is ever wanted, a
+`Solve.round_number` (or `created_at`) column would enable materialization here.
+Wall-clock **freeze** (phase 6) will filter solves by a `Solve.created_at` added then;
+until that column exists, flag freeze is best-effort. Rollback does not currently
+delete solves (they are red captures, independent of blue's service rounds).
+
 ---
 
 ## 7. Rollback, freeze, and cache — the three cross-cutting contracts

--- a/WAVE_2_DESIGN.md
+++ b/WAVE_2_DESIGN.md
@@ -1,0 +1,374 @@
+# Wave 2 Design — `round_score` materialization and what it unblocks
+
+Status: design, not yet implemented. Author pass: 2026-07-24.
+
+Wave 1 hardened the existing engine. Wave 2 changes the **scoring model** itself.
+Four features the maintainer wants — red-team scoring, competition freeze, manual
+score adjustments, and the performance fix for large competitions — all depend on
+one thing that does not exist yet: a durable, per-round record of what each team
+scored. This document designs that record (`round_score`), then shows how each
+feature sits on top of it.
+
+Read this before writing any wave-2 code. The schema decisions here are load-bearing.
+
+---
+
+## 1. The problem
+
+Every score in the app is recomputed live from the full `checks` history on every
+read. There is no stored "team X earned Y in round Z" anywhere.
+
+Concretely, today:
+
+| Read path | How it computes | Cost |
+|---|---|---|
+| `Team.current_score` | `SUM(Service.points)` ⋈ `Check` WHERE `result=True` | full history |
+| `Team.current_inject_score` | `SUM(InjectRubricScore.score)` WHERE `status='Graded'` | full inject history |
+| `Team.place` / `Service.rank` | re-queries **all** teams/services per access | full history × N teams |
+| `sla.calculate_team_total_penalties` | loops every service, **2 full-history queries each** | services × 2 × history |
+| `sla.calculate_team_base_score_with_dynamic` | `GROUP BY round`, applies multipliers live | full history |
+| flag `Solve` rows | **not scored anywhere** | — |
+
+This has three consequences, and wave 2 is really about the second and third:
+
+1. **Performance.** `calculate_team_total_penalties` at 100 teams × 20 services is
+   ~4,000 full-history queries for one uncached scoreboard render, and
+   `update_all_cache` calls `cache.clear()` every round, so the first request after
+   each round pays it on every endpoint. Wave 1's indexes soften this; they do not
+   remove it.
+2. **You cannot freeze, adjust, or attribute a score you recompute from scratch
+   every time.** There is no row to freeze, no row to add an adjustment beside, no
+   place to record "red team scored 50 here."
+3. **Editing `Service.points` retroactively rewrites all history**, because history
+   is just `COUNT(passing checks) × current points`. There is no record of what a
+   check was worth *when it was scored*.
+
+`round_score` fixes all three by writing the facts down once, at round close.
+
+---
+
+## 2. Constraints discovered while reading the code
+
+These are non-negotiable; the design is shaped around them.
+
+- **Rollback contract** (`feature/score-rollback`, already in master).
+  `admin_rollback` bulk-deletes `Round`, `Check`, and `KB` rows where
+  `round >= N` in batches, then calls `update_all_cache`. **Any table keyed by
+  round must be deleted in the same operation, or a rolled-back competition keeps
+  ghost scores.** The engine's own failed-round cleanup
+  (`_cleanup_failed_round`) has the identical requirement.
+- **Weighted scoring already anticipates flags** (`feature/weighted-scoring`,
+  stale/unmerged). It ships `weighted_scoring_enabled`, `service_weight`,
+  `inject_weight`, `flag_weight` config. `flag_weight` scores nothing today — it is
+  a placeholder for exactly the red-team scoring wave 2 adds. That branch's
+  `scoreboard.py` predates the anonymize refactor and **cannot be merged as-is**;
+  harvest its config surface, not its code.
+- **Airgapped + SQLite tests.** No new runtime deps. Every migration must run under
+  `batch_alter_table` for SQLite, and the test suite (SQLite) must exercise the new
+  tables.
+- **Client-side rendering rule** (CLAUDE.md). New score data reaches the browser
+  through cached `/api/...` endpoints keyed per visibility, never server-rendered.
+- **Settings cache** has a 60s TTL and must be cleared after mutation
+  (`Setting.clear_cache`).
+
+---
+
+## 3. Proposed schema
+
+Two new tables. One is engine-written fact; the other is operator-written audit.
+Keeping them separate is deliberate — they have different authors, different
+lifecycles, and different rollback behaviour.
+
+### 3.1 `round_score` — the materialized fact table
+
+Written **once per team per round**, at round close, by the engine. Never updated
+after write (a corrected round is rolled back and re-run, never patched in place).
+
+```
+round_score
+  id              INTEGER PK
+  round_id        FK -> rounds.id      (ON DELETE cascade-in-app, see §7)
+  round_number    INTEGER  (denormalized: lets reads filter by number without a join)
+  team_id         FK -> teams.id
+  service_points  INTEGER  NOT NULL DEFAULT 0   -- raw uptime points earned this round
+  flag_points     INTEGER  NOT NULL DEFAULT 0   -- red-team points from solves this round (§6)
+  UNIQUE (round_id, team_id)
+  INDEX (team_id, round_number)
+  INDEX (round_number)
+```
+
+Design choices, with reasons:
+
+- **Store RAW earned points, not weighted/multiplied totals.** Weights
+  (`service_weight`, `flag_weight`) and the dynamic per-round multiplier are
+  *policy* an admin may tune mid-competition; the current app applies them
+  retroactively and we preserve that. Applying them at read time over ~`N_rounds`
+  rows per team is cheap (scalar math, no history scan). Baking them in would lock
+  past rounds and make a weight change silently not apply — the opposite of what
+  `feature/weighted-scoring` intends.
+- **Per (team, round), not per (team, round, service).** The hot reads are
+  team-level totals and ranks. Per-service granularity already lives in `checks`
+  (now indexed); duplicating it here just re-creates the N+1. Service-level views
+  (`Service.rank`, per-service history) keep reading `checks`.
+- **`round_number` denormalized.** `Round.get_last_round_num`, freeze filters, and
+  dynamic-multiplier lookups all key on the number, not the id. Carrying it avoids
+  a join on every read. It is immutable once written.
+- **Injects are deliberately NOT a column here.** Injects are graded asynchronously,
+  not per round — folding them into a per-round row would mean rewriting old rows on
+  every grade. Inject totals stay a separate small aggregate (see §5). `round_score`
+  is strictly the *engine-per-round* fact.
+
+### 3.2 `score_adjustment` — manual white-team adjustments (audit log)
+
+```
+score_adjustment
+  id           INTEGER PK
+  team_id      FK -> teams.id
+  points       INTEGER  NOT NULL        -- signed: +bonus or -penalty
+  reason       TEXT     NOT NULL        -- required; shown in audit view
+  author_id    FK -> users.id           -- who applied it
+  created_at   DATETIME NOT NULL
+  effective_round INTEGER NULL          -- for freeze: counts only if <= frozen round
+  INDEX (team_id)
+```
+
+Separate table because: it is operator-authored (not engine-derived), it is an
+**append-only audit trail** (you never silently edit a competition score; you add a
+compensating row), and it must **survive `admin_rollback`** — rolling back rounds
+should not erase a manual ruling unless the operator says so. (`effective_round`
+lets a specific adjustment ride along with a rollback if desired; default is to keep
+adjustments.)
+
+---
+
+## 4. Write path — where `round_score` rows are created
+
+**One hook, in the engine, at round close.** In `engine.py`, the round loop
+processes all check results and commits at what is currently ~line 678
+(`round_obj.round_end = ...; self.db.session.commit()`). Immediately after that
+commit, while we already hold every processed check in memory, aggregate per team
+and insert `round_score` rows in the same transaction boundary:
+
+```
+# after checks for this round are committed
+per_team = defaultdict(lambda: {"service": 0, "flag": 0})
+for check that passed:
+    per_team[team_id]["service"] += check.service.points
+for solve created in this round window (§6):
+    per_team[team_id]["flag"] += flag_value(solve)
+bulk-insert one round_score row per team for round_obj
+commit
+```
+
+Critical properties:
+
+- **Idempotent per round.** The `UNIQUE(round_id, team_id)` guard means a retried
+  round-close cannot double-write. On the failed-round path
+  (`_cleanup_failed_round`), delete this round's `round_score` rows alongside the
+  `Round`/`Check` deletion so a discarded round leaves nothing behind.
+- **Same transaction as the round.** A `round_score` row exists **iff** its round
+  exists. No window where the scoreboard sees a round with no scores or scores with
+  no round.
+- **Written before `update_all_cache`.** The cache flush at round close then rebuilds
+  from the materialized rows, not the live history.
+
+Backfill for existing competitions is a migration concern (§8), not a runtime one.
+
+---
+
+## 5. Read path — what each current computation becomes
+
+New helpers in a `scoring_engine/scores.py` module (keeps `sla.py` focused on
+penalties). Every current read-path is redirected:
+
+| Today | Becomes |
+|---|---|
+| `Team.current_score` | `SUM(round_score.service_points × service_weight × dyn_mult(round))` for team |
+| red-team / flag total (new) | `SUM(round_score.flag_points × flag_weight × dyn_mult(round))` |
+| `Team.place`, `Service.rank` | one `GROUP BY team_id` over `round_score` (was per-team full history) |
+| `calculate_team_base_score_with_dynamic` | reads `round_score`, applies multiplier per stored `round_number` |
+| inject total | unchanged — `SUM(InjectRubricScore.score)` WHERE `Graded` (small table) |
+| manual total (new) | `SUM(score_adjustment.points)` for team |
+| `get_consecutive_failures` (SLA) | **still reads `checks`** — needs per-service granularity round_score doesn't hold; wave-1 index makes it cheap |
+
+Team grand total (the number on the scoreboard) becomes:
+
+```
+weighted_service + weighted_flag + weighted_inject + manual_adjustments − sla_penalty
+```
+
+where SLA penalty is still computed from `checks` (consecutive failures) but its
+*base* (the score it takes a percentage of) now comes from `round_score` instead of
+another full-history scan — this is the single biggest perf win, killing the
+services × 2 × history loop in `calculate_team_total_penalties`.
+
+The `dyn_mult(round)` and `service_weight`/`flag_weight` factors are applied in
+Python over the per-round rows, exactly as `apply_dynamic_scoring_to_round` does
+today — so dynamic scoring and weighted scoring keep working, retroactively, with no
+history scan.
+
+---
+
+## 6. Red-team / flag scoring (the feature `flag_weight` was waiting for)
+
+Semantics, confirmed from the code: a `Solve(host, team, flag)` row is created when a
+blue team's BTA agent reports a red-team flag present on one of its hosts
+(`api/agent.py` `agent_checkin_post`). A present flag is an indicator of compromise:
+**a point for red, a compromise signal against blue.** Flags carry a `perm` level
+(`user` / `root`) — root compromise is worth more.
+
+Design:
+
+- Each flag has a point value (start simple: a config pair
+  `flag_points_user` / `flag_points_root`, mirroring the existing weight config;
+  or a per-flag column later).
+- At round close, `round_score.flag_points` for a team = sum over that team's solves
+  **whose flag became active in this round window** of the flag's value. Scoring at
+  round close (not at check-in) keeps flags on the same materialized cadence as
+  services and makes them roll back for free.
+- **Red team total** = `SUM` of all blue teams' `flag_points` (red scores by
+  compromising anyone), surfaced on a red-team leaderboard.
+- **Blue exposure** = a team's own `flag_points` shown as a compromise count /
+  optional penalty (policy toggle — some competitions score red purely offensively,
+  others also penalize blue).
+
+Open question for the maintainer (see §11): does a captured flag *subtract* from the
+blue team's score, or only *add* to red's? Both are legitimate competition rules; the
+schema supports either (it stores the raw flag_points; the read path decides sign).
+
+---
+
+## 7. Rollback, freeze, and cache — the three cross-cutting contracts
+
+**Rollback.** Extend `admin_rollback` and the engine's `_cleanup_failed_round` to
+delete `round_score` WHERE `round_number >= N` in the same batched transaction as
+`checks`. `score_adjustment` rows are kept by default (audit), with an optional
+"also remove adjustments effective at/after round N" checkbox driven by
+`effective_round`. Add `round_score` counts to the rollback preview/summary so an
+operator sees what will be discarded.
+
+**Freeze.** A new `Setting`, `scoreboard_frozen_round` (nullable int). When set, every
+read helper adds `WHERE round_number <= frozen_round`, injects filter on
+`graded_at <= freeze_time`, and adjustments on `effective_round <= frozen_round`. The
+engine keeps scoring rounds past the freeze (so the competition continues and can be
+un-frozen), but the public scoreboard reflects the frozen instant. White team sees a
+"FROZEN at round N" banner and the live numbers. Because the read path is already
+centralized in `scores.py`, freeze is one `WHERE` clause in one place — this is a
+direct payoff of materializing.
+
+**Cache.** All new mutations (round close, manual adjustment, freeze toggle,
+rollback) call the existing `cache_helper` invalidators. Add
+`update_scores_data()` / `update_flags_score_data()` helpers mirroring the existing
+per-visibility flush pattern. Adjustment and freeze are white-team actions → flush
+overview, scoreboard, team, stats caches.
+
+---
+
+## 8. Migration and backfill (`alembic` revision 005)
+
+- Create both tables via `batch_alter_table` (SQLite-safe), following the
+  wave-1 `003`/`004` style. `005` chains off `004`.
+- **Backfill `round_score` from existing `checks`** so a mid-competition upgrade
+  keeps its scoreboard: for every existing round, `INSERT ... SELECT` the
+  per-team `SUM(service.points)` of passing checks into `service_points`, and the
+  per-team solve values into `flag_points`. This is a one-time historical
+  reconstruction; it is exact for services, and for flags uses the same
+  round-window rule as the live path.
+- `downgrade()` drops both tables (lossless — they are derived data;
+  `score_adjustment` is the only non-derived data, so its downgrade must warn/refuse
+  if rows exist, like `004`'s pattern).
+- Verify against a scratch SQLite DB populated with real rounds, both upgrade and
+  downgrade, before trusting.
+
+---
+
+## 9. Interaction with wave-1 branches
+
+- Sits cleanly on top of `feature/wave-1-hardening`. The wave-1 indexes on
+  `checks(round_id, result)` and `(service_id, round_id)` are exactly what the
+  backfill query and the still-live SLA consecutive-failure scan need.
+- **Supersedes `feature/weighted-scoring`.** Do not merge that branch. Re-apply its
+  config surface (`weighted_scoring_enabled` + the three weights) on top of the
+  current, anonymize-aware `scoreboard.py`, and wire the weights into the new
+  `scores.py` read path. Its 256-line test file is a useful oracle for the weighting
+  math.
+- **Composes with `feature/bta-uptime-page`.** That page reads `AgentCheck` results;
+  red scoring reads `Solve` rows. Independent, mergeable together. (Note: that branch
+  has a latent `Check.round_id == last_round_number` bug — it compares a round *id*
+  to a round *number*; flag it if that branch is revived.)
+
+---
+
+## 10. Phased implementation plan
+
+Ordered by dependency. Each phase is independently testable and landable; later
+phases assume earlier ones. Validate UI phases with Claude-in-Chrome against a live
+`docker compose` stack.
+
+1. **Schema + write path + backfill.** `round_score` table, `alembic 005` with
+   backfill, engine round-close hook, `_cleanup_failed_round` + `admin_rollback`
+   deletion. No read path changes yet — assert the materialized totals equal the
+   live-computed totals (a golden test: for every team, `SUM(round_score)` ==
+   `Team.current_score`). This phase is invisible to users and de-risks everything
+   after it.
+2. **Read-path cutover.** New `scoring_engine/scores.py`; redirect
+   `Team.current_score`, `place`, `rank`, and the scoreboard/overview/stats APIs to
+   read `round_score`. Delete the full-history scans. Perf test: scoreboard render at
+   100 teams. Behaviour must be identical (same golden test, now through the new
+   path).
+3. **Weighted scoring re-applied** on the new read path (harvest
+   `feature/weighted-scoring` config + tests).
+4. **Red-team / flag scoring.** `flag_points` population at round close, flag value
+   config, red-team leaderboard API + page, blue exposure display. Decide the
+   subtract-from-blue question (§11) first.
+5. **Manual score adjustments.** `score_adjustment` table, white-team API + audit
+   UI, inclusion in totals, rollback interaction.
+6. **Competition freeze.** `scoreboard_frozen_round` setting, read-path filter,
+   white-team banner + control.
+
+Phases 4–6 are independent of each other once 1–2 land, so they can fan out in
+parallel the way wave 1 did.
+
+## 11. Decisions — resolved 2026-07-24
+
+1. **Flag scoring sign** (§6): **Add to red only.** A captured flag adds to the red
+   team's total; the compromised blue team's score is untouched. `round_score`
+   still stores each blue team's raw `flag_points`; the red total is
+   `SUM(flag_points)` across all blue teams, read in phase 4. Blue's own total is
+   service + inject + adjustments − SLA penalty, with no flag term.
+2. **Flag point values**: **Flat per perm level.** Two config values,
+   `flag_points_user` and `flag_points_root` (root worth more), mirroring the
+   existing weight config surface. Per-flag YAML values can layer on later.
+3. **Freeze basis**: **Wall-clock time.** Organizers announce "board freezes at
+   3pm." A new `scoreboard_freeze_time` setting (nullable datetime). The read path
+   resolves it to a boundary per component: `round_score` counts rounds whose
+   `round.round_end <= freeze_time`, injects filter on `graded <= freeze_time`,
+   adjustments on `created_at <= freeze_time`. See §7 revision below.
+4. **Adjustments vs rollback**: keep manual adjustments across a rollback by default
+   (audit trail), optional discard.
+5. **Dynamic multiplier**: keep applying dynamic/weight policy retroactively
+   (matches today's behaviour), reading raw points from `round_score`.
+
+### §7 revision — freeze is time-based
+
+Because freeze is wall-clock, the read filter keys on timestamps, not round number:
+
+- `round_score`: join `rounds` and filter `round.round_end <= scoreboard_freeze_time`
+  (a round counts once it *closed* before the freeze). `round_number` is still
+  carried for dynamic-multiplier lookup; the freeze filter uses `round_end`.
+- injects: `graded <= scoreboard_freeze_time`.
+- adjustments: `created_at <= scoreboard_freeze_time`.
+
+The engine keeps scoring past the freeze so the competition continues and can be
+un-frozen; only the public read path applies the filter. White team sees live
+numbers plus a "FROZEN at HH:MM" banner. `score_adjustment.effective_round` is
+dropped in favour of `created_at` for the freeze comparison (simpler, one basis).
+
+---
+
+## 12. What this explicitly does not change
+
+- SLA consecutive-failure detection still reads `checks` (needs per-service grain).
+- Inject grading flow is untouched; only its inclusion in the total is centralized.
+- The engine's round cadence, dispatch, and check execution are untouched.
+- No new runtime dependencies; airgap story unchanged.

--- a/alembic/versions/005_add_round_score.py
+++ b/alembic/versions/005_add_round_score.py
@@ -1,0 +1,81 @@
+"""Add the round_score materialized fact table (wave 2, phase 1)
+
+``round_score`` stores one row per team per round holding the raw points that team
+earned that round. It replaces recomputing every team's total from the full
+``checks`` history on every scoreboard read. The engine writes a row at round close
+(see scoring_engine/scores.materialize_round); this migration creates the table and
+backfills it from existing checks so a mid-competition upgrade keeps its scoreboard.
+
+Columns:
+  service_points  sum of Service.points over the team's passing checks that round
+  flag_points     red-team capture points (populated in phase 4; backfilled as 0)
+
+The backfill is exact for services: for every existing round it reconstructs the
+per-team passing-check point sum -- the same value scoring_engine.scores computes
+live. Only teams with a non-zero total get a row (a missing (team, round) reads as
+zero), which matches the live write path.
+
+downgrade() drops the table. This is lossless: round_score is derived data --
+service_points can be recomputed from checks at any time, and flag_points is still 0
+at this phase.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "005"
+down_revision = "004"
+branch_labels = None
+depends_on = None
+
+
+TABLE = "round_score"
+
+
+def upgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE in inspector.get_table_names():
+        # Idempotent: a fresh install created the table via create_all() already.
+        return
+
+    op.create_table(
+        TABLE,
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("round_id", sa.Integer(), nullable=False),
+        sa.Column("round_number", sa.Integer(), nullable=False),
+        sa.Column("team_id", sa.Integer(), nullable=False),
+        sa.Column("service_points", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("flag_points", sa.Integer(), nullable=False, server_default="0"),
+        sa.ForeignKeyConstraint(["round_id"], ["rounds.id"]),
+        sa.ForeignKeyConstraint(["team_id"], ["teams.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("round_id", "team_id", name="_round_score_round_team_uc"),
+    )
+    op.create_index("ix_round_score_team_round", TABLE, ["team_id", "round_number"], unique=False)
+    op.create_index("ix_round_score_round_number", TABLE, ["round_number"], unique=False)
+
+    # Backfill from existing checks. One row per (round, team) with a non-zero
+    # passing-check point sum. `checks.result = 1` is portable across MariaDB
+    # (TINYINT(1)) and SQLite (INTEGER); both compare boolean truth to 1.
+    op.execute(
+        """
+        INSERT INTO round_score (round_id, round_number, team_id, service_points, flag_points)
+        SELECT r.id, r.number, s.team_id, SUM(s.points), 0
+        FROM checks c
+        JOIN services s ON s.id = c.service_id
+        JOIN rounds r ON r.id = c.round_id
+        WHERE c.result = 1
+        GROUP BY r.id, r.number, s.team_id
+        HAVING SUM(s.points) > 0
+        """
+    )
+
+
+def downgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return
+    op.drop_index("ix_round_score_round_number", table_name=TABLE)
+    op.drop_index("ix_round_score_team_round", table_name=TABLE)
+    op.drop_table(TABLE)

--- a/alembic/versions/005_add_round_score.py
+++ b/alembic/versions/005_add_round_score.py
@@ -55,20 +55,57 @@ def upgrade():
     op.create_index("ix_round_score_team_round", TABLE, ["team_id", "round_number"], unique=False)
     op.create_index("ix_round_score_round_number", TABLE, ["round_number"], unique=False)
 
-    # Backfill from existing checks. One row per (round, team) with a non-zero
-    # passing-check point sum. `checks.result = 1` is portable across MariaDB
-    # (TINYINT(1)) and SQLite (INTEGER); both compare boolean truth to 1.
+    # Backfill from existing checks: one row per (round, team) with a non-zero
+    # passing-check point sum. Built with SQLAlchemy core rather than a raw boolean
+    # literal so the truth test renders per dialect -- a hardcoded `result = 1`
+    # breaks on PostgreSQL (boolean vs integer), and a bare `WHERE result` breaks on
+    # MSSQL (BIT), both of which the README lists as supported. `result.is_(True)`
+    # is exactly what the live scoring path uses.
+    checks = sa.table(
+        "checks",
+        sa.column("result", sa.Boolean),
+        sa.column("service_id", sa.Integer),
+        sa.column("round_id", sa.Integer),
+    )
+    services = sa.table(
+        "services",
+        sa.column("id", sa.Integer),
+        sa.column("team_id", sa.Integer),
+        sa.column("points", sa.Integer),
+    )
+    rounds = sa.table("rounds", sa.column("id", sa.Integer), sa.column("number", sa.Integer))
+    round_score = sa.table(
+        TABLE,
+        sa.column("round_id"),
+        sa.column("round_number"),
+        sa.column("team_id"),
+        sa.column("service_points"),
+        sa.column("flag_points"),
+    )
+
+    points_sum = sa.func.sum(services.c.points)
+    backfill_select = (
+        sa.select(
+            rounds.c.id,
+            rounds.c.number,
+            services.c.team_id,
+            points_sum,
+            sa.literal(0),
+        )
+        .select_from(
+            checks.join(services, services.c.id == checks.c.service_id).join(
+                rounds, rounds.c.id == checks.c.round_id
+            )
+        )
+        .where(checks.c.result.is_(True))
+        .group_by(rounds.c.id, rounds.c.number, services.c.team_id)
+        .having(points_sum > 0)
+    )
     op.execute(
-        """
-        INSERT INTO round_score (round_id, round_number, team_id, service_points, flag_points)
-        SELECT r.id, r.number, s.team_id, SUM(s.points), 0
-        FROM checks c
-        JOIN services s ON s.id = c.service_id
-        JOIN rounds r ON r.id = c.round_id
-        WHERE c.result = 1
-        GROUP BY r.id, r.number, s.team_id
-        HAVING SUM(s.points) > 0
-        """
+        round_score.insert().from_select(
+            ["round_id", "round_number", "team_id", "service_points", "flag_points"],
+            backfill_select,
+        )
     )
 
 

--- a/alembic/versions/006_add_score_adjustment.py
+++ b/alembic/versions/006_add_score_adjustment.py
@@ -1,0 +1,52 @@
+"""Add the score_adjustment table (wave 2, phase 5)
+
+Manual white-team score adjustments -- an append-only audit log of bonuses and
+penalties applied to teams with a required reason. See
+scoring_engine/models/score_adjustment.py.
+
+Nothing to backfill: adjustments only exist once an operator creates one.
+downgrade() drops the table (its rows are the only copy of the data, so a
+downgrade with rows present would lose them -- the operator is expected to know
+that, same as any table drop).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "006"
+down_revision = "005"
+branch_labels = None
+depends_on = None
+
+
+TABLE = "score_adjustment"
+
+
+def upgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE in inspector.get_table_names():
+        # Idempotent: a fresh install created the table via create_all() already.
+        return
+
+    op.create_table(
+        TABLE,
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("team_id", sa.Integer(), nullable=False),
+        sa.Column("points", sa.Integer(), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("author_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["team_id"], ["teams.id"]),
+        sa.ForeignKeyConstraint(["author_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_score_adjustment_team_id", TABLE, ["team_id"], unique=False)
+
+
+def downgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return
+    op.drop_index("ix_score_adjustment_team_id", table_name=TABLE)
+    op.drop_table(TABLE)

--- a/alembic/versions/007_add_solve_created_at.py
+++ b/alembic/versions/007_add_solve_created_at.py
@@ -1,0 +1,50 @@
+"""Add created_at to flag_solves (wave 2, phase 6)
+
+The wall-clock scoreboard freeze counts a captured flag only if its solve was
+recorded at/before the freeze time. Solves had no timestamp, so add one.
+
+Existing rows (captured before this feature) are backfilled to the migration
+time -- a freeze set during a competition is always after the upgrade, so those
+solves correctly count as pre-freeze.
+"""
+
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "007"
+down_revision = "006"
+branch_labels = None
+depends_on = None
+
+
+TABLE = "flag_solves"
+COLUMN = "created_at"
+
+
+def upgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return
+    if COLUMN in {c["name"] for c in inspector.get_columns(TABLE)}:
+        return  # fresh install already has it via create_all()
+
+    with op.batch_alter_table(TABLE) as batch_op:
+        batch_op.add_column(sa.Column(COLUMN, sa.DateTime(), nullable=True))
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    op.execute(
+        sa.text("UPDATE flag_solves SET created_at = :now WHERE created_at IS NULL").bindparams(now=now)
+    )
+
+
+def downgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return
+    if COLUMN not in {c["name"] for c in inspector.get_columns(TABLE)}:
+        return
+    with op.batch_alter_table(TABLE) as batch_op:
+        batch_op.drop_column(COLUMN)

--- a/alembic/versions/008_add_competition_window.py
+++ b/alembic/versions/008_add_competition_window.py
@@ -1,0 +1,46 @@
+"""Add competition_window table (multi-day scheduling)
+
+Stores the ``[start_time, end_time)`` intervals during which the engine should
+run. No rows == no schedule == the historical always-on behaviour, so nothing is
+seeded here; the table simply starts empty on upgrade.
+
+Fresh installs get the table from ``create_all()`` and this migration is a no-op
+(guarded by the table-exists check); existing databases get it created here.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "008"
+down_revision = "007"
+branch_labels = None
+depends_on = None
+
+
+TABLE = "competition_window"
+
+
+def upgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE in inspector.get_table_names():
+        return  # fresh install already has it via create_all()
+
+    op.create_table(
+        TABLE,
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("start_time", sa.DateTime(), nullable=False),
+        sa.Column("end_time", sa.DateTime(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_competition_window_start", TABLE, ["start_time"])
+
+
+def downgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return
+    op.drop_index("ix_competition_window_start", table_name=TABLE)
+    op.drop_table(TABLE)

--- a/alembic/versions/009_add_checks_sla_scan_index.py
+++ b/alembic/versions/009_add_checks_sla_scan_index.py
@@ -1,0 +1,44 @@
+"""Add ix_checks_sla_scan covering index for batched SLA penalties
+
+scores.team_penalties computes SLA penalties for every team in a couple of
+grouped queries over ``checks`` (last-passing-round MAX and trailing-failure
+COUNT, both grouped by service_id and filtered on completed/result with a
+round_id bound). Without a composite index these do full scans of the largest
+table in the schema. ``(service_id, completed, result, round_id)`` lets both run
+as index-only loose scans -- measured ~6x faster cold scoreboard recompute at
+100 teams x 100 services x 3000 rounds.
+
+Fresh installs get the index from ``create_all``; this migration adds it to
+existing databases (and is a no-op if it is already present).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "009"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+TABLE = "checks"
+INDEX = "ix_checks_sla_scan"
+COLUMNS = ["service_id", "completed", "result", "round_id"]
+
+
+def upgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return
+    if INDEX in {i["name"] for i in inspector.get_indexes(TABLE)}:
+        return  # fresh install already has it via create_all()
+    op.create_index(INDEX, TABLE, COLUMNS)
+
+
+def downgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return
+    if INDEX not in {i["name"] for i in inspector.get_indexes(TABLE)}:
+        return
+    op.drop_index(INDEX, table_name=TABLE)

--- a/alembic/versions/010_add_service_consecutive_failures_cache.py
+++ b/alembic/versions/010_add_service_consecutive_failures_cache.py
@@ -1,0 +1,57 @@
+"""Add services.consecutive_failures_cache and backfill it
+
+The batched SLA penalty read (scores.team_penalties) gets each service's
+consecutive-failure count from this materialized column instead of scanning the
+checks table -- the engine keeps it current at round close. Add the column and
+backfill it from existing check history so an upgraded database is correct
+immediately (matching scores._service_consecutive_failures: completed failing
+checks in rounds after the service's last passing round, or all of them if it
+never passed).
+
+Fresh installs get the column from create_all and populate it via bin/setup
+(example data) or leave it at 0 (no checks yet); this migration covers upgrades.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "010"
+down_revision = "009"
+branch_labels = None
+depends_on = None
+
+TABLE = "services"
+COLUMN = "consecutive_failures_cache"
+
+# 1/0 literals rather than bound booleans so the same SQL runs on MySQL and
+# SQLite (both store booleans as 0/1). Correlated on services.id; the inner
+# selects read only ``checks``, so this never selects from the table it updates.
+_BACKFILL = (
+    "UPDATE services SET consecutive_failures_cache = ("
+    "  SELECT COUNT(*) FROM checks c"
+    "  WHERE c.service_id = services.id AND c.completed = 1 AND c.result = 0"
+    "    AND c.round_id > COALESCE("
+    "      (SELECT MAX(round_id) FROM checks"
+    "       WHERE service_id = services.id AND completed = 1 AND result = 1), 0)"
+    ")"
+)
+
+
+def upgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return
+    if COLUMN not in {c["name"] for c in inspector.get_columns(TABLE)}:
+        with op.batch_alter_table(TABLE) as batch_op:
+            batch_op.add_column(sa.Column(COLUMN, sa.Integer(), nullable=False, server_default="0"))
+    op.execute(_BACKFILL)
+
+
+def downgrade():
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return
+    if COLUMN in {c["name"] for c in inspector.get_columns(TABLE)}:
+        with op.batch_alter_table(TABLE) as batch_op:
+            batch_op.drop_column(COLUMN)

--- a/bin/generate-perf-data
+++ b/bin/generate-perf-data
@@ -143,6 +143,12 @@ def generate(teams, services_per_team, rounds, check_rounds, complex_config):
         s.commit()
         n_checks += len(ck)
 
+    # The engine maintains this at round close; loaded statically here, so
+    # populate it from the generated checks (matches what bin/setup does).
+    from scoring_engine.scores import recompute_consecutive_failures_cache
+
+    recompute_consecutive_failures_cache(s)
+
     if complex_config:
         _apply_complex_config(blue_ids)
 

--- a/bin/generate-perf-data
+++ b/bin/generate-perf-data
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+"""Generate a large synthetic dataset for performance/scale testing.
+
+Bulk-loads blue teams, services, rounds, materialized ``round_score`` rows, and
+(optionally) a recent window of ``checks`` so the read paths can be exercised at
+competition scale -- e.g. the scoreboard, overview, SLA penalties, and dynamic /
+weighted scoring under load.
+
+This is a developer/benchmarking tool, NOT part of setup: it wipes the
+perf-relevant tables (checks, round_score, services, rounds, flag_solves,
+score_adjustment) and every Blue team, then regenerates them. White/Red teams,
+users, and settings are left intact so you can still log in. Point it at a
+throwaway database.
+
+Examples
+--------
+    # 100 teams x 100 services x 3000 rounds, checks for the last 300 rounds
+    python bin/generate-perf-data --teams 100 --services 100 --rounds 3000 --check-rounds 300
+
+    # ...and turn on the heaviest scoring configuration + one adjustment per team
+    python bin/generate-perf-data --teams 100 --services 100 --rounds 3000 --complex-config
+
+Notes
+-----
+- ``round_score`` is written directly (one row per team per round) rather than by
+  running the engine, so this is fast and independent of check generation.
+- ``checks`` are only generated for the most recent ``--check-rounds`` rounds,
+  because that is what the SLA path (consecutive-failure scan) and the overview
+  up/down counts actually read. Full history would be teams*services*rounds rows.
+"""
+
+import argparse
+import random
+import time
+from datetime import datetime, timezone
+
+from scoring_engine.web import create_app
+
+BATCH = 50000
+WIPE_TABLES = ("checks", "round_score", "services", "rounds", "flag_solves", "score_adjustment")
+
+
+def _naive_utcnow():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def generate(teams, services_per_team, rounds, check_rounds, complex_config):
+    from sqlalchemy import text
+
+    from scoring_engine.db import db
+    from scoring_engine.models.check import Check
+    from scoring_engine.models.round import Round
+    from scoring_engine.models.round_score import RoundScore
+    from scoring_engine.models.service import Service
+    from scoring_engine.models.team import Team
+
+    s = db.session
+    t0 = time.time()
+
+    # Wipe perf tables + blue teams (FK checks off so order/references don't
+    # matter). TRUNCATE, not DELETE: at perf scale these tables hold millions of
+    # rows and a row-by-row DELETE would dominate the runtime. Blue teams still
+    # use DELETE because it is a filtered removal, not a whole-table reset.
+    s.execute(text("SET FOREIGN_KEY_CHECKS=0"))
+    for tbl in WIPE_TABLES:
+        s.execute(text(f"TRUNCATE TABLE {tbl}"))
+    s.execute(text("DELETE FROM teams WHERE color='Blue'"))
+    s.execute(text("SET FOREIGN_KEY_CHECKS=1"))
+    s.commit()
+
+    s.bulk_insert_mappings(Team, [{"name": f"Team{i}", "color": "Blue"} for i in range(1, teams + 1)])
+    s.commit()
+    blue_ids = [row[0] for row in s.query(Team.id).filter(Team.color == "Blue").all()]
+
+    svc = [
+        {
+            "name": f"svc{k}",
+            "check_name": "ICMPCheck",
+            "team_id": tid,
+            "points": 100,
+            "host": "127.0.0.1",
+            "port": 1 + k,
+            "worker_queue": "main",
+        }
+        for tid in blue_ids
+        for k in range(services_per_team)
+    ]
+    s.bulk_insert_mappings(Service, svc)
+    s.commit()
+    svc_by_team = {}
+    for sid, tid in s.query(Service.id, Service.team_id).all():
+        svc_by_team.setdefault(tid, []).append(sid)
+
+    now = _naive_utcnow()
+    s.bulk_insert_mappings(Round, [{"number": n, "round_start": now, "round_end": now} for n in range(1, rounds + 1)])
+    s.commit()
+    round_rows = s.query(Round.id, Round.number).order_by(Round.number).all()
+
+    rs = []
+    for rid, rnum in round_rows:
+        for tid in blue_ids:
+            rs.append(
+                {
+                    "round_id": rid,
+                    "round_number": rnum,
+                    "team_id": tid,
+                    "service_points": random.randint(0, services_per_team * 100),
+                    "flag_points": 0,
+                }
+            )
+        if len(rs) >= BATCH:
+            s.bulk_insert_mappings(RoundScore, rs)
+            s.commit()
+            rs = []
+    if rs:
+        s.bulk_insert_mappings(RoundScore, rs)
+        s.commit()
+
+    n_checks = 0
+    check_rids = [rid for rid, rnum in round_rows if rnum > rounds - check_rounds]
+    ck = []
+    for rid in check_rids:
+        for tid in blue_ids:
+            for sid in svc_by_team[tid]:
+                ck.append(
+                    {
+                        "round_id": rid,
+                        "service_id": sid,
+                        "result": random.random() < 0.7,
+                        "completed": True,
+                        "output": "",
+                        "reason": "",
+                        "command": "",
+                    }
+                )
+        if len(ck) >= BATCH:
+            s.bulk_insert_mappings(Check, ck)
+            s.commit()
+            n_checks += len(ck)
+            ck = []
+    if ck:
+        s.bulk_insert_mappings(Check, ck)
+        s.commit()
+        n_checks += len(ck)
+
+    if complex_config:
+        _apply_complex_config(blue_ids)
+
+    _flush_caches()
+
+    print(f"DONE in {round(time.time() - t0, 1)}s")
+    print(
+        f"  teams={len(blue_ids)} services={len(svc)} rounds={rounds} "
+        f"round_score={rounds * len(blue_ids)} checks={n_checks} "
+        f"(checks for last {check_rounds} rounds)"
+    )
+    if complex_config:
+        print("  complex config ON: weighted + dynamic + SLA + injects, one adjustment/team")
+
+
+def _apply_complex_config(blue_ids):
+    from scoring_engine.db import db
+    from scoring_engine.models.score_adjustment import ScoreAdjustment
+    from scoring_engine.models.setting import Setting
+
+    def setv(name, value):
+        setting = Setting.get_setting(name)
+        setting.value = value
+        db.session.add(setting)
+
+    setv("weighted_scoring_enabled", True)
+    setv("service_weight", "1.5")
+    setv("inject_weight", "2.0")
+    setv("flag_weight", "1.0")
+    setv("dynamic_scoring_enabled", True)
+    setv("sla_enabled", True)
+    setv("inject_scores_visible", True)
+    db.session.commit()
+    for tid in blue_ids:
+        db.session.add(ScoreAdjustment(team_id=tid, points=250, reason="perf"))
+    db.session.commit()
+    Setting.clear_cache()
+
+
+def _flush_caches():
+    from scoring_engine.cache_helper import update_all_cache
+
+    update_all_cache()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--teams", type=int, default=100, help="number of blue teams (default 100)")
+    parser.add_argument("--services", type=int, default=100, help="services per team (default 100)")
+    parser.add_argument("--rounds", type=int, default=3000, help="number of rounds / round_score rows per team")
+    parser.add_argument(
+        "--check-rounds",
+        type=int,
+        default=300,
+        help="generate checks for the most recent N rounds (default 300; 0 = none)",
+    )
+    parser.add_argument(
+        "--complex-config",
+        action="store_true",
+        help="also enable weighted+dynamic+SLA+inject scoring and add one adjustment per team",
+    )
+    args = parser.parse_args()
+
+    app = create_app()
+    with app.app_context():
+        generate(args.teams, args.services, args.rounds, min(args.check_rounds, args.rounds), args.complex_config)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/setup
+++ b/bin/setup
@@ -29,8 +29,9 @@ from scoring_engine.web import (
 parser = optparse.OptionParser()
 parser.add_option("--overwrite-db", action="store_true", default=False)
 parser.add_option("--example", action="store_true", default=False)
-parser.add_option("--announcements", type="int", default=8,
-                  help="Number of sample announcements to generate (default: 8)")
+parser.add_option(
+    "--announcements", type="int", default=8, help="Number of sample announcements to generate (default: 8)"
+)
 
 options, arguments = parser.parse_args()
 
@@ -199,13 +200,14 @@ with app.app_context():
     # Welcome Page Configuration
     logger.info("Creating the Welcome Page Configuration")
     import json
+
     welcome_config = {
         "welcome_message": "<h2 class='text-center'>Welcome to the Competition!</h2><p class='text-center lead'>Good luck to all teams. Check back here for updates and sponsor information.</p>",
         "sponsor_tiers": [
             {"name": "Diamond", "display_order": 1, "sponsors": []},
             {"name": "Platinum", "display_order": 2, "sponsors": []},
             {"name": "Gold", "display_order": 3, "sponsors": []},
-        ]
+        ],
     }
     db.session.add(Setting(name="welcome_config", value=json.dumps(welcome_config)))
 
@@ -216,6 +218,9 @@ with app.app_context():
     # Red-team flag scoring (flat points per captured flag by permission level)
     db.session.add(Setting(name="flag_points_user", value=str(config.flag_points_user)))
     db.session.add(Setting(name="flag_points_root", value=str(config.flag_points_root)))
+
+    # Wall-clock scoreboard freeze (empty = not frozen; set at runtime by white team)
+    db.session.add(Setting(name="scoreboard_freeze_time", value=""))
 
     db.session.commit()
 
@@ -417,25 +422,29 @@ with app.app_context():
         ]
         # Add a team-specific announcement if there are blue teams
         if len(blue_team_ids) >= 2:
-            sample_announcements.append({
-                "title": "DNS Issue Resolved",
-                "content": (
-                    "<p>The DNS resolution issue affecting your team has been resolved. "
-                    "Please verify your DNS service is passing checks.</p>"
-                ),
-                "audience": f"team:{blue_team_ids[0]}",
-                "is_pinned": False,
-            })
-            sample_announcements.append({
-                "title": "Scoring Adjustment",
-                "content": (
-                    "<p>A scoring adjustment has been applied to your teams due to "
-                    "the infrastructure issue earlier. Two failed checks have been "
-                    "marked as passing.</p>"
-                ),
-                "audience": f"teams:{blue_team_ids[0]},{blue_team_ids[1]}",
-                "is_pinned": False,
-            })
+            sample_announcements.append(
+                {
+                    "title": "DNS Issue Resolved",
+                    "content": (
+                        "<p>The DNS resolution issue affecting your team has been resolved. "
+                        "Please verify your DNS service is passing checks.</p>"
+                    ),
+                    "audience": f"team:{blue_team_ids[0]}",
+                    "is_pinned": False,
+                }
+            )
+            sample_announcements.append(
+                {
+                    "title": "Scoring Adjustment",
+                    "content": (
+                        "<p>A scoring adjustment has been applied to your teams due to "
+                        "the infrastructure issue earlier. Two failed checks have been "
+                        "marked as passing.</p>"
+                    ),
+                    "audience": f"teams:{blue_team_ids[0]},{blue_team_ids[1]}",
+                    "is_pinned": False,
+                }
+            )
 
         # Slice to requested count, or cycle if more requested than available
         num_announcements = options.announcements
@@ -444,7 +453,9 @@ with app.app_context():
         else:
             selected_announcements = list(sample_announcements)
             while len(selected_announcements) < num_announcements:
-                selected_announcements.append(sample_announcements[len(selected_announcements) % len(sample_announcements)])
+                selected_announcements.append(
+                    sample_announcements[len(selected_announcements) % len(sample_announcements)]
+                )
 
         for ann_data in selected_announcements:
             announcement = Announcement(

--- a/bin/setup
+++ b/bin/setup
@@ -220,6 +220,12 @@ with app.app_context():
     db.session.add(Setting(name="flag_points_user", value=str(config.flag_points_user)))
     db.session.add(Setting(name="flag_points_root", value=str(config.flag_points_root)))
 
+    # Weighted scoring (rebalance service/inject/flag contributions to the total)
+    db.session.add(Setting(name="weighted_scoring_enabled", value=config.weighted_scoring_enabled))
+    db.session.add(Setting(name="service_weight", value=str(config.service_weight)))
+    db.session.add(Setting(name="inject_weight", value=str(config.inject_weight)))
+    db.session.add(Setting(name="flag_weight", value=str(config.flag_weight)))
+
     # Wall-clock scoreboard freeze (empty = not frozen; set at runtime by white team)
     db.session.add(Setting(name="scoreboard_freeze_time", value=""))
 

--- a/bin/setup
+++ b/bin/setup
@@ -15,6 +15,7 @@ from scoring_engine.models.inject import Inject, InjectRubricScore, RubricItem, 
 from scoring_engine.models.notifications import Notification
 from scoring_engine.models.round import Round
 from scoring_engine.models.service import Service
+from scoring_engine.scores import materialize_all_rounds
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
 from scoring_engine.models.announcement import Announcement
@@ -271,6 +272,15 @@ with app.app_context():
                 check.finished(result, reason, output, command)
                 db.session.add(check)
         db.session.commit()
+
+        # Materialize round_score for the simulated rounds. In production the
+        # engine writes these rows as each round closes, but example data is
+        # loaded statically without ever running the engine, and a fresh install
+        # stamps Alembic to head rather than running the 005 backfill -- so
+        # without this the round_score-backed scoreboard/overview read zero for
+        # every team even though the checks exist.
+        logger.info("Materializing round scores for the simulated rounds")
+        materialize_all_rounds(db.session)
 
         # Simulate Injects
         num_injects = randint(5, 15)

--- a/bin/setup
+++ b/bin/setup
@@ -213,6 +213,10 @@ with app.app_context():
     logger.info("Creating the Inject Settings")
     db.session.add(Setting(name="inject_scores_visible", value=config.inject_scores_visible))
 
+    # Red-team flag scoring (flat points per captured flag by permission level)
+    db.session.add(Setting(name="flag_points_user", value=str(config.flag_points_user)))
+    db.session.add(Setting(name="flag_points_root", value=str(config.flag_points_root)))
+
     db.session.commit()
 
     if options.example:

--- a/bin/setup
+++ b/bin/setup
@@ -15,7 +15,7 @@ from scoring_engine.models.inject import Inject, InjectRubricScore, RubricItem, 
 from scoring_engine.models.notifications import Notification
 from scoring_engine.models.round import Round
 from scoring_engine.models.service import Service
-from scoring_engine.scores import materialize_all_rounds
+from scoring_engine.scores import materialize_all_rounds, recompute_consecutive_failures_cache
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
 from scoring_engine.models.announcement import Announcement
@@ -287,6 +287,11 @@ with app.app_context():
         # every team even though the checks exist.
         logger.info("Materializing round scores for the simulated rounds")
         materialize_all_rounds(db.session)
+
+        # Same reasoning for the SLA consecutive-failure cache the batched penalty
+        # read uses: the engine would maintain it, but example data skips it.
+        logger.info("Materializing SLA consecutive-failure cache")
+        recompute_consecutive_failures_cache(db.session)
 
         # Simulate Injects
         num_injects = randint(5, 15)

--- a/engine.conf.inc
+++ b/engine.conf.inc
@@ -120,3 +120,13 @@ inject_scores_visible = False
 # team's total; the compromised blue team's own score is not reduced.
 flag_points_user = 100
 flag_points_root = 200
+
+# Weighted Scoring
+# Rebalance how service uptime, injects, and flag captures combine into the
+# scoreboard total (e.g. dampen flags if they dominate, or make injects count
+# for more). Each weight is a multiplier; disabled means every weight is
+# effectively 1.0 and totals are unchanged.
+weighted_scoring_enabled = False
+service_weight = 1.0
+inject_weight = 1.0
+flag_weight = 1.0

--- a/engine.conf.inc
+++ b/engine.conf.inc
@@ -113,3 +113,10 @@ dynamic_scoring_late_multiplier = 0.5
 # Inject Score Visibility
 # Show inject scores on the public scoreboard (default: hidden for private grading)
 inject_scores_visible = False
+
+# Red-Team Flag Scoring
+# Flat points awarded to the red team per captured flag, by permission level.
+# A captured flag (a Solve reported by a blue team's agent) adds to the red
+# team's total; the compromised blue team's own score is not reduced.
+flag_points_user = 100
+flag_points_root = 200

--- a/scoring_engine/config_loader.py
+++ b/scoring_engine/config_loader.py
@@ -286,6 +286,30 @@ class ConfigLoader(object):
             "int",
         )
 
+        # Weighted scoring: rebalance how service uptime, injects, and flag
+        # captures contribute to the combined scoreboard total. Every weight is a
+        # multiplier (1.0 = no change); the whole feature is off unless enabled.
+        self.weighted_scoring_enabled = self.parse_sources(
+            "weighted_scoring_enabled",
+            self.parser["OPTIONS"].get("weighted_scoring_enabled", "false").lower() == "true",
+            "bool",
+        )
+        self.service_weight = self.parse_sources(
+            "service_weight",
+            float(self.parser["OPTIONS"].get("service_weight", "1.0")),
+            "float",
+        )
+        self.inject_weight = self.parse_sources(
+            "inject_weight",
+            float(self.parser["OPTIONS"].get("inject_weight", "1.0")),
+            "float",
+        )
+        self.flag_weight = self.parse_sources(
+            "flag_weight",
+            float(self.parser["OPTIONS"].get("flag_weight", "1.0")),
+            "float",
+        )
+
     def parse_sources(self, key_name, default_value, obj_type="str"):
         """Return a configuration value using environment overrides when present.
 

--- a/scoring_engine/config_loader.py
+++ b/scoring_engine/config_loader.py
@@ -274,6 +274,18 @@ class ConfigLoader(object):
             "bool",
         )
 
+        # Red-team flag scoring: flat points per captured flag by permission level.
+        self.flag_points_user = self.parse_sources(
+            "flag_points_user",
+            int(self.parser["OPTIONS"].get("flag_points_user", "100")),
+            "int",
+        )
+        self.flag_points_root = self.parse_sources(
+            "flag_points_root",
+            int(self.parser["OPTIONS"].get("flag_points_root", "200")),
+            "int",
+        )
+
     def parse_sources(self, key_name, default_value, obj_type="str"):
         """Return a configuration value using environment overrides when present.
 

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -27,6 +27,7 @@ from scoring_engine.models.check import Check
 from scoring_engine.models.environment import Environment
 from scoring_engine.models.kb import KB
 from scoring_engine.models.round import Round
+from scoring_engine.models.round_score import RoundScore
 from scoring_engine.models.property import Property
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
@@ -344,6 +345,12 @@ class Engine(object):
                     ]
                     if round_ids:
                         self.db.session.query(Check).filter(Check.round_id.in_(round_ids)).delete(
+                            synchronize_session=False
+                        )
+                        # Materialized scores are keyed by round; they must die with
+                        # the round or the scoreboard keeps ghost points for a round
+                        # that no longer exists.
+                        self.db.session.query(RoundScore).filter(RoundScore.round_id.in_(round_ids)).delete(
                             synchronize_session=False
                         )
                         self.db.session.query(Round).filter(Round.id.in_(round_ids)).delete(synchronize_session=False)
@@ -677,6 +684,14 @@ class Engine(object):
                 round_obj.round_end = round_end_time
                 self.db.session.commit()
                 logger.info("Database commit complete")
+
+                # Materialize per-team score facts for this round while its checks
+                # are fresh, in the same transaction boundary as the round itself.
+                # Reads consume these instead of re-scanning the full check history.
+                from scoring_engine.scores import materialize_round
+
+                rows_written = materialize_round(self.db.session, round_obj)
+                logger.info("Materialized round scores for %d team(s)", rows_written)
 
             except Exception as e:
                 # Something blew up part way through the round (most often a

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -31,6 +31,7 @@ from scoring_engine.models.round_score import RoundScore
 from scoring_engine.models.property import Property
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
+from scoring_engine.schedule import engine_should_run
 
 
 def _utcnow():
@@ -462,6 +463,18 @@ class Engine(object):
             if Setting.get_setting("engine_paused").value:
                 pause_duration = int(Setting.get_setting("pause_duration").value)
                 logger.info("Engine Paused. Sleeping for {0} seconds".format(pause_duration))
+                self.sleep(pause_duration)
+                continue
+
+            # Competition schedule: outside every configured window the engine
+            # idles rather than probing hosts that are powered down between
+            # competition days. This gates only the *next* round, so any in-flight
+            # round finishes and materializes first; the loop re-checks each cycle,
+            # so the engine resumes on its own when the next window opens. No
+            # windows configured means no schedule -- the engine always runs.
+            if not engine_should_run(_utcnow(), session=self.db.session):
+                pause_duration = int(Setting.get_setting("pause_duration").value)
+                logger.info("Outside competition window. Sleeping for {0} seconds".format(pause_duration))
                 self.sleep(pause_duration)
                 continue
 

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -357,6 +357,16 @@ class Engine(object):
                         row.id for row in self.db.session.query(Round.id).filter(Round.number == round_number).all()
                     ]
                     if round_ids:
+                        # Services touched by this round, captured before its checks
+                        # are deleted, so the consecutive-failure cache can be
+                        # repaired from the remaining history once they are gone.
+                        affected_service_ids = [
+                            row[0]
+                            for row in self.db.session.query(Check.service_id)
+                            .filter(Check.round_id.in_(round_ids))
+                            .distinct()
+                            .all()
+                        ]
                         self.db.session.query(Check).filter(Check.round_id.in_(round_ids)).delete(
                             synchronize_session=False
                         )
@@ -367,6 +377,15 @@ class Engine(object):
                             synchronize_session=False
                         )
                         self.db.session.query(Round).filter(Round.id.in_(round_ids)).delete(synchronize_session=False)
+                        # The deleted round's pass/fail no longer applies; rebuild
+                        # the consecutive-failure cache for the services it touched
+                        # from the remaining checks (rare path -- a scan is fine).
+                        if affected_service_ids:
+                            from scoring_engine.scores import recompute_consecutive_failures_cache
+
+                            recompute_consecutive_failures_cache(
+                                self.db.session, service_ids=affected_service_ids, commit=False
+                            )
                     kb_removed = (
                         self.db.session.query(KB)
                         .filter(KB.round_num == round_number, KB.name == "task_ids")
@@ -630,6 +649,11 @@ class Engine(object):
                 # as the checks -- no extra query, and nothing that would autoflush
                 # the pending checks early.
                 round_points = {}
+                # Per-service pass/fail for this round, accumulated in memory so
+                # the consecutive-failure cache can be updated in the same commit
+                # without querying the pending checks (which would autoflush them).
+                round_pass_ids = set()  # services with >=1 passing check this round
+                round_fail_counts = {}  # service id -> count of failing checks this round
                 processed_count = 0
                 for team_name, team_task_ids in task_ids.items():
                     for task_id in team_task_ids:
@@ -698,8 +722,11 @@ class Engine(object):
                             teams[environment.service.team.name]["Success"].append(environment.service.name)
                             team_id = environment.service.team_id
                             round_points[team_id] = round_points.get(team_id, 0) + environment.service.points
+                            round_pass_ids.add(environment.service.id)
                         else:
                             teams[environment.service.team.name]["Failed"].append(environment.service.name)
+                            sid = environment.service.id
+                            round_fail_counts[sid] = round_fail_counts.get(sid, 0) + 1
 
                         check = Check(service=environment.service, round=round_obj)
 
@@ -741,6 +768,17 @@ class Engine(object):
                     clear_existing=False,
                     commit=False,
                 )
+
+                # Fold this round's pass/fail into the materialized consecutive-
+                # failure cache in the SAME commit. no_autoflush keeps the pending
+                # checks from flushing early; the in-memory result sets mean no
+                # checks query runs here. A round that rolls back before the commit
+                # reverts these updates for free (they were never committed).
+                from scoring_engine.scores import apply_consecutive_failures
+
+                with self.db.session.no_autoflush:
+                    apply_consecutive_failures(self.db.session, round_pass_ids, round_fail_counts)
+
                 self.db.session.commit()
                 logger.info("Database commit complete; materialized round scores for %d team(s)", rows_written)
 

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -557,6 +557,13 @@ class Engine(object):
                 round_obj = Round(round_start=round_start_time, number=self.current_round)
                 self.db.session.add(round_obj)
                 self.db.session.commit()
+                # Capture the round's PK as a plain int now, while nothing is pending
+                # so the read is harmless. commit() above expired round_obj, and later
+                # reading any attribute off it (even the PK) reloads the row and
+                # autoflushes -- which, once checks are pending, would flush them
+                # ahead of the single round-close commit and defeat the failed-round
+                # handling. Use this int for materialization instead.
+                round_id = round_obj.id
 
                 # Pre-fetch all environments needed for result processing in one query
                 all_env_ids = list(set(task_env_map.values()))
@@ -593,6 +600,11 @@ class Engine(object):
                 # We keep track of the number of passed and failed checks per round
                 # so we can report a little bit at the end of each round
                 teams = {}
+                # Accumulate per-team service points for passing checks as we go, so
+                # the round_score rows can be written from memory in the same commit
+                # as the checks -- no extra query, and nothing that would autoflush
+                # the pending checks early.
+                round_points = {}
                 processed_count = 0
                 for team_name, team_task_ids in task_ids.items():
                     for task_id in team_task_ids:
@@ -659,6 +671,8 @@ class Engine(object):
                             }
                         if result:
                             teams[environment.service.team.name]["Success"].append(environment.service.name)
+                            team_id = environment.service.team_id
+                            round_points[team_id] = round_points.get(team_id, 0) + environment.service.points
                         else:
                             teams[environment.service.team.name]["Failed"].append(environment.service.name)
 
@@ -682,16 +696,28 @@ class Engine(object):
                 logger.info("Processed %d check results, committing to database", total_tasks)
                 round_end_time = datetime.now()
                 round_obj.round_end = round_end_time
-                self.db.session.commit()
-                logger.info("Database commit complete")
 
-                # Materialize per-team score facts for this round while its checks
-                # are fresh, in the same transaction boundary as the round itself.
-                # Reads consume these instead of re-scanning the full check history.
+                # Materialize per-team score facts from the sums accumulated above,
+                # staged into the SAME commit as the round's checks so a round and
+                # its scores become visible atomically. Passing the precomputed
+                # points (and clear_existing=False, since a fresh round has no prior
+                # rows) means no query runs here -- nothing autoflushes the pending
+                # checks ahead of this single commit.
                 from scoring_engine.scores import materialize_round
 
-                rows_written = materialize_round(self.db.session, round_obj)
-                logger.info("Materialized round scores for %d team(s)", rows_written)
+                # Use the round_id/current_round ints captured earlier -- reading an
+                # attribute off the (expired) round_obj here would autoflush the
+                # pending checks ahead of this single commit.
+                rows_written = materialize_round(
+                    self.db.session,
+                    round_id,
+                    self.current_round,
+                    points_by_team=round_points,
+                    clear_existing=False,
+                    commit=False,
+                )
+                self.db.session.commit()
+                logger.info("Database commit complete; materialized round scores for %d team(s)", rows_written)
 
             except Exception as e:
                 # Something blew up part way through the round (most often a

--- a/scoring_engine/engine/engine.py
+++ b/scoring_engine/engine/engine.py
@@ -8,7 +8,7 @@ import re
 import signal
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
 
@@ -31,6 +31,18 @@ from scoring_engine.models.round_score import RoundScore
 from scoring_engine.models.property import Property
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
+
+
+def _utcnow():
+    """Current time as a naive UTC datetime.
+
+    The round timestamps must be UTC to match how they are stored/compared
+    everywhere else (the round model default, the display localizers, and the
+    wall-clock scoreboard freeze all assume naive UTC). Plain ``datetime.now()``
+    is the container's *local* time, which only coincides with UTC when the
+    container clock happens to be UTC.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 def engine_sigint_handler(signum, frame, engine):
@@ -418,7 +430,7 @@ class Engine(object):
         except Exception:
             # The database is probably what failed in the first place.
             target_round_time = 60
-        round_delta = target_round_time - (datetime.now() - round_start_time).seconds
+        round_delta = target_round_time - (_utcnow() - round_start_time).seconds
         # The exponent is clamped as well as the result: with the bound
         # disabled the failure count is unbounded, and 2 ** (a few thousand) is
         # an expensive way to arrive at a number we are about to throw away.
@@ -465,7 +477,7 @@ class Engine(object):
 
             self.current_round += 1
             logger.info("Running round: " + str(self.current_round))
-            round_start_time = datetime.now()
+            round_start_time = _utcnow()
             self.round_running = True
             self.rounds_run += 1
 
@@ -694,7 +706,7 @@ class Engine(object):
                         )
                         self.db.session.add(check)
                 logger.info("Processed %d check results, committing to database", total_tasks)
-                round_end_time = datetime.now()
+                round_end_time = _utcnow()
                 round_obj.round_end = round_end_time
 
                 # Materialize per-team score facts from the sums accumulated above,
@@ -787,7 +799,7 @@ class Engine(object):
 
             if not self.is_last_round():
                 target_round_time = int(Setting.get_setting("target_round_time").value)
-                round_duration = (datetime.now() - round_start_time).seconds
+                round_duration = (_utcnow() - round_start_time).seconds
                 round_delta = target_round_time - round_duration
                 if round_delta > 0:
                     logger.info(

--- a/scoring_engine/models/__init__.py
+++ b/scoring_engine/models/__init__.py
@@ -7,6 +7,7 @@ from scoring_engine.models.kb import KB
 from scoring_engine.models.property import Property
 from scoring_engine.models.round import Round
 from scoring_engine.models.round_score import RoundScore
+from scoring_engine.models.score_adjustment import ScoreAdjustment
 from scoring_engine.models.service import Service
 from scoring_engine.models.team import Team
 from scoring_engine.models.user import User

--- a/scoring_engine/models/__init__.py
+++ b/scoring_engine/models/__init__.py
@@ -6,6 +6,7 @@ from scoring_engine.models.inject import Inject, InjectComment, InjectFile, Inje
 from scoring_engine.models.kb import KB
 from scoring_engine.models.property import Property
 from scoring_engine.models.round import Round
+from scoring_engine.models.round_score import RoundScore
 from scoring_engine.models.service import Service
 from scoring_engine.models.team import Team
 from scoring_engine.models.user import User

--- a/scoring_engine/models/__init__.py
+++ b/scoring_engine/models/__init__.py
@@ -1,5 +1,6 @@
 from scoring_engine.models.account import Account
 from scoring_engine.models.check import Check
+from scoring_engine.models.competition_window import CompetitionWindow
 from scoring_engine.models.environment import Environment
 from scoring_engine.models.announcement import Announcement
 from scoring_engine.models.inject import Inject, InjectComment, InjectFile, InjectRubricScore, RubricItem, Template

--- a/scoring_engine/models/check.py
+++ b/scoring_engine/models/check.py
@@ -26,6 +26,12 @@ class Check(Base):
         # api/overview.py num_up_services / num_down_services and
         # api/admin.py round stats: WHERE round_id = ? AND result = ?.
         Index("ix_checks_round_id_result", "round_id", "result"),
+        # scores.team_penalties (batched SLA): the last-passing-round MAX and the
+        # trailing-failure COUNT both group by service_id and filter on
+        # completed/result with a round_id bound. Ordering the columns as
+        # (service_id, completed, result, round_id) lets both run as index-only
+        # loose scans instead of scanning the whole (huge) checks table.
+        Index("ix_checks_sla_scan", "service_id", "completed", "result", "round_id"),
     )
     id = Column(Integer, primary_key=True)
     round_id = Column(Integer, ForeignKey("rounds.id"))

--- a/scoring_engine/models/competition_window.py
+++ b/scoring_engine/models/competition_window.py
@@ -1,0 +1,72 @@
+"""Scheduled competition windows (multi-day scheduling).
+
+A competition window is a ``[start_time, end_time)`` interval during which the
+engine is meant to be scoring. Between windows -- overnight, between competition
+days -- the engine idles instead of burning resources probing hosts that are
+powered down or firewalled off, and the public scoreboard freezes to the end of
+the last completed window.
+
+Semantics live in :mod:`scoring_engine.schedule`; this is just the storage:
+
+- Times are stored naive-UTC, exactly like ``rounds.round_end`` and the
+  ``scoreboard_freeze_time`` setting, so the engine's ``_utcnow()`` and the
+  read-time freeze comparisons all speak the same clock.
+- ``enabled`` lets an operator park a window (e.g. a cancelled day) without
+  losing the row.
+- **No rows means no schedule**, which is the historical behaviour: the engine
+  runs continuously and only the manual ``scoreboard_freeze_time`` freezes the
+  board. Scheduling is opt-in the moment the first window is added.
+"""
+
+import pytz
+from sqlalchemy import Boolean, Column, DateTime, Index, Integer, String
+
+from scoring_engine.config import config
+from scoring_engine.datetime_utils import ensure_utc_aware
+from scoring_engine.models.base import Base
+
+
+class CompetitionWindow(Base):
+    __tablename__ = "competition_window"
+    # The hot query is "windows ordered by start", asked on every scoreboard
+    # read (via the cached schedule) and every engine round boundary.
+    __table_args__ = (Index("ix_competition_window_start", "start_time"),)
+
+    id = Column(Integer, primary_key=True)
+    # Optional human label ("Day 1"); purely cosmetic for the admin list.
+    name = Column(String(255), nullable=True)
+    start_time = Column(DateTime, nullable=False)  # naive UTC
+    end_time = Column(DateTime, nullable=False)  # naive UTC
+    enabled = Column(Boolean, nullable=False, default=True)
+
+    def _localize(self, value):
+        return ensure_utc_aware(value).astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z")
+
+    @property
+    def local_start_time(self):
+        return self._localize(self.start_time)
+
+    @property
+    def local_end_time(self):
+        return self._localize(self.end_time)
+
+    def to_dict(self):
+        """Serialize for the admin API.
+
+        ``start_time`` / ``end_time`` are the raw naive-UTC ISO strings (what the
+        POST endpoint round-trips); ``*_display`` are pre-localized for the UI.
+        """
+        return {
+            "id": self.id,
+            "name": self.name,
+            "enabled": bool(self.enabled),
+            "start_time": self.start_time.isoformat() if self.start_time else None,
+            "end_time": self.end_time.isoformat() if self.end_time else None,
+            "start_display": self.local_start_time if self.start_time else None,
+            "end_display": self.local_end_time if self.end_time else None,
+        }
+
+    def __repr__(self):
+        return "<CompetitionWindow id={0} name={1} start={2} end={3} enabled={4}>".format(
+            self.id, self.name, self.start_time, self.end_time, self.enabled
+        )

--- a/scoring_engine/models/flag.py
+++ b/scoring_engine/models/flag.py
@@ -1,6 +1,7 @@
 import enum
 import html
 import uuid
+from datetime import datetime, timezone
 
 import pytz
 from sqlalchemy import JSON, Boolean, Column, DateTime, Enum, ForeignKey, Index, Integer, String, UniqueConstraint
@@ -94,5 +95,8 @@ class Solve(Base):
     host = Column(String(260), nullable=False)
     flag_id = Column(String(36), ForeignKey("flags.id"))
     team_id = Column(Integer, ForeignKey("teams.id"))
+    # When the capture was recorded. Basis for the wall-clock scoreboard freeze:
+    # a frozen view counts only solves created at/before the freeze time.
+    created_at = Column(DateTime, nullable=True, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
     flag = relationship("Flag", backref="solves", lazy="joined")
     team = relationship("Team", backref="flag_solves", lazy="joined")

--- a/scoring_engine/models/round_score.py
+++ b/scoring_engine/models/round_score.py
@@ -1,0 +1,57 @@
+"""Materialized per-team, per-round score facts.
+
+Written once by the engine when a round closes (see engine._materialize_round),
+and never updated afterwards -- a corrected round is rolled back and re-run, never
+patched in place. This is the fast-read fact table that replaces recomputing every
+team's total from the full ``checks`` history on every scoreboard render.
+
+Only components that are known at round close live here:
+
+- ``service_points``: raw uptime points earned this round (sum of ``Service.points``
+  for the team's passing checks). "Raw" is deliberate -- weights and the dynamic
+  per-round multiplier are policy an admin may tune mid-competition, so they are
+  applied at read time over these rows, not baked in.
+- ``flag_points``: red-team capture points attributable to this round. The column
+  exists now so the schema is complete, but it is populated as 0 until wave-2
+  phase 4 (red-team scoring) lands its config and read path.
+
+Rows are written only for teams that scored something (a missing ``(team, round)``
+means zero, and reads coalesce accordingly), which keeps the table small and keeps
+the live write path consistent with the historical backfill in migration 005.
+"""
+
+from sqlalchemy import Column, ForeignKey, Index, Integer, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from scoring_engine.models.base import Base
+
+
+class RoundScore(Base):
+    __tablename__ = "round_score"
+    __table_args__ = (
+        # One row per team per round. Guards the idempotent round-close write:
+        # a retried close cannot double-count.
+        UniqueConstraint("round_id", "team_id", name="_round_score_round_team_uc"),
+        # The hot read is "this team's points across rounds", keyed on the
+        # denormalized round_number so no join to rounds is needed.
+        Index("ix_round_score_team_round", "team_id", "round_number"),
+        # Freeze and rollback scan by round.
+        Index("ix_round_score_round_number", "round_number"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    round_id = Column(Integer, ForeignKey("rounds.id"), nullable=False)
+    # Denormalized copy of rounds.number: reads and freeze filters key on the
+    # number, not the id, and it is immutable once written.
+    round_number = Column(Integer, nullable=False)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=False)
+    service_points = Column(Integer, nullable=False, default=0)
+    flag_points = Column(Integer, nullable=False, default=0)
+
+    round = relationship("Round")
+    team = relationship("Team")
+
+    def __repr__(self):
+        return "<RoundScore team={0} round={1} service={2} flag={3}>".format(
+            self.team_id, self.round_number, self.service_points, self.flag_points
+        )

--- a/scoring_engine/models/score_adjustment.py
+++ b/scoring_engine/models/score_adjustment.py
@@ -1,0 +1,42 @@
+"""Manual, white-team score adjustments (wave 2, phase 5).
+
+An append-only audit log: a white-team member grants a bonus or applies a penalty
+to a team with a required reason. You never silently edit a competition score --
+to reverse an adjustment you add a compensating row, so the trail is complete.
+
+Kept separate from ``round_score`` because it is operator-authored (not engine
+materialized) and must survive a rollback of rounds by default (an operator ruling
+should not vanish when the engine rolls back service rounds). ``created_at`` is the
+basis for the wall-clock scoreboard freeze added in phase 6.
+"""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, Text
+from sqlalchemy.orm import relationship
+
+from scoring_engine.models.base import Base
+
+
+def _utcnow():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class ScoreAdjustment(Base):
+    __tablename__ = "score_adjustment"
+    __table_args__ = (Index("ix_score_adjustment_team_id", "team_id"),)
+
+    id = Column(Integer, primary_key=True)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=False)
+    # Signed: positive is a bonus, negative is a penalty.
+    points = Column(Integer, nullable=False)
+    reason = Column(Text, nullable=False)
+    # Who applied it (nullable so history survives a user deletion).
+    author_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=_utcnow)
+
+    team = relationship("Team")
+    author = relationship("User")
+
+    def __repr__(self):
+        return "<ScoreAdjustment team={0} points={1:+d}>".format(self.team_id, self.points)

--- a/scoring_engine/models/service.py
+++ b/scoring_engine/models/service.py
@@ -41,6 +41,13 @@ class Service(Base):
     host = Column(String(256), nullable=False)
     port = Column(Integer, default=0)
     worker_queue = Column(String(50), default="main")
+    # Materialized consecutive-failure count, maintained by the engine at round
+    # close (scores.apply_consecutive_failures). Read by the batched SLA penalty
+    # path (scores.team_penalties) so the scoreboard never scans the whole checks
+    # table. Kept in sync with the ``consecutive_failures`` property, which
+    # recomputes the same value from checks and stays the source of truth for the
+    # single-service paths and the equivalence test.
+    consecutive_failures_cache = Column(Integer, nullable=False, default=0, server_default="0")
 
     def check_result_for_round(self, round_num):
         """

--- a/scoring_engine/models/team.py
+++ b/scoring_engine/models/team.py
@@ -10,7 +10,6 @@ from scoring_engine.db import db
 from scoring_engine.models.base import Base
 from scoring_engine.models.check import Check
 
-
 # Curated palette: medium-saturation, medium-lightness colors that maintain
 # WCAG AA contrast (4.5:1) on both dark (#0a0a0a–#161616) and light
 # (#fafafa–#ffffff) backgrounds across all visual themes.
@@ -114,22 +113,14 @@ class Team(Base):
     @property
     def current_score(self):
         """
-        Calculate current score from successful checks.
-        WARNING: This performs a DB query on each access. Consider caching results
-        or using bulk queries when accessing scores for multiple teams.
+        Current raw service score, read from the materialized round_score table
+        instead of re-summing the full check history on every access. Identical in
+        value to the old ``SUM(Service.points) JOIN checks WHERE result`` -- the
+        engine writes one round_score row per team per round at round close.
         """
-        score = (
-            db.session.query(func.sum(Service.points))
-            .select_from(Team)
-            .join(Service)
-            .join(Check)
-            .filter(Service.team_id == self.id)
-            .filter(Check.result.is_(True))
-            .scalar()
-        )
-        if not score:
-            return 0
-        return score
+        from scoring_engine.scores import team_service_score
+
+        return team_service_score(db.session, self.id)
 
     @property
     def current_inject_score(self):
@@ -189,24 +180,88 @@ class Team(Base):
     # Adjectives and animals for anonymous team names
     # 50 adjectives × 30 animals = 1500 unique combinations
     _ADJECTIVES = [
-        "Swift", "Brave", "Mighty", "Silent", "Cunning",
-        "Bold", "Fierce", "Noble", "Stealthy", "Shadow",
-        "Iron", "Golden", "Crystal", "Storm", "Frost",
-        "Crimson", "Thunder", "Phantom", "Blazing", "Savage",
-        "Lunar", "Solar", "Cyber", "Primal", "Spectral",
-        "Ancient", "Emerald", "Sapphire", "Onyx", "Obsidian",
-        "Rapid", "Rogue", "Eternal", "Mystic", "Stealth",
-        "Elite", "Prime", "Alpha", "Omega", "Delta",
-        "Apex", "Neon", "Arctic", "Inferno", "Venom",
-        "Titan", "Dusk", "Tempest", "Wraith", "Chaos",
+        "Swift",
+        "Brave",
+        "Mighty",
+        "Silent",
+        "Cunning",
+        "Bold",
+        "Fierce",
+        "Noble",
+        "Stealthy",
+        "Shadow",
+        "Iron",
+        "Golden",
+        "Crystal",
+        "Storm",
+        "Frost",
+        "Crimson",
+        "Thunder",
+        "Phantom",
+        "Blazing",
+        "Savage",
+        "Lunar",
+        "Solar",
+        "Cyber",
+        "Primal",
+        "Spectral",
+        "Ancient",
+        "Emerald",
+        "Sapphire",
+        "Onyx",
+        "Obsidian",
+        "Rapid",
+        "Rogue",
+        "Eternal",
+        "Mystic",
+        "Stealth",
+        "Elite",
+        "Prime",
+        "Alpha",
+        "Omega",
+        "Delta",
+        "Apex",
+        "Neon",
+        "Arctic",
+        "Inferno",
+        "Venom",
+        "Titan",
+        "Dusk",
+        "Tempest",
+        "Wraith",
+        "Chaos",
     ]
     _ANIMALS = [
-        "Falcon", "Wolf", "Tiger", "Panther", "Eagle",
-        "Bear", "Lion", "Viper", "Phoenix", "Dragon",
-        "Hawk", "Cobra", "Raven", "Jaguar", "Shark",
-        "Lynx", "Scorpion", "Stallion", "Raptor", "Hydra",
-        "Griffin", "Serpent", "Kraken", "Mantis", "Barracuda",
-        "Wyvern", "Basilisk", "Chimera", "Sphinx", "Cerberus",
+        "Falcon",
+        "Wolf",
+        "Tiger",
+        "Panther",
+        "Eagle",
+        "Bear",
+        "Lion",
+        "Viper",
+        "Phoenix",
+        "Dragon",
+        "Hawk",
+        "Cobra",
+        "Raven",
+        "Jaguar",
+        "Shark",
+        "Lynx",
+        "Scorpion",
+        "Stallion",
+        "Raptor",
+        "Hydra",
+        "Griffin",
+        "Serpent",
+        "Kraken",
+        "Mantis",
+        "Barracuda",
+        "Wyvern",
+        "Basilisk",
+        "Chimera",
+        "Sphinx",
+        "Cerberus",
     ]
 
     @classmethod

--- a/scoring_engine/models/team.py
+++ b/scoring_engine/models/team.py
@@ -3,12 +3,11 @@ import itertools
 import random
 from collections import defaultdict
 
-from sqlalchemy import Column, Integer, String, desc, func
+from sqlalchemy import Column, Integer, String, func
 from sqlalchemy.orm import relationship
 
 from scoring_engine.db import db
 from scoring_engine.models.base import Base
-from scoring_engine.models.check import Check
 
 # Curated palette: medium-saturation, medium-lightness colors that maintain
 # WCAG AA contrast (4.5:1) on both dark (#0a0a0a–#161616) and light
@@ -52,7 +51,6 @@ _TEAM_COLORS = [
 _palette_index = 0
 from scoring_engine.models.inject import Inject, InjectRubricScore
 from scoring_engine.models.round import Round
-from scoring_engine.models.service import Service
 
 
 def _get_rank_from_scores(scores, target_id, default=1):
@@ -143,25 +141,16 @@ class Team(Base):
     @property
     def place(self):
         """
-        Calculate team's current place/rank based on scores.
-        WARNING: This queries ALL teams and their scores on EVERY access!
-        This is very expensive - avoid calling in loops or templates.
-        For bulk operations, calculate ranks once and cache/pass the results.
-        See scoring_engine/web/views/api/overview.py for an efficient batch implementation.
+        Calculate team's current place/rank based on raw service scores, read from
+        the materialized round_score table (no full-history scan). Ranking is by raw
+        points, matching the historical behaviour of this property.
+        WARNING: still O(all teams) per access -- avoid calling in loops or
+        templates. For bulk operations calculate ranks once; see
+        scoring_engine/web/views/api/overview.py for a batch implementation.
         """
-        scores = (
-            db.session.query(
-                Service.team_id,
-                func.sum(Service.points).label("score"),
-            )
-            .join(Check)
-            .filter(Check.result.is_(True))
-            .group_by(Service.team_id)
-            .order_by(desc("score"))
-            .all()
-        )
+        from scoring_engine.scores import all_team_service_scores
 
-        # Scores are already sorted descending by the query
+        scores = sorted(all_team_service_scores(db.session).items(), key=lambda kv: kv[1], reverse=True)
         # Returns 1 if no scores or team not in list
         return _get_rank_from_scores(scores, self.id, default=1)
 
@@ -317,50 +306,43 @@ class Team(Base):
         return mapping
 
     def get_array_of_scores(self, max_round):
-        round_scores = (
-            db.session.query(
-                Check.round_id,
-                func.sum(Service.points),
-            )
-            .join(Check)
-            .join(Round)
-            .filter(Service.team_id == self.id)
-            .filter(Check.result.is_(True))
-            .filter(Round.number <= max_round)
-            .group_by(Check.round_id)
+        """Cumulative raw service score at each round 0..max_round.
+
+        Reads per-round points from round_score, keyed on round_number. (The old
+        implementation grouped by round_id but filled the 0..max_round range with
+        round *numbers*, which only lined up when id == number; keying on
+        round_number is both correct and free of a full-history scan.)
+        """
+        from scoring_engine.models.round_score import RoundScore
+
+        rows = (
+            db.session.query(RoundScore.round_number, RoundScore.service_points)
+            .filter(RoundScore.team_id == self.id)
+            .filter(RoundScore.round_number <= max_round)
             .all()
         )
+        by_round = defaultdict(int)
+        for round_number, points in rows:
+            by_round[round_number] += points
 
-        # Create default dict with 0 as default round value
-        d = defaultdict(int)
-        for k, v in round_scores:
-            d[k] = v
-
-        # Loop over all rounds and add 0 if not present
-        # TODO - There has to be a better way to do this...
-        for i in range(0, max_round + 1):
-            d[i]
-
-        # Accumulate the scores for each round based on previous round
-        return list(itertools.accumulate([x[1] for x in sorted(d.items())]))
+        per_round = [by_round.get(i, 0) for i in range(0, max_round + 1)]
+        return list(itertools.accumulate(per_round))
 
     # TODO - Can this be deprecated, it only exists in tests
     def get_round_scores(self, round_num):
         if round_num == 0:
             return 0
 
+        from scoring_engine.models.round_score import RoundScore
+
         score = (
-            db.session.query(func.sum(Service.points))
-            .join(Check)
-            .join(Round)
-            .filter(Service.team_id == self.id)
-            .filter(Check.result.is_(True))
-            .filter(Round.number == round_num)
-            .group_by(Check.round_id)
+            db.session.query(func.coalesce(func.sum(RoundScore.service_points), 0))
+            .filter(RoundScore.team_id == self.id)
+            .filter(RoundScore.round_number == round_num)
             .scalar()
         )
 
-        return score if score else 0
+        return int(score) if score else 0
 
     @staticmethod
     def get_all_blue_teams():

--- a/scoring_engine/schedule.py
+++ b/scoring_engine/schedule.py
@@ -1,0 +1,147 @@
+"""Competition scheduling: when the engine runs and how the board freezes.
+
+Wraps the :class:`~scoring_engine.models.competition_window.CompetitionWindow`
+rows in the two decisions the rest of the system needs:
+
+- :func:`engine_should_run` -- gates the engine's round loop. Outside every
+  window the engine idles instead of probing hosts that are powered down between
+  competition days.
+- :func:`window_derived_freeze` -- the display freeze implied by the schedule.
+  Between windows the public scoreboard shows the final standings of the last
+  completed window; inside a window it is live. This composes with the manual
+  ``scoreboard_freeze_time`` (see :func:`scores.get_freeze_time`), which still
+  wins when an operator sets an explicit last-hour freeze.
+
+**No windows == no schedule == the historical behaviour**: the engine runs
+continuously and the schedule implies no freeze. Scheduling turns on the moment
+the first window exists.
+
+The window list is read on every scoreboard request and every engine round
+boundary, so it is cached in Redis (60s TTL, mirroring the settings cache) and
+invalidated on any window mutation via :func:`clear_windows_cache`.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+
+# Reuse the exact Redis client factory the settings cache uses, so schedule and
+# settings share connection behaviour and the "Redis disabled -> query the DB"
+# fallback (tests, cache_type != redis).
+from scoring_engine.models.setting import _get_redis
+
+logger = logging.getLogger(__name__)
+
+CACHE_KEY = "schedule:windows"
+CACHE_TTL = 60
+
+
+def _naive_utcnow():
+    """Current time as a naive-UTC datetime (matches how the engine stores times)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _query_windows(session=None):
+    """Enabled windows from the DB as ``{"id","name","start","end"}`` dicts, sorted."""
+    from scoring_engine.models.competition_window import CompetitionWindow
+
+    if session is None:
+        from scoring_engine.db import db
+
+        session = db.session
+    rows = (
+        session.query(CompetitionWindow)
+        .filter(CompetitionWindow.enabled.is_(True))
+        .order_by(CompetitionWindow.start_time)
+        .all()
+    )
+    return [{"id": w.id, "name": w.name, "start": w.start_time, "end": w.end_time} for w in rows]
+
+
+def _row_to_json(w):
+    return {"id": w["id"], "name": w["name"], "start": w["start"].isoformat(), "end": w["end"].isoformat()}
+
+
+def _row_from_json(d):
+    return {
+        "id": d["id"],
+        "name": d["name"],
+        "start": datetime.fromisoformat(d["start"]),
+        "end": datetime.fromisoformat(d["end"]),
+    }
+
+
+def get_windows(session=None):
+    """Return enabled competition windows, sorted by start (naive-UTC datetimes).
+
+    Redis-cached (60s) because the scoreboard read path asks for this per request.
+    On a cache miss -- or with Redis disabled -- it queries the DB directly.
+    Disabled windows are excluded; they exist only so an operator can park a
+    window without deleting it.
+    """
+    r = _get_redis()
+    if r is not None:
+        try:
+            cached = r.get(CACHE_KEY)
+            if cached is not None:
+                return [_row_from_json(row) for row in json.loads(cached)]
+        except Exception:
+            logger.debug("windows cache read failed", exc_info=True)
+
+    windows = _query_windows(session)
+
+    if r is not None:
+        try:
+            r.setex(CACHE_KEY, CACHE_TTL, json.dumps([_row_to_json(w) for w in windows]))
+        except Exception:
+            logger.debug("windows cache write failed", exc_info=True)
+    return windows
+
+
+def clear_windows_cache():
+    """Drop the cached window list. Call after any window create/update/delete."""
+    r = _get_redis()
+    if r is None:
+        return
+    try:
+        r.delete(CACHE_KEY)
+    except Exception:
+        logger.debug("windows cache clear failed", exc_info=True)
+
+
+def engine_should_run(now=None, session=None):
+    """Whether the engine should run a round right now.
+
+    No windows configured -> always ``True`` (historical always-on behaviour).
+    Otherwise ``True`` iff *now* falls inside some window (``start <= now < end``).
+    Half-open on the end so a round is never started exactly at a window's close.
+    """
+    windows = get_windows(session)
+    if not windows:
+        return True
+    if now is None:
+        now = _naive_utcnow()
+    return any(w["start"] <= now < w["end"] for w in windows)
+
+
+def window_derived_freeze(now=None, session=None):
+    """The display freeze implied by the schedule, or ``None``.
+
+    - No windows, or *now* inside a window -> ``None`` (board is live).
+    - *now* before the first window opens -> ``None`` (nothing scored yet, so the
+      board is trivially empty).
+    - Between/after windows -> the end of the last window that has already closed,
+      so the public board shows the last completed window's final standings and
+      nothing from the current gap.
+    """
+    windows = get_windows(session)
+    if not windows:
+        return None
+    if now is None:
+        now = _naive_utcnow()
+    if any(w["start"] <= now < w["end"] for w in windows):
+        return None
+    closed_ends = [w["end"] for w in windows if w["end"] <= now]
+    if not closed_ends:
+        return None  # before the competition's first window
+    return max(closed_ends)

--- a/scoring_engine/scores.py
+++ b/scoring_engine/scores.py
@@ -17,6 +17,7 @@ Per-service reads (``Service.score_earned``/``rank``) and SLA consecutive-failur
 detection still read ``checks`` directly -- round_score is team-grained.
 """
 
+from sqlalchemy import and_, case, or_
 from sqlalchemy.sql import func
 
 from scoring_engine.models.check import Check
@@ -302,6 +303,133 @@ def red_team_flag_total(session, user_points=None, root_points=None, freeze_time
     blue teams (a handful of red teams share this pool today).
     """
     return sum(flag_points_by_team(session, user_points, root_points, freeze_time=freeze_time).values())
+
+
+def _service_consecutive_failures(session):
+    """Return ``{service_id: consecutive_failures}`` for every service, batched.
+
+    Consecutive failures = the run of failing *completed* checks from the most
+    recent round backwards, i.e. the completed failures in rounds after the
+    service's last passing round (all completed failures if it never passed).
+    Equivalent to ``sla.get_consecutive_failures`` per service, in one grouped
+    query instead of one-query-per-service.
+    """
+    last_pass = (
+        session.query(Check.service_id.label("sid"), func.max(Check.round_id).label("lpr"))
+        .filter(Check.completed.is_(True))
+        .filter(Check.result.is_(True))
+        .group_by(Check.service_id)
+        .subquery()
+    )
+    rows = (
+        session.query(Check.service_id, func.count())
+        .outerjoin(last_pass, last_pass.c.sid == Check.service_id)
+        .filter(Check.completed.is_(True))
+        .filter(Check.result.is_(False))
+        .filter(or_(last_pass.c.lpr.is_(None), Check.round_id > last_pass.c.lpr))
+        .group_by(Check.service_id)
+        .all()
+    )
+    return {sid: count for sid, count in rows}
+
+
+def _service_base_scores(session, config, points_by_service, service_ids):
+    """Return ``{service_id: earned base score}`` for the given services, batched.
+
+    Only the services passed in ``service_ids`` are queried -- the caller has
+    already narrowed to the handful that are actually over the penalty threshold,
+    so this never scans the whole (large) checks table for the 99% of services
+    that carry no penalty.
+
+    Matches ``sla.calculate_service_base_score_with_dynamic`` exactly:
+
+    - non-dynamic: ``count(passing checks) * points`` (``Service.score_earned``).
+    - dynamic: ``sum(int(points * multiplier))`` per passing check, where the
+      multiplier is the round bucket (early/mid/late). Because the multiplier is
+      constant within a bucket, ``sum`` over a bucket equals
+      ``count_bucket * int(points * multiplier)`` -- which reproduces the
+      original per-check integer truncation without a non-portable SQL FLOOR.
+    """
+    if not service_ids:
+        return {}
+
+    if not config.dynamic_enabled:
+        rows = (
+            session.query(Check.service_id, func.count())
+            .filter(Check.result.is_(True))
+            .filter(Check.service_id.in_(service_ids))
+            .group_by(Check.service_id)
+            .all()
+        )
+        return {sid: count * points_by_service.get(sid, 0) for sid, count in rows}
+
+    from scoring_engine.models.round import Round
+
+    early, late = config.early_rounds, config.late_start_round
+    # Buckets mirror the original elif chain: <= early wins first, then >= late.
+    early_c = func.sum(case((Round.number <= early, 1), else_=0))
+    mid_c = func.sum(case((and_(Round.number > early, Round.number < late), 1), else_=0))
+    late_c = func.sum(case((and_(Round.number > early, Round.number >= late), 1), else_=0))
+    rows = (
+        session.query(Check.service_id, early_c, mid_c, late_c)
+        .join(Round, Round.id == Check.round_id)
+        .filter(Check.result.is_(True))
+        .filter(Check.service_id.in_(service_ids))
+        .group_by(Check.service_id)
+        .all()
+    )
+    scores = {}
+    for sid, e, m, ln in rows:
+        p = points_by_service.get(sid, 0)
+        # SUM() comes back as Decimal on MySQL/MariaDB (int on SQLite); coerce so
+        # the later ``base * (percent / 100)`` is plain int/float arithmetic.
+        e, m, ln = int(e or 0), int(m or 0), int(ln or 0)
+        scores[sid] = e * int(p * config.early_multiplier) + m * p + ln * int(p * config.late_multiplier)
+    return scores
+
+
+def team_penalties(session, config):
+    """Return ``{team_id: total_sla_penalty}`` for every team, batched.
+
+    Replaces the per-service ``sla.calculate_team_total_penalties`` loop -- which
+    issued two check queries for *every* service (~20k queries at 100 teams x 100
+    services) -- with a handful of grouped queries. Produces byte-identical
+    penalties (guarded by an equivalence test); teams with no penalty are absent.
+
+    Order matters for cost: consecutive failures are computed for all services
+    first, but the (expensive) earned-score scan is then run only for the services
+    actually over the penalty threshold -- typically a tiny fraction. A service
+    with no penalty never has its base score queried.
+
+    Deliberately not freeze-aware, matching the existing penalty path (the frozen
+    public scoreboard already shows live penalties).
+    """
+    if not config.sla_enabled:
+        return {}
+
+    from scoring_engine.sla import calculate_sla_penalty_percent
+
+    consecutive = _service_consecutive_failures(session)
+    percents = {}
+    for service_id, failures in consecutive.items():
+        percent = calculate_sla_penalty_percent(failures, config)
+        if percent > 0:
+            percents[service_id] = percent
+    if not percents:
+        return {}
+
+    penalized_ids = list(percents)
+    points_by_service = dict(session.query(Service.id, Service.points).filter(Service.id.in_(penalized_ids)).all())
+    base_scores = _service_base_scores(session, config, points_by_service, penalized_ids)
+    service_team = dict(session.query(Service.id, Service.team_id).filter(Service.id.in_(penalized_ids)).all())
+
+    penalties = {}
+    for service_id, percent in percents.items():
+        penalty = int(base_scores.get(service_id, 0) * (percent / 100))
+        if penalty:
+            team_id = service_team.get(service_id)
+            penalties[team_id] = penalties.get(team_id, 0) + penalty
+    return penalties
 
 
 def team_dynamic_service_score(session, team_id, sla_config):

--- a/scoring_engine/scores.py
+++ b/scoring_engine/scores.py
@@ -1,9 +1,17 @@
-"""Score materialization.
+"""Score materialization and reads.
 
 Wave 2 replaces recompute-from-full-history scoring with a per-round fact table
-(``round_score``). This module owns writing those rows. Read helpers that consume
-them land in phase 2; for now the only public entry point is
-:func:`materialize_round`, called by the engine when a round closes.
+(``round_score``). This module owns both sides of it:
+
+- Write: :func:`materialize_round` (called by the engine at round close) and
+  :func:`materialize_all_rounds` (backfill / non-engine contexts).
+- Read: :func:`team_service_scores` (all teams, for the scoreboard/overview),
+  :func:`team_service_score` (one team's raw total, backing ``Team.current_score``),
+  and :func:`team_dynamic_service_score` (one team, dynamic multiplier applied,
+  backing the SLA base). These replace the full-history ``JOIN checks`` scans.
+
+Per-service reads (``Service.score_earned``/``rank``) and SLA consecutive-failure
+detection still read ``checks`` directly -- round_score is team-grained.
 """
 
 from sqlalchemy.sql import func
@@ -82,3 +90,79 @@ def materialize_round(session, round_id, round_number, points_by_team=None, clea
     if commit:
         session.commit()
     return written
+
+
+def materialize_all_rounds(session, commit=True):
+    """(Re)materialize round_score for every round from the current checks.
+
+    Idempotent per round (clear-and-rewrite). The engine keeps round_score current
+    at round close in production; this is for backfill parity and for any context
+    that creates checks without the engine (tests, manual imports, a one-off
+    recompute after correcting historical data).
+    """
+    from scoring_engine.models.round import Round
+
+    total = 0
+    for round_id, round_number in session.query(Round.id, Round.number).all():
+        total += materialize_round(session, round_id, round_number, clear_existing=True, commit=False)
+    if commit:
+        session.commit()
+    return total
+
+
+def team_service_scores(session, sla_config=None):
+    """Return ``{team_id: service_score}`` for all teams, read from round_score.
+
+    Replaces the full-history ``SUM(Service.points) JOIN checks GROUP BY team``
+    scans on the scoreboard and overview. Dynamic scoring, when enabled, is applied
+    per round from the stored raw points and ``round_number`` -- exactly as the old
+    per-round path did -- so behaviour is unchanged.
+    """
+    from scoring_engine.sla import apply_dynamic_scoring_to_round, get_sla_config
+
+    if sla_config is None:
+        sla_config = get_sla_config()
+
+    if not sla_config.dynamic_enabled:
+        rows = session.query(RoundScore.team_id, func.sum(RoundScore.service_points)).group_by(RoundScore.team_id).all()
+        return {team_id: int(total or 0) for team_id, total in rows}
+
+    # Dynamic: each round_score row already holds a team's per-round total, so apply
+    # the multiplier per row keyed on the stored round_number.
+    scores = {}
+    rows = session.query(RoundScore.team_id, RoundScore.round_number, RoundScore.service_points).all()
+    for team_id, round_number, service_points in rows:
+        scores[team_id] = scores.get(team_id, 0) + apply_dynamic_scoring_to_round(
+            round_number, service_points, sla_config
+        )
+    return scores
+
+
+def team_service_score(session, team_id):
+    """Raw (un-weighted, un-multiplied) service score for one team from round_score.
+
+    Matches the historical semantics of ``Team.current_score`` -- callers that want
+    dynamic scoring go through :func:`team_service_scores`.
+    """
+    total = (
+        session.query(func.coalesce(func.sum(RoundScore.service_points), 0))
+        .filter(RoundScore.team_id == team_id)
+        .scalar()
+    )
+    return int(total or 0)
+
+
+def team_dynamic_service_score(session, team_id, sla_config):
+    """One team's service score with the dynamic multiplier applied per round.
+
+    Reads the team's per-round raw points from round_score and applies the
+    multiplier keyed on the stored round_number -- the same result as the old
+    full-history GROUP BY over checks.
+    """
+    from scoring_engine.sla import apply_dynamic_scoring_to_round
+
+    total = 0
+    rows = session.query(RoundScore.round_number, RoundScore.service_points).filter(RoundScore.team_id == team_id).all()
+    for round_number, service_points in rows:
+        total += apply_dynamic_scoring_to_round(round_number, service_points, sla_config)
+    return total

--- a/scoring_engine/scores.py
+++ b/scoring_engine/scores.py
@@ -1,0 +1,62 @@
+"""Score materialization.
+
+Wave 2 replaces recompute-from-full-history scoring with a per-round fact table
+(``round_score``). This module owns writing those rows. Read helpers that consume
+them land in phase 2; for now the only public entry point is
+:func:`materialize_round`, called by the engine when a round closes.
+"""
+
+from sqlalchemy.sql import func
+
+from scoring_engine.models.check import Check
+from scoring_engine.models.round_score import RoundScore
+from scoring_engine.models.service import Service
+
+
+def compute_round_service_points(session, round_id):
+    """Return ``{team_id: service_points}`` for a single round.
+
+    ``service_points`` is the sum of ``Service.points`` over the team's *passing*
+    checks in this round. Only teams with a non-zero total appear.
+    """
+    rows = (
+        session.query(Service.team_id, func.sum(Service.points))
+        .join(Check, Check.service_id == Service.id)
+        .filter(Check.round_id == round_id)
+        .filter(Check.result.is_(True))
+        .group_by(Service.team_id)
+        .all()
+    )
+    return {team_id: int(points or 0) for team_id, points in rows if points}
+
+
+def materialize_round(session, round_obj, commit=True):
+    """Write ``round_score`` rows for a freshly closed round.
+
+    Idempotent: safe to call again for the same round (any existing rows for it
+    are cleared first), so a retried round-close cannot double-count. Writes one
+    row per team that scored something this round; a team with zero simply has no
+    row, and reads coalesce a missing ``(team, round)`` to zero.
+
+    ``flag_points`` is written as 0 here -- red-team scoring (phase 4) will
+    populate it. The column exists so the schema is stable across phases.
+
+    Returns the number of rows written.
+    """
+    # Clear any prior rows for this round to stay idempotent under retry.
+    session.query(RoundScore).filter(RoundScore.round_id == round_obj.id).delete(synchronize_session=False)
+
+    points_by_team = compute_round_service_points(session, round_obj.id)
+    for team_id, service_points in points_by_team.items():
+        session.add(
+            RoundScore(
+                round_id=round_obj.id,
+                round_number=round_obj.number,
+                team_id=team_id,
+                service_points=service_points,
+                flag_points=0,
+            )
+        )
+    if commit:
+        session.commit()
+    return len(points_by_team)

--- a/scoring_engine/scores.py
+++ b/scoring_engine/scores.py
@@ -164,6 +164,33 @@ def team_service_score(session, team_id):
     return int(total or 0)
 
 
+def team_adjustment_totals(session):
+    """Return ``{team_id: net_adjustment_points}`` for every team with adjustments.
+
+    Sum of the signed manual adjustments (bonuses positive, penalties negative)
+    from the append-only score_adjustment log. Teams with no adjustments are absent
+    (reads coalesce to zero).
+    """
+    from scoring_engine.models.score_adjustment import ScoreAdjustment
+
+    rows = (
+        session.query(ScoreAdjustment.team_id, func.sum(ScoreAdjustment.points)).group_by(ScoreAdjustment.team_id).all()
+    )
+    return {team_id: int(total or 0) for team_id, total in rows}
+
+
+def team_adjustment_total(session, team_id):
+    """Net manual adjustment points for one team (0 if none)."""
+    from scoring_engine.models.score_adjustment import ScoreAdjustment
+
+    total = (
+        session.query(func.coalesce(func.sum(ScoreAdjustment.points), 0))
+        .filter(ScoreAdjustment.team_id == team_id)
+        .scalar()
+    )
+    return int(total or 0)
+
+
 def get_flag_point_values():
     """Return ``(user_points, root_points)`` for captured flags from settings.
 

--- a/scoring_engine/scores.py
+++ b/scoring_engine/scores.py
@@ -164,6 +164,64 @@ def team_service_score(session, team_id):
     return int(total or 0)
 
 
+def get_flag_point_values():
+    """Return ``(user_points, root_points)`` for captured flags from settings.
+
+    Admin-tunable mid-competition (like the SLA settings); falls back to the
+    documented defaults if a setting is missing or unparseable.
+    """
+    from scoring_engine.models.setting import Setting
+
+    def _int(name, default):
+        setting = Setting.get_setting(name)
+        try:
+            return int(setting.value) if setting else default
+        except (ValueError, TypeError):
+            return default
+
+    return _int("flag_points_user", 100), _int("flag_points_root", 200)
+
+
+def flag_points_by_team(session, user_points=None, root_points=None):
+    """Return ``{blue_team_id: captured_flag_value}`` -- each team's flag exposure.
+
+    A captured flag is a non-dummy ``Solve`` (a blue team's agent reported a red
+    flag present on one of its hosts). Each is worth ``root_points`` when the flag
+    is a root flag, else ``user_points``. This is the value the red team earns for
+    compromising that team; per the "add to red only" rule the blue team's own
+    score is unaffected.
+    """
+    from scoring_engine.models.flag import Flag, Solve
+
+    if user_points is None or root_points is None:
+        cfg_user, cfg_root = get_flag_point_values()
+        user_points = cfg_user if user_points is None else user_points
+        root_points = cfg_root if root_points is None else root_points
+
+    rows = (
+        session.query(Solve.team_id, Flag.perm, func.count())
+        .join(Flag, Flag.id == Solve.flag_id)
+        .filter(Flag.dummy.is_(False))
+        .group_by(Solve.team_id, Flag.perm)
+        .all()
+    )
+    result = {}
+    for team_id, perm, count in rows:
+        perm_value = perm.value if hasattr(perm, "value") else perm
+        points = root_points if perm_value == "root" else user_points
+        result[team_id] = result.get(team_id, 0) + points * count
+    return result
+
+
+def red_team_flag_total(session, user_points=None, root_points=None):
+    """Total red-team flag score: the sum of every blue team's captured-flag value.
+
+    The red team scores by compromising anyone, so its total is the sum across all
+    blue teams (a handful of red teams share this pool today).
+    """
+    return sum(flag_points_by_team(session, user_points, root_points).values())
+
+
 def team_dynamic_service_score(session, team_id, sla_config):
     """One team's service score with the dynamic multiplier applied per round.
 

--- a/scoring_engine/scores.py
+++ b/scoring_engine/scores.py
@@ -388,18 +388,92 @@ def _service_base_scores(session, config, points_by_service, service_ids):
     return scores
 
 
+def apply_consecutive_failures(session, pass_service_ids, fail_counts):
+    """Fold one round's results into ``Service.consecutive_failures_cache``.
+
+    Called by the engine at round close from the pass/fail results it already
+    holds in memory -- so it never queries the round's still-pending checks (which
+    would autoflush them ahead of the single atomic round commit). The caller
+    wraps this in ``session.no_autoflush`` and lets the round's own commit persist
+    the updates atomically with the checks and round_score.
+
+    A service that passed at least once this round resets to 0; a service that
+    only failed increments by its number of failing checks this round (the scan
+    counts per check, and round_score already scores multi-environment services
+    per check, so the streak does too).
+    """
+    from collections import defaultdict
+
+    if pass_service_ids:
+        session.query(Service).filter(Service.id.in_(list(pass_service_ids))).update(
+            {Service.consecutive_failures_cache: 0}, synchronize_session=False
+        )
+    # Group fail-only services by their increment so each distinct count is a
+    # single UPDATE (one UPDATE total in the common one-check-per-service case).
+    by_increment = defaultdict(list)
+    for service_id, count in fail_counts.items():
+        if service_id in pass_service_ids:
+            continue  # passed at least once -> already reset to 0
+        by_increment[count].append(service_id)
+    for increment, service_ids in by_increment.items():
+        session.query(Service).filter(Service.id.in_(service_ids)).update(
+            {Service.consecutive_failures_cache: Service.consecutive_failures_cache + increment},
+            synchronize_session=False,
+        )
+
+
+def recompute_consecutive_failures_cache(session, service_ids=None, commit=True):
+    """Recompute ``Service.consecutive_failures_cache`` from the checks table.
+
+    The authoritative slow path, for when the incremental in-memory maintenance
+    does not apply: backfill (migration / example data loaded without the engine)
+    and repair after a round is deleted (engine or admin rollback). Recomputes for
+    all services, or just ``service_ids``.
+    """
+    from collections import defaultdict
+
+    counts = _service_consecutive_failures(session)
+
+    target = session.query(Service.id)
+    if service_ids is not None:
+        target = target.filter(Service.id.in_(list(service_ids)))
+    target_ids = [sid for (sid,) in target.all()]
+    if not target_ids:
+        if commit:
+            session.commit()
+        return
+
+    # Reset the target set, then set the (few) services that have failures --
+    # grouped by value so it is a handful of UPDATEs, not one per service.
+    session.query(Service).filter(Service.id.in_(target_ids)).update(
+        {Service.consecutive_failures_cache: 0}, synchronize_session=False
+    )
+    target_set = set(target_ids)
+    by_value = defaultdict(list)
+    for service_id, failures in counts.items():
+        if failures and service_id in target_set:
+            by_value[failures].append(service_id)
+    for value, sids in by_value.items():
+        session.query(Service).filter(Service.id.in_(sids)).update(
+            {Service.consecutive_failures_cache: value}, synchronize_session=False
+        )
+    if commit:
+        session.commit()
+
+
 def team_penalties(session, config):
     """Return ``{team_id: total_sla_penalty}`` for every team, batched.
 
     Replaces the per-service ``sla.calculate_team_total_penalties`` loop -- which
     issued two check queries for *every* service (~20k queries at 100 teams x 100
-    services) -- with a handful of grouped queries. Produces byte-identical
-    penalties (guarded by an equivalence test); teams with no penalty are absent.
+    services) -- with a read that scans no checks at all for the failure counts:
+    they come from the materialized ``Service.consecutive_failures_cache`` (kept
+    current by the engine at round close). Produces byte-identical penalties
+    (guarded by an equivalence test); teams with no penalty are absent.
 
-    Order matters for cost: consecutive failures are computed for all services
-    first, but the (expensive) earned-score scan is then run only for the services
-    actually over the penalty threshold -- typically a tiny fraction. A service
-    with no penalty never has its base score queried.
+    The (small) earned-score scan then runs only for the services actually over
+    the penalty threshold -- typically a tiny fraction -- so a service with no
+    penalty never has its base score queried.
 
     Deliberately not freeze-aware, matching the existing penalty path (the frozen
     public scoreboard already shows live penalties).
@@ -409,25 +483,28 @@ def team_penalties(session, config):
 
     from scoring_engine.sla import calculate_sla_penalty_percent
 
-    consecutive = _service_consecutive_failures(session)
     percents = {}
-    for service_id, failures in consecutive.items():
-        percent = calculate_sla_penalty_percent(failures, config)
+    points_by_service = {}
+    team_by_service = {}
+    for service_id, team_id, points, failures in session.query(
+        Service.id, Service.team_id, Service.points, Service.consecutive_failures_cache
+    ).all():
+        percent = calculate_sla_penalty_percent(failures or 0, config)
         if percent > 0:
             percents[service_id] = percent
+            points_by_service[service_id] = points
+            team_by_service[service_id] = team_id
     if not percents:
         return {}
 
     penalized_ids = list(percents)
-    points_by_service = dict(session.query(Service.id, Service.points).filter(Service.id.in_(penalized_ids)).all())
     base_scores = _service_base_scores(session, config, points_by_service, penalized_ids)
-    service_team = dict(session.query(Service.id, Service.team_id).filter(Service.id.in_(penalized_ids)).all())
 
     penalties = {}
     for service_id, percent in percents.items():
         penalty = int(base_scores.get(service_id, 0) * (percent / 100))
         if penalty:
-            team_id = service_team.get(service_id)
+            team_id = team_by_service[service_id]
             penalties[team_id] = penalties.get(team_id, 0) + penalty
     return penalties
 

--- a/scoring_engine/scores.py
+++ b/scoring_engine/scores.py
@@ -30,33 +30,55 @@ def compute_round_service_points(session, round_id):
     return {team_id: int(points or 0) for team_id, points in rows if points}
 
 
-def materialize_round(session, round_obj, commit=True):
+def materialize_round(session, round_id, round_number, points_by_team=None, clear_existing=True, commit=True):
     """Write ``round_score`` rows for a freshly closed round.
 
-    Idempotent: safe to call again for the same round (any existing rows for it
-    are cleared first), so a retried round-close cannot double-count. Writes one
-    row per team that scored something this round; a team with zero simply has no
-    row, and reads coalesce a missing ``(team, round)`` to zero.
-
+    Writes one row per team that scored something this round; a team with zero
+    simply has no row, and reads coalesce a missing ``(team, round)`` to zero.
     ``flag_points`` is written as 0 here -- red-team scoring (phase 4) will
     populate it. The column exists so the schema is stable across phases.
 
+    Takes ``round_id`` / ``round_number`` as plain integers rather than a Round
+    object on purpose: the engine's Round was expired by its earlier commit, and
+    reading an expired ORM attribute here would trigger a refresh query that
+    autoflushes the round's still-pending checks ahead of the single round-close
+    commit -- breaking both atomicity and the engine's failure handling. Ints
+    can't do that.
+
+    Parameters
+    ----------
+    points_by_team : dict, optional
+        Precomputed ``{team_id: service_points}``. The engine passes the sums it
+        already accumulated while processing checks, so the common path runs no
+        query at all. When omitted (tests, backfill-equivalence), the sums are
+        queried from the checks for ``round_id``.
+    clear_existing : bool
+        Delete any prior rows for this round first, for idempotency under retry.
+        The engine passes ``False`` because a freshly created round has none, and
+        skipping the delete avoids an autoflush of the pending checks.
+
     Returns the number of rows written.
     """
-    # Clear any prior rows for this round to stay idempotent under retry.
-    session.query(RoundScore).filter(RoundScore.round_id == round_obj.id).delete(synchronize_session=False)
+    if clear_existing:
+        session.query(RoundScore).filter(RoundScore.round_id == round_id).delete(synchronize_session=False)
 
-    points_by_team = compute_round_service_points(session, round_obj.id)
+    if points_by_team is None:
+        points_by_team = compute_round_service_points(session, round_id)
+
+    written = 0
     for team_id, service_points in points_by_team.items():
+        if not service_points:
+            continue
         session.add(
             RoundScore(
-                round_id=round_obj.id,
-                round_number=round_obj.number,
+                round_id=round_id,
+                round_number=round_number,
                 team_id=team_id,
                 service_points=service_points,
                 flag_points=0,
             )
         )
+        written += 1
     if commit:
         session.commit()
-    return len(points_by_team)
+    return written

--- a/scoring_engine/scores.py
+++ b/scoring_engine/scores.py
@@ -24,6 +24,40 @@ from scoring_engine.models.round_score import RoundScore
 from scoring_engine.models.service import Service
 
 
+def get_freeze_time():
+    """Return the scoreboard freeze time as a naive-UTC datetime, or None.
+
+    Stored in the ``scoreboard_freeze_time`` setting as an ISO string (empty when
+    not frozen). Normalized to naive UTC to compare against the naive-UTC datetimes
+    the app stores (round_end, graded, created_at).
+    """
+    import pytz
+    from dateutil.parser import parse
+
+    from scoring_engine.models.setting import Setting
+
+    setting = Setting.get_setting("scoreboard_freeze_time")
+    value = setting.value if setting else None
+    if not value:
+        return None
+    try:
+        dt = parse(str(value))
+    except (ValueError, TypeError, OverflowError):
+        return None
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(pytz.utc).replace(tzinfo=None)
+    return dt
+
+
+def _round_freeze_filter(query, freeze_time):
+    """Restrict a round_score query to rounds that closed at/before the freeze."""
+    if freeze_time is None:
+        return query
+    from scoring_engine.models.round import Round
+
+    return query.join(Round, Round.id == RoundScore.round_id).filter(Round.round_end <= freeze_time)
+
+
 def compute_round_service_points(session, round_id):
     """Return ``{team_id: service_points}`` for a single round.
 
@@ -113,13 +147,16 @@ def materialize_all_rounds(session, commit=True):
     return total
 
 
-def team_service_scores(session, sla_config=None):
+def team_service_scores(session, sla_config=None, freeze_time=None):
     """Return ``{team_id: service_score}`` for all teams, read from round_score.
 
     Replaces the full-history ``SUM(Service.points) JOIN checks GROUP BY team``
     scans on the scoreboard and overview. Dynamic scoring, when enabled, is applied
     per round from the stored raw points and ``round_number`` -- exactly as the old
     per-round path did -- so behaviour is unchanged.
+
+    ``freeze_time`` (naive UTC) restricts the total to rounds that closed at/before
+    that instant -- the wall-clock scoreboard freeze.
     """
     from scoring_engine.sla import apply_dynamic_scoring_to_round, get_sla_config
 
@@ -127,55 +164,58 @@ def team_service_scores(session, sla_config=None):
         sla_config = get_sla_config()
 
     if not sla_config.dynamic_enabled:
-        return all_team_service_scores(session)
+        return all_team_service_scores(session, freeze_time=freeze_time)
 
     # Dynamic: each round_score row already holds a team's per-round total, so apply
     # the multiplier per row keyed on the stored round_number.
     scores = {}
-    rows = session.query(RoundScore.team_id, RoundScore.round_number, RoundScore.service_points).all()
-    for team_id, round_number, service_points in rows:
+    query = session.query(RoundScore.team_id, RoundScore.round_number, RoundScore.service_points)
+    query = _round_freeze_filter(query, freeze_time)
+    for team_id, round_number, service_points in query.all():
         scores[team_id] = scores.get(team_id, 0) + apply_dynamic_scoring_to_round(
             round_number, service_points, sla_config
         )
     return scores
 
 
-def all_team_service_scores(session):
+def all_team_service_scores(session, freeze_time=None):
     """Raw ``{team_id: service_score}`` for every team, no dynamic multiplier.
 
     Backs ``Team.place`` (raw ranking) and the non-dynamic branch of
-    :func:`team_service_scores`.
+    :func:`team_service_scores`. ``freeze_time`` restricts to rounds closed at/before
+    the freeze.
     """
-    rows = session.query(RoundScore.team_id, func.sum(RoundScore.service_points)).group_by(RoundScore.team_id).all()
+    query = session.query(RoundScore.team_id, func.sum(RoundScore.service_points))
+    query = _round_freeze_filter(query, freeze_time)
+    rows = query.group_by(RoundScore.team_id).all()
     return {team_id: int(total or 0) for team_id, total in rows}
 
 
-def team_service_score(session, team_id):
+def team_service_score(session, team_id, freeze_time=None):
     """Raw (un-weighted, un-multiplied) service score for one team from round_score.
 
     Matches the historical semantics of ``Team.current_score`` -- callers that want
     dynamic scoring go through :func:`team_service_scores`.
     """
-    total = (
-        session.query(func.coalesce(func.sum(RoundScore.service_points), 0))
-        .filter(RoundScore.team_id == team_id)
-        .scalar()
-    )
-    return int(total or 0)
+    query = session.query(func.coalesce(func.sum(RoundScore.service_points), 0)).filter(RoundScore.team_id == team_id)
+    query = _round_freeze_filter(query, freeze_time)
+    return int(query.scalar() or 0)
 
 
-def team_adjustment_totals(session):
+def team_adjustment_totals(session, freeze_time=None):
     """Return ``{team_id: net_adjustment_points}`` for every team with adjustments.
 
     Sum of the signed manual adjustments (bonuses positive, penalties negative)
     from the append-only score_adjustment log. Teams with no adjustments are absent
-    (reads coalesce to zero).
+    (reads coalesce to zero). ``freeze_time`` restricts to adjustments created
+    at/before the freeze.
     """
     from scoring_engine.models.score_adjustment import ScoreAdjustment
 
-    rows = (
-        session.query(ScoreAdjustment.team_id, func.sum(ScoreAdjustment.points)).group_by(ScoreAdjustment.team_id).all()
-    )
+    query = session.query(ScoreAdjustment.team_id, func.sum(ScoreAdjustment.points))
+    if freeze_time is not None:
+        query = query.filter(ScoreAdjustment.created_at <= freeze_time)
+    rows = query.group_by(ScoreAdjustment.team_id).all()
     return {team_id: int(total or 0) for team_id, total in rows}
 
 
@@ -209,14 +249,15 @@ def get_flag_point_values():
     return _int("flag_points_user", 100), _int("flag_points_root", 200)
 
 
-def flag_points_by_team(session, user_points=None, root_points=None):
+def flag_points_by_team(session, user_points=None, root_points=None, freeze_time=None):
     """Return ``{blue_team_id: captured_flag_value}`` -- each team's flag exposure.
 
     A captured flag is a non-dummy ``Solve`` (a blue team's agent reported a red
     flag present on one of its hosts). Each is worth ``root_points`` when the flag
     is a root flag, else ``user_points``. This is the value the red team earns for
     compromising that team; per the "add to red only" rule the blue team's own
-    score is unaffected.
+    score is unaffected. ``freeze_time`` restricts to solves recorded at/before the
+    freeze.
     """
     from scoring_engine.models.flag import Flag, Solve
 
@@ -225,13 +266,14 @@ def flag_points_by_team(session, user_points=None, root_points=None):
         user_points = cfg_user if user_points is None else user_points
         root_points = cfg_root if root_points is None else root_points
 
-    rows = (
+    query = (
         session.query(Solve.team_id, Flag.perm, func.count())
         .join(Flag, Flag.id == Solve.flag_id)
         .filter(Flag.dummy.is_(False))
-        .group_by(Solve.team_id, Flag.perm)
-        .all()
     )
+    if freeze_time is not None:
+        query = query.filter(Solve.created_at <= freeze_time)
+    rows = query.group_by(Solve.team_id, Flag.perm).all()
     result = {}
     for team_id, perm, count in rows:
         perm_value = perm.value if hasattr(perm, "value") else perm
@@ -240,13 +282,13 @@ def flag_points_by_team(session, user_points=None, root_points=None):
     return result
 
 
-def red_team_flag_total(session, user_points=None, root_points=None):
+def red_team_flag_total(session, user_points=None, root_points=None, freeze_time=None):
     """Total red-team flag score: the sum of every blue team's captured-flag value.
 
     The red team scores by compromising anyone, so its total is the sum across all
     blue teams (a handful of red teams share this pool today).
     """
-    return sum(flag_points_by_team(session, user_points, root_points).values())
+    return sum(flag_points_by_team(session, user_points, root_points, freeze_time=freeze_time).values())
 
 
 def team_dynamic_service_score(session, team_id, sla_config):

--- a/scoring_engine/scores.py
+++ b/scoring_engine/scores.py
@@ -5,10 +5,13 @@ Wave 2 replaces recompute-from-full-history scoring with a per-round fact table
 
 - Write: :func:`materialize_round` (called by the engine at round close) and
   :func:`materialize_all_rounds` (backfill / non-engine contexts).
-- Read: :func:`team_service_scores` (all teams, for the scoreboard/overview),
-  :func:`team_service_score` (one team's raw total, backing ``Team.current_score``),
-  and :func:`team_dynamic_service_score` (one team, dynamic multiplier applied,
-  backing the SLA base). These replace the full-history ``JOIN checks`` scans.
+- Read: :func:`team_service_scores` (all teams, dynamic-aware, for the
+  scoreboard/overview), :func:`all_team_service_scores` (all teams, raw, backing
+  ``Team.place``), :func:`team_service_score` (one team's raw total, backing
+  ``Team.current_score``), and :func:`team_dynamic_service_score` (one team,
+  dynamic multiplier applied, backing the SLA base). ``Team.get_array_of_scores`` /
+  ``get_round_scores`` and the scoreboard line chart also read round_score directly.
+  These replace the full-history ``JOIN checks`` scans.
 
 Per-service reads (``Service.score_earned``/``rank``) and SLA consecutive-failure
 detection still read ``checks`` directly -- round_score is team-grained.
@@ -124,8 +127,7 @@ def team_service_scores(session, sla_config=None):
         sla_config = get_sla_config()
 
     if not sla_config.dynamic_enabled:
-        rows = session.query(RoundScore.team_id, func.sum(RoundScore.service_points)).group_by(RoundScore.team_id).all()
-        return {team_id: int(total or 0) for team_id, total in rows}
+        return all_team_service_scores(session)
 
     # Dynamic: each round_score row already holds a team's per-round total, so apply
     # the multiplier per row keyed on the stored round_number.
@@ -136,6 +138,16 @@ def team_service_scores(session, sla_config=None):
             round_number, service_points, sla_config
         )
     return scores
+
+
+def all_team_service_scores(session):
+    """Raw ``{team_id: service_score}`` for every team, no dynamic multiplier.
+
+    Backs ``Team.place`` (raw ranking) and the non-dynamic branch of
+    :func:`team_service_scores`.
+    """
+    rows = session.query(RoundScore.team_id, func.sum(RoundScore.service_points)).group_by(RoundScore.team_id).all()
+    return {team_id: int(total or 0) for team_id, total in rows}
 
 
 def team_service_score(session, team_id):

--- a/scoring_engine/scores.py
+++ b/scoring_engine/scores.py
@@ -25,11 +25,19 @@ from scoring_engine.models.service import Service
 
 
 def get_freeze_time():
-    """Return the scoreboard freeze time as a naive-UTC datetime, or None.
+    """Return the effective scoreboard freeze time as a naive-UTC datetime, or None.
 
-    Stored in the ``scoreboard_freeze_time`` setting as an ISO string (empty when
-    not frozen). Normalized to naive UTC to compare against the naive-UTC datetimes
-    the app stores (round_end, graded, created_at).
+    Two sources, in precedence order:
+
+    1. The manual ``scoreboard_freeze_time`` setting (an ISO string; empty when
+       not set). This is the operator's explicit last-hour freeze and wins when
+       present -- it freezes the display while the engine keeps scoring.
+    2. Otherwise the schedule-derived freeze: between competition windows the
+       board shows the last completed window's standings (see
+       :func:`scoring_engine.schedule.window_derived_freeze`).
+
+    Normalized to naive UTC to compare against the naive-UTC datetimes the app
+    stores (round_end, graded, created_at).
     """
     import pytz
     from dateutil.parser import parse
@@ -38,15 +46,20 @@ def get_freeze_time():
 
     setting = Setting.get_setting("scoreboard_freeze_time")
     value = setting.value if setting else None
-    if not value:
-        return None
-    try:
-        dt = parse(str(value))
-    except (ValueError, TypeError, OverflowError):
-        return None
-    if dt.tzinfo is not None:
-        dt = dt.astimezone(pytz.utc).replace(tzinfo=None)
-    return dt
+    if value:
+        try:
+            dt = parse(str(value))
+        except (ValueError, TypeError, OverflowError):
+            dt = None
+        if dt is not None:
+            if dt.tzinfo is not None:
+                dt = dt.astimezone(pytz.utc).replace(tzinfo=None)
+            return dt
+
+    # No explicit freeze -- fall back to the competition schedule.
+    from scoring_engine.schedule import window_derived_freeze
+
+    return window_derived_freeze()
 
 
 def _round_freeze_filter(query, freeze_time):

--- a/scoring_engine/sla.py
+++ b/scoring_engine/sla.py
@@ -379,47 +379,12 @@ def calculate_team_base_score_with_dynamic(team, config=None):
     if not config.dynamic_enabled:
         return team.current_score
 
-    from sqlalchemy.sql import func
+    # Read per-round raw points from the materialized round_score table and apply
+    # the dynamic multiplier per round -- same result as the old full-history
+    # GROUP BY over checks, without the scan.
+    from scoring_engine.scores import team_dynamic_service_score
 
-    from scoring_engine.models.check import Check
-    from scoring_engine.models.round import Round
-    from scoring_engine.models.service import Service
-
-    # Single query with JOIN to get round scores with round numbers
-    # Previously queried ALL rounds which was very inefficient
-    round_scores = (
-        db.session.query(
-            Round.number,
-            func.sum(Service.points).label("round_score"),
-        )
-        .select_from(Check)
-        .join(Service, Check.service_id == Service.id)
-        .join(Round, Check.round_id == Round.id)
-        .filter(Service.team_id == team.id)
-        .filter(Check.result.is_(True))
-        .group_by(Round.number)
-        .all()
-    )
-
-    # Calculate total with multipliers
-    # Pre-fetch config values to avoid repeated attribute access in loop
-    total_score = 0
-    early_rounds = config.early_rounds
-    early_multiplier = config.early_multiplier
-    late_start = config.late_start_round
-    late_multiplier = config.late_multiplier
-
-    for round_number, round_score in round_scores:
-        # Inline multiplier calculation for performance
-        if round_number <= early_rounds:
-            multiplier = early_multiplier
-        elif round_number >= late_start:
-            multiplier = late_multiplier
-        else:
-            multiplier = 1.0
-        total_score += int(round_score * multiplier)
-
-    return total_score
+    return team_dynamic_service_score(db.session, team.id, config)
 
 
 def calculate_team_adjusted_score(team, config=None):

--- a/scoring_engine/sla.py
+++ b/scoring_engine/sla.py
@@ -38,6 +38,13 @@ class SLAConfig:
         self.late_start_round = self._get_int_setting("dynamic_scoring_late_start_round", 50)
         self.late_multiplier = self._get_float_setting("dynamic_scoring_late_multiplier", 0.5)
 
+        # Weighted scoring settings: multipliers that rebalance the service,
+        # inject, and flag contributions to the combined scoreboard total.
+        self.weighted_scoring_enabled = self._get_bool_setting("weighted_scoring_enabled", False)
+        self.service_weight = self._get_float_setting("service_weight", 1.0)
+        self.inject_weight = self._get_float_setting("inject_weight", 1.0)
+        self.flag_weight = self._get_float_setting("flag_weight", 1.0)
+
     def _get_setting(self, name, default):
         """Get a setting value from the database."""
         setting = Setting.get_setting(name)

--- a/scoring_engine/web/static/css/main.css
+++ b/scoring_engine/web/static/css/main.css
@@ -794,10 +794,29 @@ body.team-white .navbar-brand {
     border-color: var(--border);
 }
 
+/* Team-name headers stay on one line so a wide competition (many teams) scrolls
+   horizontally in its container rather than wrapping into unreadable rows. */
+.overview-matrix thead th {
+    white-space: nowrap;
+}
+
+/* Pin the label column (service names / metric rows) so it stays visible while
+   scrolling through the team columns. An opaque background keeps the scrolling
+   cells from showing through it. */
 .overview-matrix th:first-child,
 .overview-matrix td:first-child {
     text-align: left;
     padding-left: 1.25rem;
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    background: var(--surface);
+    border-right: 1px solid var(--border-strong);
+}
+
+.overview-matrix thead th:first-child {
+    z-index: 3;
+    background: var(--raised);
 }
 
 .overview-matrix thead th {

--- a/scoring_engine/web/templates/admin/adjustments.html
+++ b/scoring_engine/web/templates/admin/adjustments.html
@@ -1,0 +1,117 @@
+{% extends 'admin/adminbase.html' %}
+{% block title %}Admin - Score Adjustments{% endblock %}
+{% block head %}
+    {{ super() }}
+    <script src="{{ url_for('static', filename='vendor/js/dataTables.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='vendor/js/dataTables.bootstrap5.min.js') }}"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='vendor/css/dataTables.bootstrap5.min.css') }}" />
+{% endblock %}
+{% block header %}Score Adjustments{% endblock %}
+{% block admincontent %}
+
+  <div class="row mb-4">
+    <div class="col-md-5">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title text-center">Add Adjustment</h5>
+          <p class="text-muted small">
+            Bonuses and penalties are an append-only audit log. To reverse one, add a
+            compensating adjustment &mdash; there is no edit or delete.
+          </p>
+          <form id="adjustment-form" role="form">
+            <div class="mb-3">
+              <label class="form-label">Team</label>
+              <select class="form-select" name="team_id" id="teamSelect" required>
+                {% for team in teams %}
+                <option value="{{ team.id }}">{{ team.name }} ({{ team.color }})</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Points</label>
+              <input type="number" class="form-control" name="points" id="pointsInput"
+                     placeholder="e.g. 250 or -100" required>
+              <div class="form-text">Positive for a bonus, negative for a penalty.</div>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Reason</label>
+              <input type="text" class="form-control" name="reason" id="reasonInput"
+                     maxlength="1000" placeholder="Required" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Apply Adjustment</button>
+            <div id="adjustment-error" class="text-danger mt-2" role="alert"></div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h5>Adjustment Log</h5>
+  <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
+    <table id="adjustments" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>Team</th>
+          <th>Points</th>
+          <th>Reason</th>
+          <th>By</th>
+        </tr>
+      </thead>
+    </table>
+  </div>
+
+<script>
+$(document).ready(function () {
+  var table = $('#adjustments').DataTable({
+    ajax: '/api/admin/adjustments',
+    order: [[0, 'desc']],
+    columns: [
+      {
+        data: 'created_at',
+        render: function (data) {
+          return data ? new Date(data).toLocaleString() : '';
+        }
+      },
+      { data: 'team', render: ScoringEngineUtils.dtEscape() },
+      {
+        data: 'points',
+        render: function (data) {
+          var cls = data < 0 ? 'text-danger' : 'text-success';
+          var sign = data > 0 ? '+' : '';
+          return '<span class="' + cls + '">' + sign + data + '</span>';
+        }
+      },
+      { data: 'reason', render: ScoringEngineUtils.dtEscape() },
+      { data: 'author', render: ScoringEngineUtils.dtEscape() }
+    ]
+  });
+
+  $('#adjustment-form').on('submit', function (e) {
+    e.preventDefault();
+    $('#adjustment-error').text('');
+    var payload = {
+      team_id: $('#teamSelect').val(),
+      points: $('#pointsInput').val(),
+      reason: $('#reasonInput').val()
+    };
+    $.ajax({
+      url: '/api/admin/adjustments',
+      method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify(payload),
+      success: function () {
+        $('#pointsInput').val('');
+        $('#reasonInput').val('');
+        table.ajax.reload(null, false);
+      },
+      error: function (xhr) {
+        var msg = 'Error applying adjustment';
+        try { msg = xhr.responseJSON.message || msg; } catch (err) {}
+        $('#adjustment-error').text(msg);
+      }
+    });
+  });
+});
+</script>
+{% endblock %}

--- a/scoring_engine/web/templates/admin/adminbase.html
+++ b/scoring_engine/web/templates/admin/adminbase.html
@@ -24,6 +24,8 @@
             <i class="bi bi-gear"></i> Competition</a>
           <a href="/admin/sla" class="sidebar-link {% if request.path == '/admin/sla' %}active{% endif %}">
             <i class="bi bi-shield-check"></i> SLA & Scoring</a>
+          <a href="/admin/adjustments" class="sidebar-link {% if request.path == '/admin/adjustments' %}active{% endif %}">
+            <i class="bi bi-plus-slash-minus"></i> Score Adjustments</a>
           <a href="/admin/permissions" class="sidebar-link {% if request.path == '/admin/permissions' %}active{% endif %}">
             <i class="bi bi-lock"></i> Permissions</a>
           <a href="/admin/manage" class="sidebar-link {% if request.path == '/admin/manage' %}active{% endif %}">

--- a/scoring_engine/web/templates/admin/sla.html
+++ b/scoring_engine/web/templates/admin/sla.html
@@ -61,6 +61,103 @@
   });
   </script>
 
+  <!-- Competition Schedule (multi-day windows) -->
+  <h3 class="section-header">Competition Schedule</h3>
+  <div class="chart-card">
+    <p class="text-muted">
+      Define the windows during which the engine scores (competition timezone).
+      Outside every window the engine idles &mdash; no wasted checks between
+      competition days &mdash; and the public scoreboard freezes to the end of the
+      last completed window, while the white team keeps seeing live scores. With no
+      windows defined the engine runs continuously and only the manual freeze above
+      applies.
+    </p>
+    <div id="windows-list" class="mb-3"></div>
+    <form id="window-form" role="form" class="row g-2 align-items-end">
+      <div class="col-auto">
+        <label class="form-label">Label (optional)</label>
+        <input type="text" class="form-control" id="window-name" placeholder="Day 1">
+      </div>
+      <div class="col-auto">
+        <label class="form-label">Start (competition local time)</label>
+        <input type="datetime-local" step="1" class="form-control" id="window-start">
+      </div>
+      <div class="col-auto">
+        <label class="form-label">End (competition local time)</label>
+        <input type="datetime-local" step="1" class="form-control" id="window-end">
+      </div>
+      <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Add Window</button>
+      </div>
+      <div class="col-12"><div id="window-msg" class="small mt-1"></div></div>
+    </form>
+  </div>
+  <script>
+  $(function () {
+    function renderWindows(windows) {
+      if (!windows || !windows.length) {
+        $('#windows-list').html('<span class="badge bg-secondary">No schedule</span> ' +
+          '<span class="text-muted small">Engine runs continuously.</span>');
+        return;
+      }
+      var rows = windows.map(function (w) {
+        var label = w.name ? ScoringEngineUtils.escapeHtml(w.name) + ': ' : '';
+        var badge = w.enabled ? '<span class="badge bg-success">enabled</span>'
+                              : '<span class="badge bg-secondary">disabled</span>';
+        return '<tr data-id="' + w.id + '">' +
+          '<td>' + label + ScoringEngineUtils.escapeHtml(w.start_display) + ' &rarr; ' +
+            ScoringEngineUtils.escapeHtml(w.end_display) + '</td>' +
+          '<td>' + badge + '</td>' +
+          '<td class="text-end">' +
+            '<button type="button" class="btn btn-sm btn-outline-secondary window-toggle">' +
+              (w.enabled ? 'Disable' : 'Enable') + '</button> ' +
+            '<button type="button" class="btn btn-sm btn-outline-danger window-delete">Delete</button>' +
+          '</td></tr>';
+      }).join('');
+      $('#windows-list').html('<table class="table table-sm align-middle mb-0"><tbody>' + rows + '</tbody></table>');
+    }
+    function loadWindows() {
+      $.getJSON('/api/admin/windows', function (d) { renderWindows(d.windows); });
+    }
+    function showMsg(text, ok) {
+      $('#window-msg').removeClass('text-danger text-success')
+        .addClass(ok ? 'text-success' : 'text-danger').text(text);
+    }
+    $('#window-form').on('submit', function (e) {
+      e.preventDefault();
+      $('#window-msg').text('');
+      $.ajax({
+        url: '/api/admin/windows', method: 'POST', contentType: 'application/json',
+        data: JSON.stringify({
+          name: $('#window-name').val(),
+          start_time: $('#window-start').val(),
+          end_time: $('#window-end').val()
+        }),
+        success: function () {
+          showMsg('Window added.', true);
+          $('#window-name,#window-start,#window-end').val('');
+          loadWindows();
+        },
+        error: function (xhr) {
+          var m = 'Error'; try { m = xhr.responseJSON.message || m; } catch (e) {}
+          showMsg(m, false);
+        }
+      });
+    });
+    $('#windows-list').on('click', '.window-delete', function () {
+      var id = $(this).closest('tr').data('id');
+      $.ajax({ url: '/api/admin/windows/' + id, method: 'DELETE',
+        success: loadWindows, error: function () { showMsg('Delete failed.', false); } });
+    });
+    $('#windows-list').on('click', '.window-toggle', function () {
+      var id = $(this).closest('tr').data('id');
+      $.ajax({ url: '/api/admin/windows/' + id, method: 'PATCH',
+        success: loadWindows, error: function () { showMsg('Update failed.', false); } });
+    });
+    loadWindows();
+  });
+  </script>
+
   <!-- SLA Penalties Section -->
   <h3 class="section-header">SLA Penalty Configuration</h3>
   <div class="chart-card">

--- a/scoring_engine/web/templates/admin/sla.html
+++ b/scoring_engine/web/templates/admin/sla.html
@@ -9,6 +9,58 @@
 
 {% block admincontent %}
 <div class="pt-3">
+  <!-- Scoreboard Freeze -->
+  <h3 class="section-header">Scoreboard Freeze</h3>
+  <div class="chart-card">
+    <p class="text-muted">
+      Freeze the public scoreboard at a wall-clock time (competition timezone). Once
+      the freeze time passes, competitors see standings as of that instant while the
+      engine keeps scoring; the white team keeps seeing live scores. Clear the field
+      to unfreeze.
+    </p>
+    <div id="freeze-current" class="mb-2"></div>
+    <form id="freeze-form" role="form" class="row g-2 align-items-end">
+      <div class="col-auto">
+        <label class="form-label">Freeze at (competition local time)</label>
+        <input type="datetime-local" step="1" class="form-control" id="freeze-input">
+      </div>
+      <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Set Freeze</button>
+        <button type="button" class="btn btn-outline-secondary" id="freeze-clear">Clear</button>
+      </div>
+      <div class="col-12"><div id="freeze-msg" class="small mt-1"></div></div>
+    </form>
+  </div>
+  <script>
+  $(function () {
+    function loadFreeze() {
+      $.getJSON('/api/scoreboard/freeze_status', function (d) {
+        if (d && d.frozen) {
+          $('#freeze-current').html('<span class="badge bg-warning text-dark">Freeze set</span> ' +
+            ScoringEngineUtils.escapeHtml(d.freeze_display));
+        } else {
+          $('#freeze-current').html('<span class="badge bg-success">Not frozen</span>');
+        }
+      });
+    }
+    function post(freezeTime) {
+      $('#freeze-msg').text('');
+      $.ajax({
+        url: '/api/admin/freeze', method: 'POST', contentType: 'application/json',
+        data: JSON.stringify({ freeze_time: freezeTime }),
+        success: function () { $('#freeze-msg').removeClass('text-danger').addClass('text-success').text('Saved.'); loadFreeze(); },
+        error: function (xhr) {
+          var m = 'Error'; try { m = xhr.responseJSON.message || m; } catch (e) {}
+          $('#freeze-msg').removeClass('text-success').addClass('text-danger').text(m);
+        }
+      });
+    }
+    $('#freeze-form').on('submit', function (e) { e.preventDefault(); post($('#freeze-input').val()); });
+    $('#freeze-clear').on('click', function () { $('#freeze-input').val(''); post(''); });
+    loadFreeze();
+  });
+  </script>
+
   <!-- SLA Penalties Section -->
   <h3 class="section-header">SLA Penalty Configuration</h3>
   <div class="chart-card">

--- a/scoring_engine/web/templates/admin/sla.html
+++ b/scoring_engine/web/templates/admin/sla.html
@@ -158,6 +158,76 @@
   });
   </script>
 
+  <!-- Weighted Scoring -->
+  <h3 class="section-header">Weighted Scoring</h3>
+  <div class="chart-card">
+    <p class="text-muted">
+      Rebalance how the categories combine into each team's scoreboard total. Each
+      weight multiplies that category's contribution (1.0 = unchanged) &mdash; use it
+      to dampen a category that dominates or lift one that should count for more.
+      Service and inject weights scale the blue teams' combined total; the flag
+      weight scales the red team's flag total. Manual adjustments are never weighted.
+    </p>
+    <div id="weighted-msg" class="small mb-2"></div>
+    <form id="weighted-form" role="form" class="row g-3 align-items-end">
+      <div class="col-12">
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" id="weighted-enabled">
+          <label class="form-check-label" for="weighted-enabled">Enable weighted scoring</label>
+        </div>
+      </div>
+      <div class="col-auto">
+        <label class="form-label">Service weight</label>
+        <input type="number" step="0.1" min="0" class="form-control" id="weight-service">
+      </div>
+      <div class="col-auto">
+        <label class="form-label">Inject weight</label>
+        <input type="number" step="0.1" min="0" class="form-control" id="weight-inject">
+      </div>
+      <div class="col-auto">
+        <label class="form-label">Flag weight (red)</label>
+        <input type="number" step="0.1" min="0" class="form-control" id="weight-flag">
+      </div>
+      <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Save Weights</button>
+      </div>
+    </form>
+  </div>
+  <script>
+  $(function () {
+    function loadWeighted() {
+      $.getJSON('/api/admin/weighted_scoring', function (d) {
+        $('#weighted-enabled').prop('checked', !!d.enabled);
+        $('#weight-service').val(d.service_weight);
+        $('#weight-inject').val(d.inject_weight);
+        $('#weight-flag').val(d.flag_weight);
+      });
+    }
+    $('#weighted-form').on('submit', function (e) {
+      e.preventDefault();
+      $('#weighted-msg').text('');
+      $.ajax({
+        url: '/api/admin/weighted_scoring', method: 'POST', contentType: 'application/json',
+        data: JSON.stringify({
+          enabled: $('#weighted-enabled').is(':checked'),
+          service_weight: $('#weight-service').val(),
+          inject_weight: $('#weight-inject').val(),
+          flag_weight: $('#weight-flag').val()
+        }),
+        success: function () {
+          $('#weighted-msg').removeClass('text-danger').addClass('text-success').text('Saved.');
+          loadWeighted();
+        },
+        error: function (xhr) {
+          var m = 'Error'; try { m = xhr.responseJSON.message || m; } catch (e) {}
+          $('#weighted-msg').removeClass('text-success').addClass('text-danger').text(m);
+        }
+      });
+    });
+    loadWeighted();
+  });
+  </script>
+
   <!-- SLA Penalties Section -->
   <h3 class="section-header">SLA Penalty Configuration</h3>
   <div class="chart-card">

--- a/scoring_engine/web/templates/flags.html
+++ b/scoring_engine/web/templates/flags.html
@@ -8,6 +8,20 @@
 {% endblock %}
 {% block content %}
 <div class="page-wrap">
+    <h3 class="section-header">Red Team Flag Score</h3>
+    <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
+        <div class="stat-value" id="red-flag-total" style="font-size:2rem; font-weight:600;">-</div>
+        <p class="text-muted" id="red-flag-values" style="margin-bottom:1rem;"></p>
+        <table id="flag-score" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
+            <thead>
+                <tr>
+                    <th>Team</th>
+                    <th>Points Conceded</th>
+                </tr>
+            </thead>
+        </table>
+    </div>
+
     <h3 class="section-header">Active Flags</h3>
     <div class="chart-card" style="padding:1rem 1.25rem; overflow:hidden;">
         <table id="flags" class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
@@ -54,6 +68,24 @@
 </div>
 <script>
 $(document).ready(function() {
+  // Red team flag score (config-driven; total plus per-blue-team breakdown)
+  $('#flag-score').DataTable({
+    ajax: '/api/flags/score',
+    order: [[1, 'desc']],
+    columns: [
+      { data: 'team', render: ScoringEngineUtils.dtEscape() },
+      { data: 'points' }
+    ],
+  });
+  $.ajax({
+    url: '/api/flags/score',
+    success: function(response) {
+      ScoringEngineUtils.setText(document.getElementById('red-flag-total'), response.red_total);
+      document.getElementById('red-flag-values').textContent =
+        'user flag: ' + response.points.user + ' pts, root flag: ' + response.points.root + ' pts';
+    }
+  });
+
   $('#flags').DataTable( {
       ajax: '/api/flags',
       order: [[1, 'asc']],

--- a/scoring_engine/web/templates/overview.html
+++ b/scoring_engine/web/templates/overview.html
@@ -43,7 +43,7 @@
 
     <!-- Service Status Matrix -->
     <h3 class="section-header">Service Status</h3>
-    <div class="chart-card animate-in" style="padding:0; overflow:hidden; animation-delay:200ms;">
+    <div class="chart-card animate-in" style="padding:0; overflow-x:auto; animation-delay:200ms;">
         <table id="overview" class="table table-sm overview-matrix">
             <thead>
                 <tr id="overview-header">
@@ -97,13 +97,17 @@
             return '<td>' + value + medal + '</td>';
         }
 
-        if (rowLabel === 'Up/Down Ratio') {
-            var up = (value && value.up) || 0;
-            var down = (value && value.down) || 0;
-            return '<td>'
-                + '<span class="text-success">' + up + ' <i class="bi bi-arrow-up"></i></span> / '
-                + '<span class="text-danger">' + down + ' <i class="bi bi-arrow-down"></i></span>'
-                + '</td>';
+        if (rowLabel === 'Services Up') {
+            var up = parseInt(value) || 0;
+            return '<td><span class="text-success">' + up + ' <i class="bi bi-arrow-up"></i></span></td>';
+        }
+
+        if (rowLabel === 'Services Down') {
+            var down = parseInt(value) || 0;
+            if (down > 0) {
+                return '<td><span class="text-danger">' + down + ' <i class="bi bi-arrow-down"></i></span></td>';
+            }
+            return '<td><span class="text-muted">0</span></td>';
         }
 
         if (rowLabel === 'SLA Penalties') {
@@ -146,7 +150,7 @@
             var rows = json.data || [];
             _serviceIds = json.service_ids || null;
             var html = '';
-            var metaRows = ['Current Score', 'Current Place', 'SLA Penalties', 'Up/Down Ratio'];
+            var metaRows = ['Current Score', 'Current Place', 'SLA Penalties', 'Services Up', 'Services Down'];
             var serviceRowIndex = 0;
 
             for (var r = 0; r < rows.length; r++) {

--- a/scoring_engine/web/templates/scoreboard.html
+++ b/scoring_engine/web/templates/scoreboard.html
@@ -16,6 +16,16 @@
         </div>
     </div>
 
+    <!-- Scoreboard freeze banner (hidden unless a freeze is set) -->
+    <div id="sc-freeze-banner" class="alert alert-warning d-none" role="status"
+         style="display:flex; align-items:center; gap:.6rem;">
+        <i class="bi bi-snow2" style="font-size:1.3rem;"></i>
+        <div>
+            <strong id="sc-freeze-headline"></strong>
+            <div class="small" id="sc-freeze-detail"></div>
+        </div>
+    </div>
+
     <!-- Stat Cards -->
     <div class="stat-cards-row">
         <div class="stat-card animate-in">
@@ -315,6 +325,61 @@
             });
         });
         observer.observe(document.documentElement, { attributes: true });
+    </script>
+
+    <script>
+    // Scoreboard freeze banner + countdown. The countdown is driven off the
+    // server's clock (freeze_epoch vs server_epoch) plus elapsed browser time, so
+    // it stays correct even if the viewer's clock or timezone is wrong -- which is
+    // exactly the case a countdown is meant to make easy to sanity-check.
+    (function () {
+      var banner = document.getElementById('sc-freeze-banner');
+      var headline = document.getElementById('sc-freeze-headline');
+      var detail = document.getElementById('sc-freeze-detail');
+      var state = null;       // {freeze_epoch, server_epoch, freeze_display, white_live}
+      var fetchedAt = null;   // browser ms when we got `state`
+
+      function fmt(sec) {
+        sec = Math.max(0, Math.floor(sec));
+        var h = Math.floor(sec / 3600), m = Math.floor((sec % 3600) / 60), s = sec % 60;
+        var p = function (n) { return (n < 10 ? '0' : '') + n; };
+        return (h > 0 ? h + 'h ' : '') + p(m) + 'm ' + p(s) + 's';
+      }
+
+      function render() {
+        if (!state) { banner.classList.add('d-none'); return; }
+        banner.classList.remove('d-none');
+        // server "now" = server_epoch at fetch + elapsed browser time since fetch
+        var serverNow = state.server_epoch + (Date.now() - fetchedAt) / 1000;
+        var remaining = state.freeze_epoch - serverNow;
+        if (remaining > 0) {
+          headline.textContent = 'Scoreboard freezes in ' + fmt(remaining);
+          detail.textContent = 'at ' + state.freeze_display
+            + (state.white_live ? ' — you (white team) will keep seeing live scores' : '');
+        } else {
+          headline.textContent = state.white_live
+            ? 'Scoreboard is FROZEN for competitors (you see live)'
+            : 'Scoreboard is FROZEN';
+          detail.textContent = 'Standings shown as of ' + state.freeze_display;
+        }
+      }
+
+      function refresh() {
+        // csrf-safe: read only
+        fetch('/api/scoreboard/freeze_status', { credentials: 'same-origin' })
+          .then(function (r) { return r.json(); })
+          .then(function (d) {
+            state = d && d.frozen ? d : null;
+            fetchedAt = Date.now();
+            render();
+          })
+          .catch(function () { /* leave last state */ });
+      }
+
+      refresh();
+      setInterval(render, 1000);   // tick the countdown
+      setInterval(refresh, 30000); // pick up admin set/clear
+    })();
     </script>
 </div>
 {% endblock %}

--- a/scoring_engine/web/templates/scoreboard.html
+++ b/scoring_engine/web/templates/scoreboard.html
@@ -168,6 +168,8 @@
                     backgroundColor: 'transparent',
                     tooltip: {
                         trigger: 'axis',
+                        confine: true,
+                        appendToBody: true,
                         axisPointer: { type: 'shadow' },
                         formatter: function(params) {
                             var idx = params[0].dataIndex;
@@ -248,7 +250,9 @@
                 teamLineChart.hideLoading();
                 teamLineChart.setOption({
                     backgroundColor: 'transparent',
-                    tooltip: { trigger: 'axis' },
+                    // appendToBody escapes the chart card's overflow:hidden (which
+                    // otherwise clips the tooltip); confine keeps it inside the window.
+                    tooltip: { trigger: 'axis', confine: true, appendToBody: true },
                     grid: {
                         left: '3%',
                         right: '4%',

--- a/scoring_engine/web/views/admin.py
+++ b/scoring_engine/web/views/admin.py
@@ -181,6 +181,16 @@ def announcements():
         return redirect(url_for("auth.unauthorized"))
 
 
+@mod.route("/admin/adjustments")
+@login_required
+def adjustments():
+    if current_user.is_white_team:
+        teams = db.session.query(Team).filter(Team.color != "White").order_by(Team.name).all()
+        return render_template("admin/adjustments.html", teams=teams)
+    else:
+        return redirect(url_for("auth.unauthorized"))
+
+
 @mod.route("/admin/welcome")
 @login_required
 def welcome():

--- a/scoring_engine/web/views/api/__init__.py
+++ b/scoring_engine/web/views/api/__init__.py
@@ -24,6 +24,23 @@ def make_cache_key(*args, **kwargs):
     return f"{request_path}_team_{g.user.team.id}"
 
 
+def get_effective_freeze():
+    """Return ``(frozen_view, freeze_time)`` for the current viewer.
+
+    The scoreboard freeze is wall-clock. When ``scoreboard_freeze_time`` is set,
+    every viewer EXCEPT the white team sees the standings frozen at that instant;
+    the white team always sees live numbers (with a banner in the UI). Returns
+    ``(False, None)`` when not frozen or when the viewer is white.
+    """
+    from scoring_engine.scores import get_freeze_time
+
+    freeze_time = get_freeze_time()
+    is_white = current_user.is_authenticated and current_user.is_white_team
+    if freeze_time is None or is_white:
+        return False, None
+    return True, freeze_time
+
+
 mod = Blueprint("api", __name__)
 
 
@@ -55,4 +72,18 @@ def events_token():
     return jsonify({"token": token})
 
 
-from . import admin, agent, announcements, flags, injects, notifications, overview, profile, scoreboard, service, sla, stats, team
+from . import (
+    admin,
+    agent,
+    announcements,
+    flags,
+    injects,
+    notifications,
+    overview,
+    profile,
+    scoreboard,
+    service,
+    sla,
+    stats,
+    team,
+)

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1942,3 +1942,75 @@ def admin_delete_window(window_id):
     db.session.commit()
     _refresh_after_window_change()
     return jsonify({"status": "success"})
+
+
+def _upsert_setting(name, value):
+    """Set a setting, creating the row if a pre-feature DB never seeded it."""
+    setting = Setting.get_setting(name)
+    if setting is None:
+        setting = Setting(name=name, value=value)
+    else:
+        setting.value = value
+    db.session.add(setting)
+    db.session.commit()
+    Setting.clear_cache(name)
+
+
+@mod.route("/api/admin/weighted_scoring", methods=["GET"])
+@login_required
+def admin_get_weighted_scoring():
+    """Return the current weighted-scoring configuration (white team only)."""
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+
+    def _float(name, default):
+        setting = Setting.get_setting(name)
+        try:
+            return float(setting.value) if setting else default
+        except (ValueError, TypeError):
+            return default
+
+    enabled = Setting.get_setting("weighted_scoring_enabled")
+    return jsonify(
+        enabled=bool(enabled.value) if enabled else False,
+        service_weight=_float("service_weight", 1.0),
+        inject_weight=_float("inject_weight", 1.0),
+        flag_weight=_float("flag_weight", 1.0),
+    )
+
+
+@mod.route("/api/admin/weighted_scoring", methods=["POST"])
+@login_required
+def admin_set_weighted_scoring():
+    """Set weighted-scoring configuration (white team only).
+
+    Accepts ``enabled`` (bool) and ``service_weight`` / ``inject_weight`` /
+    ``flag_weight`` (numbers >= 0). Absent fields are left unchanged; a present
+    weight that is negative or unparseable is rejected.
+    """
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+
+    data = request.get_json(silent=True) or request.form
+
+    if "enabled" in data:
+        raw = data.get("enabled")
+        _upsert_setting("weighted_scoring_enabled", raw is True or str(raw).lower() in ("true", "1", "on", "yes"))
+
+    for name in ("service_weight", "inject_weight", "flag_weight"):
+        if name in data:
+            try:
+                weight = float(data[name])
+            except (ValueError, TypeError):
+                return jsonify({"status": "error", "message": f"{name} must be a number"}), 400
+            if weight < 0:
+                return jsonify({"status": "error", "message": f"{name} must be >= 0"}), 400
+            _upsert_setting(name, str(weight))
+
+    # Weights change every team's combined total and the red flag total.
+    update_scoreboard_data()
+    update_overview_data()
+    update_flags_data()
+    publish_event("settings_changed", {"setting": "weighted_scoring"})
+
+    return jsonify({"status": "success"})

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -40,6 +40,7 @@ from scoring_engine.models.kb import KB
 from scoring_engine.models.property import Property
 from scoring_engine.models.round import Round
 from scoring_engine.models.round_score import RoundScore
+from scoring_engine.models.score_adjustment import ScoreAdjustment
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
@@ -1551,9 +1552,12 @@ def admin_rollback():
         return jsonify({"status": "error", "message": "No rounds exist to rollback"}), 400
 
     if round_number > current_round:
-        return jsonify(
-            {"status": "error", "message": f"round_number ({round_number}) exceeds current round ({current_round})"}
-        ), 400
+        return (
+            jsonify(
+                {"status": "error", "message": f"round_number ({round_number}) exceeds current round ({current_round})"}
+            ),
+            400,
+        )
 
     # Pause the engine to prevent race conditions during rollback
     was_paused = Setting.get_setting("engine_paused").value
@@ -1568,11 +1572,7 @@ def admin_rollback():
 
     try:
         # Revoke any pending Celery tasks for rounds being rolled back
-        task_kb_entries = (
-            db.session.query(KB)
-            .filter(KB.round_num >= round_number, KB.name == "task_ids")
-            .all()
-        )
+        task_kb_entries = db.session.query(KB).filter(KB.round_num >= round_number, KB.name == "task_ids").all()
         revoked_count = 0
         for kb_entry in task_kb_entries:
             try:
@@ -1707,4 +1707,78 @@ def admin_rollback_preview():
                 "round_scores": round_scores_count,
             },
         }
+    )
+
+
+@mod.route("/api/admin/adjustments", methods=["GET"])
+@login_required
+def admin_get_adjustments():
+    """List all manual score adjustments (append-only audit log), newest first."""
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+
+    rows = (
+        db.session.query(ScoreAdjustment).order_by(ScoreAdjustment.created_at.desc(), ScoreAdjustment.id.desc()).all()
+    )
+    data = [
+        {
+            "id": adj.id,
+            "team": adj.team.name if adj.team else None,
+            "team_id": adj.team_id,
+            "points": adj.points,
+            "reason": adj.reason,
+            "author": adj.author.username if adj.author else None,
+            "created_at": ensure_utc_aware(adj.created_at).isoformat() if adj.created_at else None,
+        }
+        for adj in rows
+    ]
+    return jsonify(data=data)
+
+
+@mod.route("/api/admin/adjustments", methods=["POST"])
+@login_required
+def admin_create_adjustment():
+    """Create a manual score adjustment (bonus or penalty) for a team.
+
+    Append-only: there is no edit or delete. To reverse an adjustment, add a
+    compensating one, so the audit trail stays complete.
+    """
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+
+    data = request.get_json(silent=True) or request.form
+    team_id = data.get("team_id")
+    points = data.get("points")
+    reason = (data.get("reason") or "").strip()
+
+    if team_id is None or points is None or not reason:
+        return jsonify({"status": "error", "message": "team_id, points, and reason are required"}), 400
+    try:
+        team_id = int(team_id)
+        points = int(points)
+    except (ValueError, TypeError):
+        return jsonify({"status": "error", "message": "team_id and points must be integers"}), 400
+
+    team = db.session.get(Team, team_id)
+    if team is None:
+        return jsonify({"status": "error", "message": "Team not found"}), 404
+
+    adjustment = ScoreAdjustment(team_id=team_id, points=points, reason=reason, author_id=current_user.id)
+    db.session.add(adjustment)
+    db.session.commit()
+
+    # The team's total changed; refresh the scoreboard caches.
+    update_scoreboard_data()
+
+    return (
+        jsonify(
+            {
+                "status": "success",
+                "id": adjustment.id,
+                "team": team.name,
+                "points": points,
+                "reason": reason,
+            }
+        ),
+        201,
     )

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -39,6 +39,7 @@ from scoring_engine.models.inject import Inject, InjectComment, InjectRubricScor
 from scoring_engine.models.kb import KB
 from scoring_engine.models.property import Property
 from scoring_engine.models.round import Round
+from scoring_engine.models.round_score import RoundScore
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
@@ -1593,12 +1594,20 @@ def admin_rollback():
         # Count KB entries to delete
         kb_count = db.session.query(KB).filter(KB.round_num >= round_number).count()
 
+        # Count materialized round scores to delete
+        round_scores_count = db.session.query(RoundScore).filter(RoundScore.round_number >= round_number).count()
+
         # Delete checks in batches to avoid lock wait timeout
         BATCH_SIZE = 500
         for i in range(0, len(round_ids), BATCH_SIZE):
             batch_ids = round_ids[i : i + BATCH_SIZE]
             db.session.query(Check).filter(Check.round_id.in_(batch_ids)).delete(synchronize_session=False)
             db.session.commit()
+
+        # Delete materialized round scores. Keyed by round_number, so they must go
+        # with the rounds or the scoreboard keeps ghost points for deleted rounds.
+        db.session.query(RoundScore).filter(RoundScore.round_number >= round_number).delete(synchronize_session=False)
+        db.session.commit()
 
         # Delete KB entries
         db.session.query(KB).filter(KB.round_num >= round_number).delete(synchronize_session=False)
@@ -1632,6 +1641,7 @@ def admin_rollback():
                 "rounds": rounds_count,
                 "checks": checks_count,
                 "kb_entries": kb_count,
+                "round_scores": round_scores_count,
             },
             "new_current_round": Round.get_last_round_num(),
         }
@@ -1668,7 +1678,7 @@ def admin_rollback_preview():
                 "status": "success",
                 "current_round": 0,
                 "round_number": round_number,
-                "will_delete": {"rounds": 0, "checks": 0, "kb_entries": 0},
+                "will_delete": {"rounds": 0, "checks": 0, "kb_entries": 0, "round_scores": 0},
             }
         )
 
@@ -1682,6 +1692,9 @@ def admin_rollback_preview():
     # Count KB entries
     kb_count = db.session.query(KB).filter(KB.round_num >= round_number).count()
 
+    # Count materialized round scores
+    round_scores_count = db.session.query(RoundScore).filter(RoundScore.round_number >= round_number).count()
+
     return jsonify(
         {
             "status": "success",
@@ -1691,6 +1704,7 @@ def admin_rollback_preview():
                 "rounds": len(rounds_to_delete),
                 "checks": checks_count,
                 "kb_entries": kb_count,
+                "round_scores": round_scores_count,
             },
         }
     )

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -16,6 +16,7 @@ from sqlalchemy.sql import func
 from scoring_engine.cache_helper import (
     update_all_cache,
     update_all_inject_data,
+    update_flags_data,
     update_inject_comments,
     update_inject_data,
     update_overview_data,
@@ -1782,3 +1783,55 @@ def admin_create_adjustment():
         ),
         201,
     )
+
+
+@mod.route("/api/admin/freeze", methods=["GET"])
+@login_required
+def admin_get_freeze():
+    """Return the current scoreboard freeze setting (raw UTC ISO, or null)."""
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+    setting = Setting.get_setting("scoreboard_freeze_time")
+    value = setting.value if setting else None
+    return jsonify(freeze_time=value or None)
+
+
+@mod.route("/api/admin/freeze", methods=["POST"])
+@login_required
+def admin_set_freeze():
+    """Set or clear the wall-clock scoreboard freeze.
+
+    Accepts ``freeze_time`` as an ISO datetime. A naive value (no offset) is
+    interpreted in the competition timezone (config.timezone), matching how times
+    are displayed everywhere else. An empty value clears the freeze. Stored as a
+    naive-UTC ISO string.
+    """
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+
+    data = request.get_json(silent=True) or request.form
+    raw = (data.get("freeze_time") or "").strip()
+
+    if not raw:
+        value = ""
+    else:
+        try:
+            dt = parse(raw)
+        except (ValueError, TypeError, OverflowError):
+            return jsonify({"status": "error", "message": "Invalid datetime"}), 400
+        if dt.tzinfo is None:
+            dt = pytz.timezone(config.timezone).localize(dt)
+        value = dt.astimezone(pytz.utc).replace(tzinfo=None).isoformat()
+
+    setting = Setting.get_setting("scoreboard_freeze_time")
+    setting.value = value
+    db.session.add(setting)
+    db.session.commit()
+    Setting.clear_cache("scoreboard_freeze_time")
+
+    # Freeze changes what every non-white viewer sees; refresh the standings caches.
+    update_scoreboard_data()
+    update_overview_data()
+    update_flags_data()
+
+    return jsonify({"status": "success", "freeze_time": value or None})

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -35,6 +35,7 @@ from scoring_engine.engine.engine import Engine
 from scoring_engine.engine.execute_command import execute_command
 from scoring_engine.events import publish_event
 from scoring_engine.models.check import Check
+from scoring_engine.models.competition_window import CompetitionWindow
 from scoring_engine.models.environment import Environment
 from scoring_engine.models.inject import Inject, InjectComment, InjectRubricScore, RubricItem, Template
 from scoring_engine.models.kb import KB
@@ -48,6 +49,7 @@ from scoring_engine.models.team import Team
 from scoring_engine.models.user import User
 from scoring_engine.models.welcome import get_welcome_config, save_welcome_config
 from scoring_engine.notifications import notify_inject_graded, notify_revision_requested
+from scoring_engine.schedule import clear_windows_cache
 
 from . import mod
 
@@ -1835,3 +1837,108 @@ def admin_set_freeze():
     update_flags_data()
 
     return jsonify({"status": "success", "freeze_time": value or None})
+
+
+def _parse_competition_time(raw):
+    """Parse an operator-entered datetime into a naive-UTC datetime, or None.
+
+    A naive value (no offset) is interpreted in the competition timezone
+    (``config.timezone``), matching how the freeze is parsed and how times are
+    displayed everywhere else. Returns None on empty or unparseable input.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    try:
+        dt = parse(raw)
+    except (ValueError, TypeError, OverflowError):
+        return None
+    if dt.tzinfo is None:
+        dt = pytz.timezone(config.timezone).localize(dt)
+    return dt.astimezone(pytz.utc).replace(tzinfo=None)
+
+
+def _refresh_after_window_change():
+    """Invalidate the schedule cache and the standings caches a window affects."""
+    clear_windows_cache()
+    update_scoreboard_data()
+    update_overview_data()
+    update_flags_data()
+
+
+@mod.route("/api/admin/windows", methods=["GET"])
+@login_required
+def admin_get_windows():
+    """List competition windows (white team only), in schedule order."""
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+    windows = db.session.query(CompetitionWindow).order_by(CompetitionWindow.start_time).all()
+    return jsonify(windows=[w.to_dict() for w in windows])
+
+
+@mod.route("/api/admin/windows", methods=["POST"])
+@login_required
+def admin_create_window():
+    """Create a competition window.
+
+    Accepts ``name`` (optional), ``start_time`` and ``end_time`` as ISO datetimes.
+    Naive values are interpreted in the competition timezone; stored naive-UTC.
+    Rejects a window whose end is not strictly after its start.
+    """
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+
+    data = request.get_json(silent=True) or request.form
+    name = (data.get("name") or "").strip() or None
+    start = _parse_competition_time(data.get("start_time"))
+    end = _parse_competition_time(data.get("end_time"))
+
+    if start is None or end is None:
+        return jsonify({"status": "error", "message": "Valid start_time and end_time are required"}), 400
+    if end <= start:
+        return jsonify({"status": "error", "message": "end_time must be after start_time"}), 400
+
+    window = CompetitionWindow(name=name, start_time=start, end_time=end, enabled=True)
+    db.session.add(window)
+    db.session.commit()
+
+    _refresh_after_window_change()
+    return jsonify({"status": "success", "window": window.to_dict()})
+
+
+@mod.route("/api/admin/windows/<int:window_id>", methods=["PATCH"])
+@login_required
+def admin_toggle_window(window_id):
+    """Enable/disable a window without deleting it (park a cancelled day)."""
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+    window = db.session.get(CompetitionWindow, window_id)
+    if window is None:
+        return jsonify({"status": "error", "message": "Not found"}), 404
+
+    data = request.get_json(silent=True) or request.form
+    if "enabled" in data:
+        raw = data.get("enabled")
+        window.enabled = raw is True or str(raw).lower() in ("true", "1", "on", "yes")
+    else:
+        window.enabled = not window.enabled
+    db.session.add(window)
+    db.session.commit()
+
+    _refresh_after_window_change()
+    return jsonify({"status": "success", "window": window.to_dict()})
+
+
+@mod.route("/api/admin/windows/<int:window_id>", methods=["DELETE"])
+@login_required
+def admin_delete_window(window_id):
+    """Delete a competition window."""
+    if not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+    window = db.session.get(CompetitionWindow, window_id)
+    if window is None:
+        return jsonify({"status": "error", "message": "Not found"}), 404
+    db.session.delete(window)
+    db.session.commit()
+    _refresh_after_window_change()
+    return jsonify({"status": "success"})

--- a/scoring_engine/web/views/api/flags.py
+++ b/scoring_engine/web/views/api/flags.py
@@ -243,6 +243,7 @@ def api_flags_score():
         return jsonify({"status": "Unauthorized"}), 403
 
     from scoring_engine.scores import flag_points_by_team, get_flag_point_values
+    from scoring_engine.sla import get_sla_config
 
     from . import get_effective_freeze
 
@@ -253,8 +254,16 @@ def api_flags_score():
     blue_teams = db.session.query(Team).filter(Team.color == "Blue").order_by(Team.id).all()
     by_team = [{"team": team.name, "points": by_team_id.get(team.id, 0)} for team in blue_teams]
 
+    # Weighted scoring can scale the red team's flag total. Flags accrue to red
+    # only, so unlike the blue scoreboard there is nothing to rebalance flags
+    # against -- flag_weight simply scales the red flag magnitude.
+    red_total = sum(by_team_id.values())
+    sla_config = get_sla_config()
+    if sla_config.weighted_scoring_enabled:
+        red_total = int(round(red_total * sla_config.flag_weight))
+
     return jsonify(
-        red_total=sum(by_team_id.values()),
+        red_total=red_total,
         by_team=by_team,
         points={"user": user_points, "root": root_points},
     )

--- a/scoring_engine/web/views/api/flags.py
+++ b/scoring_engine/web/views/api/flags.py
@@ -244,8 +244,11 @@ def api_flags_score():
 
     from scoring_engine.scores import flag_points_by_team, get_flag_point_values
 
+    from . import get_effective_freeze
+
+    _, freeze_time = get_effective_freeze()
     user_points, root_points = get_flag_point_values()
-    by_team_id = flag_points_by_team(db.session, user_points, root_points)
+    by_team_id = flag_points_by_team(db.session, user_points, root_points, freeze_time=freeze_time)
 
     blue_teams = db.session.query(Team).filter(Team.color == "Blue").order_by(Team.id).all()
     by_team = [{"team": team.name, "points": by_team_id.get(team.id, 0)} for team in blue_teams]

--- a/scoring_engine/web/views/api/flags.py
+++ b/scoring_engine/web/views/api/flags.py
@@ -226,3 +226,32 @@ def api_flags_totals():
         data.append({"team": team[0], "win_score": team[1], "nix_score": team[2], "total_score": team[1] + team[2]})
 
     return jsonify(data=data)
+
+
+@mod.route("/api/flags/score")
+@login_required
+@cache.cached(make_cache_key=make_cache_key)
+def api_flags_score():
+    """Red-team flag score: the total the red team has earned by compromising blue
+    hosts, plus a per-blue-team breakdown (that team's captured-flag value).
+
+    Config-driven (flag_points_user / flag_points_root). Per the "add to red only"
+    rule, these points accrue to the red team; blue scores are unaffected. Visible
+    to red and white teams only.
+    """
+    if not current_user.is_red_team and not current_user.is_white_team:
+        return jsonify({"status": "Unauthorized"}), 403
+
+    from scoring_engine.scores import flag_points_by_team, get_flag_point_values
+
+    user_points, root_points = get_flag_point_values()
+    by_team_id = flag_points_by_team(db.session, user_points, root_points)
+
+    blue_teams = db.session.query(Team).filter(Team.color == "Blue").order_by(Team.id).all()
+    by_team = [{"team": team.name, "points": by_team_id.get(team.id, 0)} for team in blue_teams]
+
+    return jsonify(
+        red_total=sum(by_team_id.values()),
+        by_team=by_team,
+        points={"user": user_points, "root": root_points},
+    )

--- a/scoring_engine/web/views/api/overview.py
+++ b/scoring_engine/web/views/api/overview.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 
 from flask import jsonify
 from flask_login import current_user
-from sqlalchemy import desc
 from sqlalchemy.sql import func
 
 from scoring_engine.cache import cache
@@ -12,7 +11,7 @@ from scoring_engine.models.round import Round
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
-from scoring_engine.sla import apply_dynamic_scoring_to_round, calculate_team_total_penalties, get_sla_config
+from scoring_engine.sla import calculate_team_total_penalties, get_sla_config
 
 from . import make_cache_key, mod
 
@@ -190,41 +189,11 @@ def overview_get_data():
     )
 
     if len(blue_team_ids) > 0:
-        # Calculate team scores with dynamic scoring multipliers
-        if sla_config.dynamic_enabled:
-            # Query scores per round for dynamic scoring
-            round_scores = (
-                db.session.query(
-                    Service.team_id,
-                    Check.round_id,
-                    func.sum(Service.points).label("round_score"),
-                )
-                .join(Check)
-                .filter(Check.result.is_(True))
-                .group_by(Service.team_id, Check.round_id)
-                .all()
-            )
+        # Team service scores (with dynamic multipliers when enabled) from the
+        # materialized round_score table -- no full-history scan per render.
+        from scoring_engine.scores import team_service_scores
 
-            # Get round numbers for each round_id
-            rounds_map = {r.id: r.number for r in db.session.query(Round.id, Round.number).all()}
-
-            # Calculate totals with multipliers
-            team_scores = defaultdict(int)
-            for team_id, round_id, round_score in round_scores:
-                round_number = rounds_map.get(round_id, 0)
-                adjusted_score = apply_dynamic_scoring_to_round(round_number, round_score, sla_config)
-                team_scores[team_id] += adjusted_score
-            team_scores = dict(team_scores)
-        else:
-            # No dynamic scoring - use simple sum
-            team_scores = dict(
-                db.session.query(Service.team_id, func.sum(Service.points).label("score"))
-                .join(Check)
-                .filter(Check.result.is_(True))
-                .group_by(Service.team_id)
-                .order_by(desc("score"))
-                .all()
-            )
+        team_scores = team_service_scores(db.session, sla_config)
 
         # Calculate adjusted scores with SLA penalties
         adjusted_scores_dict = {}

--- a/scoring_engine/web/views/api/overview.py
+++ b/scoring_engine/web/views/api/overview.py
@@ -193,7 +193,10 @@ def overview_get_data():
         # materialized round_score table -- no full-history scan per render.
         from scoring_engine.scores import team_service_scores
 
-        team_scores = team_service_scores(db.session, sla_config)
+        from . import get_effective_freeze
+
+        _, freeze_time = get_effective_freeze()
+        team_scores = team_service_scores(db.session, sla_config, freeze_time=freeze_time)
 
         # Calculate adjusted scores with SLA penalties
         adjusted_scores_dict = {}

--- a/scoring_engine/web/views/api/overview.py
+++ b/scoring_engine/web/views/api/overview.py
@@ -11,7 +11,7 @@ from scoring_engine.models.round import Round
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
-from scoring_engine.sla import calculate_team_total_penalties, get_sla_config
+from scoring_engine.sla import get_sla_config
 
 from . import make_cache_key, mod
 
@@ -151,7 +151,6 @@ def overview_get_data():
     data = []
     blue_teams = db.session.query(Team).filter(Team.color == "Blue").order_by(Team.id).all()
     blue_team_ids = [team.id for team in blue_teams]
-    blue_teams_dict = {team.id: team for team in blue_teams}
     last_round = Round.get_last_round_num()
 
     # Get SLA configuration
@@ -191,12 +190,14 @@ def overview_get_data():
     if len(blue_team_ids) > 0:
         # Team service scores (with dynamic multipliers when enabled) from the
         # materialized round_score table -- no full-history scan per render.
-        from scoring_engine.scores import team_service_scores
+        from scoring_engine.scores import team_penalties, team_service_scores
 
         from . import get_effective_freeze
 
         _, freeze_time = get_effective_freeze()
         team_scores = team_service_scores(db.session, sla_config, freeze_time=freeze_time)
+        # All teams' penalties in a couple of grouped queries (see scores.team_penalties).
+        penalties = team_penalties(db.session, sla_config) if sla_config.sla_enabled else {}
 
         # Calculate adjusted scores with SLA penalties
         adjusted_scores_dict = {}
@@ -204,8 +205,7 @@ def overview_get_data():
         for blue_team_id in blue_team_ids:
             base_score = team_scores.get(blue_team_id, 0)
             if sla_config.sla_enabled:
-                team = blue_teams_dict[blue_team_id]
-                penalty = calculate_team_total_penalties(team, sla_config)
+                penalty = penalties.get(blue_team_id, 0)
                 penalties_dict[blue_team_id] = penalty
                 if sla_config.allow_negative:
                     adjusted_scores_dict[blue_team_id] = base_score - penalty

--- a/scoring_engine/web/views/api/overview.py
+++ b/scoring_engine/web/views/api/overview.py
@@ -145,7 +145,7 @@ def overview_get_data():
 
     - ``Current Score`` / ``Current Place``: stringified integers
     - ``SLA Penalties``: penalty magnitude as an integer (0 when no penalty)
-    - ``Up/Down Ratio``: ``{"up": <int>, "down": <int>}``
+    - ``Services Up`` / ``Services Down``: this round's up/down counts as integers
     - service rows: check result booleans (or ``None`` when unchecked)
     """
     data = []
@@ -158,7 +158,8 @@ def overview_get_data():
 
     current_scores = ["Current Score"]
     current_places = ["Current Place"]
-    service_ratios = ["Up/Down Ratio"]
+    services_up = ["Services Up"]
+    services_down = ["Services Down"]
     sla_penalties_row = ["SLA Penalties"]
 
     num_up_services = dict(
@@ -228,13 +229,11 @@ def overview_get_data():
             else:
                 current_scores.append(str(team_scores.get(blue_team_id, 0)))
             current_places.append(str(ranks_dict.get(blue_team_id, 0)))
-            # Structured up/down counts - presentation is handled by the front end
-            service_ratios.append(
-                {
-                    "up": num_up_services.get(blue_team_id, 0),
-                    "down": num_down_services.get(blue_team_id, 0),
-                }
-            )
+            # Up and down counts as separate rows so each cell holds a single
+            # value -- a combined "up / down" wraps in a narrow team column and
+            # makes the row height jump around.
+            services_up.append(num_up_services.get(blue_team_id, 0))
+            services_down.append(num_down_services.get(blue_team_id, 0))
             # Penalty magnitude as a number (0 when no penalty); the front end
             # renders it as a negative value
             sla_penalties_row.append(penalties_dict.get(blue_team_id, 0))
@@ -244,7 +243,8 @@ def overview_get_data():
         # Show SLA penalties row when SLA is enabled
         if sla_config.sla_enabled:
             data.append(sla_penalties_row)
-        data.append(service_ratios)
+        data.append(services_up)
+        data.append(services_down)
 
         checks = (
             db.session.query(Service.id, Service.name, Check.result)

--- a/scoring_engine/web/views/api/scoreboard.py
+++ b/scoring_engine/web/views/api/scoreboard.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from datetime import datetime, timezone
 from itertools import accumulate
 
 from flask import jsonify
@@ -38,7 +39,7 @@ def get_anonymize_mode():
     return (True, False)
 
 
-def calculate_team_scores_with_dynamic_scoring(sla_config):
+def calculate_team_scores_with_dynamic_scoring(sla_config, freeze_time=None):
     """
     Calculate team scores with dynamic scoring multipliers applied per-round.
 
@@ -46,33 +47,39 @@ def calculate_team_scores_with_dynamic_scoring(sla_config):
 
     Reads from the materialized round_score table (see scoring_engine.scores)
     rather than re-summing the full check history on every scoreboard render.
+    ``freeze_time`` restricts to rounds closed at/before the wall-clock freeze.
     """
     from scoring_engine.scores import team_service_scores
 
-    return team_service_scores(db.session, sla_config)
+    return team_service_scores(db.session, sla_config, freeze_time=freeze_time)
 
 
 @cache.memoize()
-def _get_bar_data_cached(anonymize, show_both):
+def _get_bar_data_cached(anonymize, show_both, frozen_view=False):
     """
     Internal cached function for bar chart data.
-    Cache key includes anonymize/show_both flags for separate caches per user type.
+    Cache key includes anonymize/show_both/frozen_view flags for separate caches
+    per user type (frozen_view distinguishes the white/live view from the frozen
+    public view, which anonymize/show_both alone do not when anonymization is off).
     """
-    from scoring_engine.scores import team_adjustment_totals
+    from scoring_engine.scores import get_freeze_time, team_adjustment_totals
+
+    freeze_time = get_freeze_time() if frozen_view else None
 
     sla_config = get_sla_config()
-    current_scores = calculate_team_scores_with_dynamic_scoring(sla_config)
-    adjustments = team_adjustment_totals(db.session)
+    current_scores = calculate_team_scores_with_dynamic_scoring(sla_config, freeze_time=freeze_time)
+    adjustments = team_adjustment_totals(db.session, freeze_time=freeze_time)
 
     inject_scores_visible = Setting.get_setting("inject_scores_visible")
     if inject_scores_visible and inject_scores_visible.value:
-        inject_scores = dict(
+        inject_query = (
             db.session.query(Inject.team_id, func.sum(InjectRubricScore.score))
             .join(InjectRubricScore)
             .filter(Inject.status == "Graded")
-            .group_by(Inject.team_id)
-            .all()
         )
+        if freeze_time is not None:
+            inject_query = inject_query.filter(Inject.graded <= freeze_time)
+        inject_scores = dict(inject_query.group_by(Inject.team_id).all())
     else:
         inject_scores = {}
 
@@ -127,11 +134,16 @@ def _get_bar_data_cached(anonymize, show_both):
 
 
 @cache.memoize()
-def _get_line_data_cached(anonymize, show_both):
+def _get_line_data_cached(anonymize, show_both, frozen_view=False):
     """
     Internal cached function for line chart data.
-    Cache key includes anonymize/show_both flags for separate caches per user type.
+    Cache key includes anonymize/show_both/frozen_view flags for separate caches
+    per user type.
     """
+    from scoring_engine.scores import get_freeze_time
+
+    freeze_time = get_freeze_time() if frozen_view else None
+
     last_round = Round.get_last_round_num()
     sla_config = get_sla_config()
 
@@ -148,11 +160,10 @@ def _get_line_data_cached(anonymize, show_both):
     # full-history scan, no round_id->number lookup -- the number is stored).
     from scoring_engine.models.round_score import RoundScore
 
-    round_scores = (
-        db.session.query(RoundScore.team_id, RoundScore.round_number, RoundScore.service_points)
-        .order_by(RoundScore.team_id, RoundScore.round_number)
-        .all()
-    )
+    round_query = db.session.query(RoundScore.team_id, RoundScore.round_number, RoundScore.service_points)
+    if freeze_time is not None:
+        round_query = round_query.join(Round, Round.id == RoundScore.round_id).filter(Round.round_end <= freeze_time)
+    round_scores = round_query.order_by(RoundScore.team_id, RoundScore.round_number).all()
 
     scores_dict = defaultdict(lambda: defaultdict(int))
     for team_id, round_number, round_score in round_scores:
@@ -174,15 +185,52 @@ def _get_line_data_cached(anonymize, show_both):
     return team_data
 
 
+@mod.route("/api/scoreboard/freeze_status")
+def scoreboard_freeze_status():
+    """Report whether the scoreboard is frozen, for the banner + countdown.
+
+    Returns the freeze instant and the current server time as epoch seconds so the
+    client can render a countdown that does not depend on the viewer's clock being
+    correct -- the whole point of a countdown across timezones. Public: the banner
+    shows to everyone; only the white team's data stays live (``white_live``).
+    """
+    import pytz
+
+    from scoring_engine.config import config
+    from scoring_engine.datetime_utils import ensure_utc_aware
+    from scoring_engine.scores import get_freeze_time
+
+    freeze_time = get_freeze_time()
+    if freeze_time is None:
+        return jsonify(frozen=False)
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    is_white = current_user.is_authenticated and current_user.is_white_team
+    display = ensure_utc_aware(freeze_time).astimezone(pytz.timezone(config.timezone)).strftime("%Y-%m-%d %H:%M:%S %Z")
+    return jsonify(
+        frozen=True,
+        white_live=is_white,
+        freeze_epoch=int(ensure_utc_aware(freeze_time).timestamp()),
+        server_epoch=int(ensure_utc_aware(now).timestamp()),
+        freeze_display=display,
+    )
+
+
 @mod.route("/api/scoreboard/get_bar_data")
 def scoreboard_get_bar_data():
-    """Get bar chart data. Cached separately by user type."""
+    """Get bar chart data. Cached separately by user type and freeze view."""
+    from . import get_effective_freeze
+
     anonymize, show_both = get_anonymize_mode()
-    return jsonify(_get_bar_data_cached(anonymize, show_both))
+    frozen_view, _ = get_effective_freeze()
+    return jsonify(_get_bar_data_cached(anonymize, show_both, frozen_view))
 
 
 @mod.route("/api/scoreboard/get_line_data")
 def scoreboard_get_line_data():
-    """Get line chart data. Cached separately by user type."""
+    """Get line chart data. Cached separately by user type and freeze view."""
+    from . import get_effective_freeze
+
     anonymize, show_both = get_anonymize_mode()
-    return jsonify(_get_line_data_cached(anonymize, show_both))
+    frozen_view, _ = get_effective_freeze()
+    return jsonify(_get_line_data_cached(anonymize, show_both, frozen_view))

--- a/scoring_engine/web/views/api/scoreboard.py
+++ b/scoring_engine/web/views/api/scoreboard.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from datetime import datetime, timezone
-from itertools import accumulate
 
 from flask import jsonify
 from flask_login import current_user
@@ -166,6 +165,30 @@ def _get_bar_data_cached(anonymize, show_both, frozen_view=False):
     return team_data
 
 
+# Cap on the number of x-points in a line series. One point per round makes the
+# response grow without bound (~2.4 MB at 100 teams x 3000 rounds); this keeps it
+# flat regardless of competition length. A few hundred points is well past what a
+# line chart can resolve on screen.
+LINE_CHART_MAX_POINTS = 400
+
+
+def _downsample_indices(n, max_points):
+    """Evenly-spaced indices into ``range(n)``, at most ``max_points``, always
+    including the first and last. Returns every index when ``n <= max_points``.
+
+    Uniform sampling is enough here because the cumulative score series is smooth
+    and monotonic; it also gives every team the same x-points, which a shared
+    rounds axis requires.
+    """
+    if n <= max_points:
+        return list(range(n))
+    step = (n - 1) / (max_points - 1)
+    indices = sorted({round(i * step) for i in range(max_points)})
+    if indices[-1] != n - 1:
+        indices.append(n - 1)
+    return indices
+
+
 @cache.memoize()
 def _get_line_data_cached(anonymize, show_both, frozen_view=False):
     """
@@ -179,18 +202,6 @@ def _get_line_data_cached(anonymize, show_both, frozen_view=False):
 
     last_round = Round.get_last_round_num()
     sla_config = get_sla_config()
-
-    # TODO(perf): downsample the line series. This returns one point per team per
-    # round, so the payload grows without bound as a competition runs -- measured
-    # ~2.4 MB at 100 teams x 3000 rounds. The query itself is cheap (indexed
-    # round_score); the cost is JSON size / transfer. Cap each series to ~N points
-    # (e.g. bucket rounds, or LTTB downsampling that preserves the visual shape)
-    # so the response stays flat regardless of round count. Keep the full series
-    # available to the white team / an export path if the fine grain is needed.
-    team_data = {
-        "team": [],
-        "rounds": [f"Round {round}" for round in range(last_round + 1)],
-    }
 
     blue_teams = (
         db.session.query(Team.id, Team.name, Team.rgb_color).filter(Team.color == "Blue").order_by(Team.id).all()
@@ -210,14 +221,34 @@ def _get_line_data_cached(anonymize, show_both, frozen_view=False):
         # Apply dynamic scoring multiplier if enabled
         scores_dict[team_id][round_number] = apply_dynamic_scoring_to_round(round_number, round_score, sla_config)
 
+    # x-axis is every round (0..last_round), downsampled to a bounded set of
+    # points shared by all teams.
+    n = last_round + 1
+    sampled = _downsample_indices(n, LINE_CHART_MAX_POINTS)
+
+    team_data = {
+        "team": [],
+        "rounds": [f"Round {i}" for i in sampled],
+    }
+
     team_name_map = Team.get_team_name_mapping(anonymize=anonymize, show_both=show_both)
 
     for team_id, team_name, rgb_color in blue_teams:
         display_name = team_name_map.get(team_id, team_name)
+        team_rounds = scores_dict[team_id]
+        # Cumulative score at each round. A round the team did not score in carries
+        # the previous total forward, so the series stays aligned to the rounds
+        # axis (accumulating only the scored rounds would drop points and shift the
+        # line left of where it belongs).
+        cumulative = []
+        running = 0
+        for r in range(n):
+            running += team_rounds.get(r, 0)
+            cumulative.append(running)
         team_data["team"].append(
             {
                 "name": display_name,
-                "scores": list(accumulate(scores_dict[team_id].values(), initial=0)),
+                "scores": [cumulative[i] for i in sampled],
                 "color": rgb_color,
             }
         )

--- a/scoring_engine/web/views/api/scoreboard.py
+++ b/scoring_engine/web/views/api/scoreboard.py
@@ -45,41 +45,13 @@ def calculate_team_scores_with_dynamic_scoring(sla_config):
     Calculate team scores with dynamic scoring multipliers applied per-round.
 
     Returns dict mapping team_id to total score with multipliers applied.
+
+    Reads from the materialized round_score table (see scoring_engine.scores)
+    rather than re-summing the full check history on every scoreboard render.
     """
-    if not sla_config.dynamic_enabled:
-        # No dynamic scoring - use simple sum
-        return dict(
-            db.session.query(Service.team_id, func.sum(Service.points))
-            .join(Check)
-            .filter(Check.result.is_(True))
-            .group_by(Service.team_id)
-            .all()
-        )
+    from scoring_engine.scores import team_service_scores
 
-    # Query scores grouped by team and round
-    round_scores = (
-        db.session.query(
-            Service.team_id,
-            Check.round_id,
-            func.sum(Service.points).label("round_score"),
-        )
-        .join(Check)
-        .filter(Check.result.is_(True))
-        .group_by(Service.team_id, Check.round_id)
-        .all()
-    )
-
-    # Get round numbers for each round_id
-    rounds = {r.id: r.number for r in db.session.query(Round.id, Round.number).all()}
-
-    # Calculate total with multipliers
-    team_scores = defaultdict(int)
-    for team_id, round_id, round_score in round_scores:
-        round_number = rounds.get(round_id, 0)
-        adjusted_score = apply_dynamic_scoring_to_round(round_number, round_score, sla_config)
-        team_scores[team_id] += adjusted_score
-
-    return dict(team_scores)
+    return team_service_scores(db.session, sla_config)
 
 
 @cache.memoize()

--- a/scoring_engine/web/views/api/scoreboard.py
+++ b/scoring_engine/web/views/api/scoreboard.py
@@ -58,8 +58,11 @@ def _get_bar_data_cached(anonymize, show_both):
     Internal cached function for bar chart data.
     Cache key includes anonymize/show_both flags for separate caches per user type.
     """
+    from scoring_engine.scores import team_adjustment_totals
+
     sla_config = get_sla_config()
     current_scores = calculate_team_scores_with_dynamic_scoring(sla_config)
+    adjustments = team_adjustment_totals(db.session)
 
     inject_scores_visible = Setting.get_setting("inject_scores_visible")
     if inject_scores_visible and inject_scores_visible.value:
@@ -78,6 +81,7 @@ def _get_bar_data_cached(anonymize, show_both):
     team_scores = []
     team_inject_scores = []
     team_sla_penalties = []
+    team_adjustments = []
     team_adjusted_scores = []
 
     team_colors = []
@@ -91,12 +95,14 @@ def _get_bar_data_cached(anonymize, show_both):
         team_colors.append(blue_team.rgb_color)
         service_score = current_scores.get(blue_team.id, 0)
         inject_score = inject_scores.get(blue_team.id, 0)
+        adjustment = adjustments.get(blue_team.id, 0)
         team_scores.append(str(service_score))
         team_inject_scores.append(str(inject_score))
+        team_adjustments.append(str(adjustment))
 
         # Calculate SLA penalties if enabled
-        # Total base score includes both service and inject scores
-        total_base_score = service_score + inject_score
+        # Total base score includes service, inject, and manual adjustments
+        total_base_score = service_score + inject_score + adjustment
         if sla_config.sla_enabled:
             penalty = calculate_team_total_penalties(blue_team, sla_config)
             team_sla_penalties.append(str(penalty))
@@ -114,6 +120,7 @@ def _get_bar_data_cached(anonymize, show_both):
     team_data["service_scores"] = team_scores
     team_data["inject_scores"] = team_inject_scores
     team_data["sla_penalties"] = team_sla_penalties
+    team_data["adjustments"] = team_adjustments
     team_data["adjusted_scores"] = team_adjusted_scores
     team_data["sla_enabled"] = sla_config.sla_enabled
     return team_data

--- a/scoring_engine/web/views/api/scoreboard.py
+++ b/scoring_engine/web/views/api/scoreboard.py
@@ -12,7 +12,7 @@ from scoring_engine.models.inject import Inject, InjectRubricScore
 from scoring_engine.models.round import Round
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
-from scoring_engine.sla import apply_dynamic_scoring_to_round, calculate_team_total_penalties, get_sla_config
+from scoring_engine.sla import apply_dynamic_scoring_to_round, get_sla_config
 
 from . import mod
 
@@ -62,13 +62,16 @@ def _get_bar_data_cached(anonymize, show_both, frozen_view=False):
     per user type (frozen_view distinguishes the white/live view from the frozen
     public view, which anonymize/show_both alone do not when anonymization is off).
     """
-    from scoring_engine.scores import get_freeze_time, team_adjustment_totals
+    from scoring_engine.scores import get_freeze_time, team_adjustment_totals, team_penalties
 
     freeze_time = get_freeze_time() if frozen_view else None
 
     sla_config = get_sla_config()
     current_scores = calculate_team_scores_with_dynamic_scoring(sla_config, freeze_time=freeze_time)
     adjustments = team_adjustment_totals(db.session, freeze_time=freeze_time)
+    # All teams' SLA penalties in a couple of grouped queries, rather than the
+    # per-service check scan calculate_team_total_penalties runs one team at a time.
+    penalties = team_penalties(db.session, sla_config) if sla_config.sla_enabled else {}
 
     inject_scores_visible = Setting.get_setting("inject_scores_visible")
     if inject_scores_visible and inject_scores_visible.value:
@@ -132,7 +135,7 @@ def _get_bar_data_cached(anonymize, show_both, frozen_view=False):
         # Total base score includes (weighted) service, inject, and manual adjustments
         total_base_score = weighted_service + weighted_inject + adjustment
         if sla_config.sla_enabled:
-            penalty = calculate_team_total_penalties(blue_team, sla_config)
+            penalty = penalties.get(blue_team.id, 0)
             team_sla_penalties.append(str(penalty))
             if sla_config.allow_negative:
                 adjusted = total_base_score - penalty
@@ -177,6 +180,13 @@ def _get_line_data_cached(anonymize, show_both, frozen_view=False):
     last_round = Round.get_last_round_num()
     sla_config = get_sla_config()
 
+    # TODO(perf): downsample the line series. This returns one point per team per
+    # round, so the payload grows without bound as a competition runs -- measured
+    # ~2.4 MB at 100 teams x 3000 rounds. The query itself is cheap (indexed
+    # round_score); the cost is JSON size / transfer. Cap each series to ~N points
+    # (e.g. bucket rounds, or LTTB downsampling that preserves the visual shape)
+    # so the response stays flat regardless of round count. Keep the full series
+    # available to the white team / an export path if the fine grain is needed.
     team_data = {
         "team": [],
         "rounds": [f"Round {round}" for round in range(last_round + 1)],

--- a/scoring_engine/web/views/api/scoreboard.py
+++ b/scoring_engine/web/views/api/scoreboard.py
@@ -90,8 +90,20 @@ def _get_bar_data_cached(anonymize, show_both, frozen_view=False):
     team_sla_penalties = []
     team_adjustments = []
     team_adjusted_scores = []
+    # Pre-weight values, kept alongside the weighted ones so the UI can show the
+    # breakdown (e.g. "120 service x 1.5"). Equal to the weighted values when
+    # weighted scoring is off.
+    team_raw_service_scores = []
+    team_raw_inject_scores = []
 
     team_colors = []
+
+    # Weighted scoring rebalances the categories that make up the combined total:
+    # service and inject are scaled by their weights before they are summed with
+    # manual adjustments. Adjustments are absolute point awards and are never
+    # weighted. Flag captures accrue to the red team only (see the flags API),
+    # so flag_weight does not enter the blue teams' totals here.
+    weighted = sla_config.weighted_scoring_enabled
 
     blue_teams = db.session.query(Team).filter(Team.color == "Blue").order_by(Team.id).all()
     team_name_map = Team.get_team_name_mapping(anonymize=anonymize, show_both=show_both)
@@ -103,13 +115,22 @@ def _get_bar_data_cached(anonymize, show_both, frozen_view=False):
         service_score = current_scores.get(blue_team.id, 0)
         inject_score = inject_scores.get(blue_team.id, 0)
         adjustment = adjustments.get(blue_team.id, 0)
-        team_scores.append(str(service_score))
-        team_inject_scores.append(str(inject_score))
+
+        team_raw_service_scores.append(str(service_score))
+        team_raw_inject_scores.append(str(inject_score))
+        if weighted:
+            weighted_service = int(round(service_score * sla_config.service_weight))
+            weighted_inject = int(round(inject_score * sla_config.inject_weight))
+        else:
+            weighted_service = service_score
+            weighted_inject = inject_score
+        team_scores.append(str(weighted_service))
+        team_inject_scores.append(str(weighted_inject))
         team_adjustments.append(str(adjustment))
 
         # Calculate SLA penalties if enabled
-        # Total base score includes service, inject, and manual adjustments
-        total_base_score = service_score + inject_score + adjustment
+        # Total base score includes (weighted) service, inject, and manual adjustments
+        total_base_score = weighted_service + weighted_inject + adjustment
         if sla_config.sla_enabled:
             penalty = calculate_team_total_penalties(blue_team, sla_config)
             team_sla_penalties.append(str(penalty))
@@ -130,6 +151,15 @@ def _get_bar_data_cached(anonymize, show_both, frozen_view=False):
     team_data["adjustments"] = team_adjustments
     team_data["adjusted_scores"] = team_adjusted_scores
     team_data["sla_enabled"] = sla_config.sla_enabled
+    team_data["weighted_scoring_enabled"] = weighted
+    if weighted:
+        team_data["weights"] = {
+            "service": sla_config.service_weight,
+            "inject": sla_config.inject_weight,
+            "flag": sla_config.flag_weight,
+        }
+        team_data["raw_service_scores"] = team_raw_service_scores
+        team_data["raw_inject_scores"] = team_raw_inject_scores
     return team_data
 
 

--- a/scoring_engine/web/views/api/scoreboard.py
+++ b/scoring_engine/web/views/api/scoreboard.py
@@ -7,10 +7,8 @@ from sqlalchemy.sql import func
 
 from scoring_engine.cache import cache
 from scoring_engine.db import db
-from scoring_engine.models.check import Check
 from scoring_engine.models.inject import Inject, InjectRubricScore
 from scoring_engine.models.round import Round
-from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
 from scoring_engine.sla import apply_dynamic_scoring_to_round, calculate_team_total_penalties, get_sla_config
@@ -139,28 +137,20 @@ def _get_line_data_cached(anonymize, show_both):
         db.session.query(Team.id, Team.name, Team.rgb_color).filter(Team.color == "Blue").order_by(Team.id).all()
     )
 
+    # Per-team, per-round points from the materialized round_score table (no
+    # full-history scan, no round_id->number lookup -- the number is stored).
+    from scoring_engine.models.round_score import RoundScore
+
     round_scores = (
-        db.session.query(
-            Service.team_id,
-            Check.round_id,
-            func.sum(Service.points),
-        )
-        .join(Check)
-        .filter(Check.result.is_(True))
-        .group_by(Service.team_id, Check.round_id)
-        .order_by(Service.team_id, Check.round_id)
+        db.session.query(RoundScore.team_id, RoundScore.round_number, RoundScore.service_points)
+        .order_by(RoundScore.team_id, RoundScore.round_number)
         .all()
     )
 
-    # Get round numbers for dynamic scoring
-    rounds_map = {r.id: r.number for r in db.session.query(Round.id, Round.number).all()}
-
     scores_dict = defaultdict(lambda: defaultdict(int))
-    for team_id, round_id, round_score in round_scores:
+    for team_id, round_number, round_score in round_scores:
         # Apply dynamic scoring multiplier if enabled
-        round_number = rounds_map.get(round_id, 0)
-        adjusted_score = apply_dynamic_scoring_to_round(round_number, round_score, sla_config)
-        scores_dict[team_id][round_id] = adjusted_score
+        scores_dict[team_id][round_number] = apply_dynamic_scoring_to_round(round_number, round_score, sla_config)
 
     team_name_map = Team.get_team_name_mapping(anonymize=anonymize, show_both=show_both)
 

--- a/tests/integration/db_setup.py
+++ b/tests/integration/db_setup.py
@@ -113,3 +113,13 @@ def ensure_integration_data() -> None:
         _seed_team(team_index, rounds)
 
     db.session.commit()
+
+    # The scoreboard/current_score read team totals from the materialized
+    # round_score table (and SLA penalties from the consecutive-failure cache),
+    # which the engine writes at round close. This dataset is seeded statically
+    # without the engine, so materialize both here -- otherwise current_score
+    # reads zero even though the checks exist.
+    from scoring_engine.scores import materialize_all_rounds, recompute_consecutive_failures_cache
+
+    materialize_all_rounds(db.session)
+    recompute_consecutive_failures_cache(db.session)

--- a/tests/scoring_engine/conftest.py
+++ b/tests/scoring_engine/conftest.py
@@ -72,6 +72,8 @@ def _insert_default_settings():
         ("dynamic_scoring_late_start_round", "50"),
         ("dynamic_scoring_late_multiplier", "0.5"),
         ("inject_scores_visible", False),
+        ("flag_points_user", "100"),
+        ("flag_points_root", "200"),
     ]
     for name, value in settings:
         db.session.add(Setting(name=name, value=value))

--- a/tests/scoring_engine/conftest.py
+++ b/tests/scoring_engine/conftest.py
@@ -96,6 +96,48 @@ def db_session(app, _db_tables):
         db.session.commit()
 
 
+@pytest.fixture(autouse=True)
+def _materialize_scores_on_read(db_session):
+    """Keep round_score in sync for the score-read helpers, in tests.
+
+    In production the engine materializes round_score at round close (see
+    scoring_engine.scores.materialize_round), so by the time anything reads a score
+    the rows exist. Unit tests, however, create Check rows directly without running
+    the engine. Rather than sprinkle materialize calls through every test that
+    builds checks, we wrap the three round_score read helpers so they refresh
+    round_score from the current checks first. materialize_all_rounds is idempotent
+    and cheap on test-sized data.
+
+    This affects only the read path's data freshness -- the write path itself
+    (materialize_round at round close, failed-round cleanup, rollback) is exercised
+    directly by tests/scoring_engine/test_scores.py and the engine tests.
+
+    Patches manually (save/restore) rather than via pytest's ``monkeypatch``: some
+    engine tests install a flaky ``db.session.commit`` through their own
+    ``monkeypatch``, and depending on it here would reorder that fixture's teardown
+    to after the db_session cleanup commit, tripping the flaky commit at teardown.
+    """
+    import scoring_engine.scores as scores
+
+    names = ("team_service_score", "team_service_scores", "team_dynamic_service_score")
+    originals = {name: getattr(scores, name) for name in names}
+
+    def make_wrapper(orig):
+        def wrapper(session, *args, **kwargs):
+            scores.materialize_all_rounds(session)
+            return orig(session, *args, **kwargs)
+
+        return wrapper
+
+    for name, original in originals.items():
+        setattr(scores, name, make_wrapper(original))
+    try:
+        yield
+    finally:
+        for name, original in originals.items():
+            setattr(scores, name, original)
+
+
 # ---------------------------------------------------------------------------
 # Phase 3: Shared auth fixtures
 # ---------------------------------------------------------------------------

--- a/tests/scoring_engine/conftest.py
+++ b/tests/scoring_engine/conftest.py
@@ -75,6 +75,10 @@ def _insert_default_settings():
         ("flag_points_user", "100"),
         ("flag_points_root", "200"),
         ("scoreboard_freeze_time", ""),
+        ("weighted_scoring_enabled", False),
+        ("service_weight", "1.0"),
+        ("inject_weight", "1.0"),
+        ("flag_weight", "1.0"),
     ]
     for name, value in settings:
         db.session.add(Setting(name=name, value=value))

--- a/tests/scoring_engine/conftest.py
+++ b/tests/scoring_engine/conftest.py
@@ -96,48 +96,6 @@ def db_session(app, _db_tables):
         db.session.commit()
 
 
-@pytest.fixture(autouse=True)
-def _materialize_scores_on_read(db_session):
-    """Keep round_score in sync for the score-read helpers, in tests.
-
-    In production the engine materializes round_score at round close (see
-    scoring_engine.scores.materialize_round), so by the time anything reads a score
-    the rows exist. Unit tests, however, create Check rows directly without running
-    the engine. Rather than sprinkle materialize calls through every test that
-    builds checks, we wrap the three round_score read helpers so they refresh
-    round_score from the current checks first. materialize_all_rounds is idempotent
-    and cheap on test-sized data.
-
-    This affects only the read path's data freshness -- the write path itself
-    (materialize_round at round close, failed-round cleanup, rollback) is exercised
-    directly by tests/scoring_engine/test_scores.py and the engine tests.
-
-    Patches manually (save/restore) rather than via pytest's ``monkeypatch``: some
-    engine tests install a flaky ``db.session.commit`` through their own
-    ``monkeypatch``, and depending on it here would reorder that fixture's teardown
-    to after the db_session cleanup commit, tripping the flaky commit at teardown.
-    """
-    import scoring_engine.scores as scores
-
-    names = ("team_service_score", "team_service_scores", "team_dynamic_service_score")
-    originals = {name: getattr(scores, name) for name in names}
-
-    def make_wrapper(orig):
-        def wrapper(session, *args, **kwargs):
-            scores.materialize_all_rounds(session)
-            return orig(session, *args, **kwargs)
-
-        return wrapper
-
-    for name, original in originals.items():
-        setattr(scores, name, make_wrapper(original))
-    try:
-        yield
-    finally:
-        for name, original in originals.items():
-            setattr(scores, name, original)
-
-
 # ---------------------------------------------------------------------------
 # Phase 3: Shared auth fixtures
 # ---------------------------------------------------------------------------

--- a/tests/scoring_engine/conftest.py
+++ b/tests/scoring_engine/conftest.py
@@ -74,6 +74,7 @@ def _insert_default_settings():
         ("inject_scores_visible", False),
         ("flag_points_user", "100"),
         ("flag_points_root", "200"),
+        ("scoreboard_freeze_time", ""),
     ]
     for name, value in settings:
         db.session.add(Setting(name=name, value=value))

--- a/tests/scoring_engine/engine/test_engine.py
+++ b/tests/scoring_engine/engine/test_engine.py
@@ -1113,3 +1113,43 @@ class TestUtcNow:
         # Within a couple seconds of real UTC (not local time).
         delta = abs((datetime.now(timezone.utc).replace(tzinfo=None) - now).total_seconds())
         assert delta < 5
+
+
+class TestCompetitionWindowGating:
+    def test_engine_idles_outside_window(self):
+        """With a competition window entirely in the past, the engine must idle
+        (sleep pause_duration) instead of running a round."""
+        from scoring_engine.models.competition_window import CompetitionWindow
+        from scoring_engine.models.round import Round
+
+        db.session.add(
+            CompetitionWindow(
+                name="past",
+                start_time=datetime(2020, 1, 1, 9, 0, 0),
+                end_time=datetime(2020, 1, 1, 17, 0, 0),
+                enabled=True,
+            )
+        )
+        db.session.commit()
+
+        engine = Engine()
+        sleeps = []
+
+        def fake_sleep(seconds):
+            sleeps.append(seconds)
+            engine.last_round = True  # break the loop after one idle cycle
+
+        engine.sleep = fake_sleep
+        engine.run()
+
+        assert sleeps  # it idled at least once
+        assert engine.rounds_run == 0
+        assert db.session.query(Round).count() == 0
+
+    def test_engine_runs_with_no_windows(self):
+        """No windows configured -> engine_should_run is unconditionally True, so
+        the loop reaches the round body (which we short-circuit via sleep)."""
+        from scoring_engine.engine.engine import engine_should_run
+
+        engine = Engine()
+        assert engine_should_run(session=db.session) is True

--- a/tests/scoring_engine/engine/test_engine.py
+++ b/tests/scoring_engine/engine/test_engine.py
@@ -37,7 +37,7 @@ from scoring_engine.checks.winrm import WinRMCheck
 from scoring_engine.checks.wordpress import WordpressCheck
 from scoring_engine.db import db
 from scoring_engine.engine.basic_check import CHECK_SUCCESS_TEXT, CHECK_TIMED_OUT_TEXT
-from scoring_engine.engine.engine import Engine
+from scoring_engine.engine.engine import Engine, _utcnow
 from scoring_engine.models.check import Check
 from scoring_engine.models.environment import Environment
 from scoring_engine.models.kb import KB
@@ -1085,7 +1085,7 @@ class TestConsecutiveRoundFailureBound:
         engine = Engine()
         sleeps = self._record_sleeps(engine)
 
-        engine._sleep_after_failed_round(datetime.now(), consecutive_failures=99)
+        engine._sleep_after_failed_round(_utcnow(), consecutive_failures=99)
 
         assert sleeps == [engine.ROUND_FAILURE_BACKOFF_MAX]
 
@@ -1099,6 +1099,17 @@ class TestConsecutiveRoundFailureBound:
         engine = Engine()
         sleeps = self._record_sleeps(engine)
 
-        engine._sleep_after_failed_round(datetime.now(), consecutive_failures=1)
+        engine._sleep_after_failed_round(_utcnow(), consecutive_failures=1)
 
         assert sleeps == [120]
+
+
+class TestUtcNow:
+    def test_returns_naive_utc(self):
+        from datetime import timezone
+
+        now = _utcnow()
+        assert now.tzinfo is None  # naive
+        # Within a couple seconds of real UTC (not local time).
+        delta = abs((datetime.now(timezone.utc).replace(tzinfo=None) - now).total_seconds())
+        assert delta < 5

--- a/tests/scoring_engine/helpers.py
+++ b/tests/scoring_engine/helpers.py
@@ -24,6 +24,11 @@ def populate_sample_data(session):
     check_2 = Check(service=service, result=False, output="Bad output", round=round_2)
     session.add(check_2)
     session.commit()
+    # Materialize round_score, as the engine does at round close, so score reads
+    # (now backed by round_score) reflect these checks.
+    from scoring_engine.scores import materialize_all_rounds
+
+    materialize_all_rounds(session)
     return team
 
 

--- a/tests/scoring_engine/models/test_team.py
+++ b/tests/scoring_engine/models/test_team.py
@@ -88,35 +88,38 @@ class TestTeam:
         assert team.current_score == 300
 
     def test_place(self):
+        from scoring_engine.models.round import Round
+        from scoring_engine.scores import materialize_all_rounds
+
+        # Checks always belong to a round in production; build them that way so
+        # round_score (which place reads) reflects them.
+        round_1 = Round(number=1)
+        round_2 = Round(number=2)
+        db.session.add_all([round_1, round_2])
+
         team_1 = Team(name="Blue Team 1", color="Blue")
         db.session.add(team_1)
         service_1 = Service(name="Example Service 1", team=team_1, check_name="ICMP IPv4 Check", host="127.0.0.1")
         db.session.add(service_1)
-        check_1 = Check(service=service_1, result=True, output="Good output")
-        check_2 = Check(service=service_1, result=True, output="Good output")
-        db.session.add(check_1)
-        db.session.add(check_2)
-        db.session.commit()
+        db.session.add(Check(service=service_1, result=True, output="Good output", round=round_1))
+        db.session.add(Check(service=service_1, result=True, output="Good output", round=round_2))
 
         team_2 = Team(name="Blue Team 2", color="Blue")
         db.session.add(team_2)
-        service_1 = Service(name="Example Service 1", team=team_2, check_name="ICMP IPv4 Check", host="127.0.0.1")
-        db.session.add(service_1)
-        check_1 = Check(service=service_1, result=True, output="Good output")
-        check_2 = Check(service=service_1, result=True, output="Good output")
-        db.session.add(check_1)
-        db.session.add(check_2)
-        db.session.commit()
+        service_2 = Service(name="Example Service 1", team=team_2, check_name="ICMP IPv4 Check", host="127.0.0.1")
+        db.session.add(service_2)
+        db.session.add(Check(service=service_2, result=True, output="Good output", round=round_1))
+        db.session.add(Check(service=service_2, result=True, output="Good output", round=round_2))
 
         team_3 = Team(name="Blue Team 3", color="Blue")
         db.session.add(team_3)
-        service_1 = Service(name="Example Service 1", team=team_3, check_name="ICMP IPv4 Check", host="127.0.0.1")
-        db.session.add(service_1)
-        check_1 = Check(service=service_1, result=True, output="Good output")
-        check_2 = Check(service=service_1, result=False, output="Bad output")
-        db.session.add(check_1)
-        db.session.add(check_2)
+        service_3 = Service(name="Example Service 1", team=team_3, check_name="ICMP IPv4 Check", host="127.0.0.1")
+        db.session.add(service_3)
+        db.session.add(Check(service=service_3, result=True, output="Good output", round=round_1))
+        db.session.add(Check(service=service_3, result=False, output="Bad output", round=round_2))
         db.session.commit()
+        materialize_all_rounds(db.session)
+
         assert team_1.place == 1
         assert team_2.place == 1
         assert team_3.place == 3

--- a/tests/scoring_engine/models/test_team.py
+++ b/tests/scoring_engine/models/test_team.py
@@ -62,21 +62,26 @@ class TestTeam:
         assert team.users == [user_1, user_2]
 
     def test_current_score(self):
+        from scoring_engine.models.round import Round
+
         team = generate_sample_model_tree("Team", db.session)
+        # Checks always belong to a round in production (the engine creates them
+        # inside one); build them that way so current_score, now read from the
+        # round_score materialization, reflects them. (The conftest autouse
+        # fixture keeps round_score in sync for the read.)
+        round_1 = Round(number=1)
+        round_2 = Round(number=2)
+        db.session.add_all([round_1, round_2])
         service_1 = Service(name="Example Service 1", team=team, check_name="ICMP IPv4 Check", host="127.0.0.1")
         db.session.add(service_1)
-        check_1 = Check(service=service_1, result=True, output="Good output")
-        db.session.add(check_1)
+        db.session.add(Check(service=service_1, result=True, output="Good output", round=round_1))
         service_2 = Service(name="Example Service 2", team=team, check_name="SSH IPv4 Check", host="127.0.0.2")
         db.session.add(service_2)
-        check_2 = Check(service=service_2, result=True, output="Good output")
-        db.session.add(check_2)
-        check_3 = Check(service=service_2, result=True, output="Good output")
-        db.session.add(check_3)
+        db.session.add(Check(service=service_2, result=True, output="Good output", round=round_1))
+        db.session.add(Check(service=service_2, result=True, output="Good output", round=round_2))
         service_3 = Service(name="Example Service 3", team=team, check_name="SSH IPv4 Check", host="127.0.0.3")
         db.session.add(service_3)
-        check_3 = Check(service=service_3, result=False, output="bad output")
-        db.session.add(check_3)
+        db.session.add(Check(service=service_3, result=False, output="bad output", round=round_1))
         db.session.commit()
         assert team.current_score == 300
 

--- a/tests/scoring_engine/models/test_team.py
+++ b/tests/scoring_engine/models/test_team.py
@@ -63,6 +63,7 @@ class TestTeam:
 
     def test_current_score(self):
         from scoring_engine.models.round import Round
+        from scoring_engine.scores import materialize_all_rounds
 
         team = generate_sample_model_tree("Team", db.session)
         # Checks always belong to a round in production (the engine creates them
@@ -83,6 +84,7 @@ class TestTeam:
         db.session.add(service_3)
         db.session.add(Check(service=service_3, result=False, output="bad output", round=round_1))
         db.session.commit()
+        materialize_all_rounds(db.session)
         assert team.current_score == 300
 
     def test_place(self):

--- a/tests/scoring_engine/test_competition_windows_api.py
+++ b/tests/scoring_engine/test_competition_windows_api.py
@@ -1,0 +1,103 @@
+"""Tests for the competition-window admin CRUD API.
+
+The engine/schedule logic is covered in test_schedule.py; here we cover the HTTP
+surface: white-team authorization, create/list/delete/toggle, input validation,
+and the naive->competition-tz->UTC parsing (mirroring the freeze endpoint).
+"""
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.competition_window import CompetitionWindow
+
+
+class TestWindowEndpoints:
+    @pytest.fixture(autouse=True)
+    def setup(self, white_login):
+        self.client, self.teams = white_login
+
+    def test_list_empty_by_default(self):
+        resp = self.client.get("/api/admin/windows")
+        assert resp.status_code == 200
+        assert resp.json == {"windows": []}
+
+    def test_create_and_list(self):
+        resp = self.client.post(
+            "/api/admin/windows",
+            json={"name": "Day 1", "start_time": "2026-07-27T09:00:00", "end_time": "2026-07-27T17:00:00"},
+        )
+        assert resp.status_code == 200
+        assert resp.json["status"] == "success"
+        assert resp.json["window"]["name"] == "Day 1"
+
+        listing = self.client.get("/api/admin/windows").json["windows"]
+        assert len(listing) == 1
+        assert listing[0]["enabled"] is True
+        # Input is interpreted in the competition timezone (US/Eastern in tests)
+        # and stored naive-UTC; the display localizes back to the entered time.
+        assert "09:00:00" in listing[0]["start_display"]
+        assert "17:00:00" in listing[0]["end_display"]
+
+    def test_create_rejects_end_before_start(self):
+        resp = self.client.post(
+            "/api/admin/windows",
+            json={"start_time": "2026-07-27T17:00:00", "end_time": "2026-07-27T09:00:00"},
+        )
+        assert resp.status_code == 400
+        assert db.session.query(CompetitionWindow).count() == 0
+
+    def test_create_rejects_equal_start_end(self):
+        resp = self.client.post(
+            "/api/admin/windows",
+            json={"start_time": "2026-07-27T09:00:00", "end_time": "2026-07-27T09:00:00"},
+        )
+        assert resp.status_code == 400
+
+    def test_create_rejects_missing_times(self):
+        resp = self.client.post("/api/admin/windows", json={"name": "no times"})
+        assert resp.status_code == 400
+
+    def test_delete(self):
+        wid = self.client.post(
+            "/api/admin/windows",
+            json={"start_time": "2026-07-27T09:00:00", "end_time": "2026-07-27T17:00:00"},
+        ).json["window"]["id"]
+        resp = self.client.delete(f"/api/admin/windows/{wid}")
+        assert resp.status_code == 200
+        assert self.client.get("/api/admin/windows").json["windows"] == []
+
+    def test_delete_missing_is_404(self):
+        assert self.client.delete("/api/admin/windows/99999").status_code == 404
+
+    def test_toggle_flips_enabled(self):
+        wid = self.client.post(
+            "/api/admin/windows",
+            json={"start_time": "2026-07-27T09:00:00", "end_time": "2026-07-27T17:00:00"},
+        ).json["window"]["id"]
+        # Default enabled -> PATCH with no body flips to disabled.
+        resp = self.client.patch(f"/api/admin/windows/{wid}")
+        assert resp.status_code == 200
+        assert resp.json["window"]["enabled"] is False
+        # Explicit enable.
+        resp = self.client.patch(f"/api/admin/windows/{wid}", json={"enabled": True})
+        assert resp.json["window"]["enabled"] is True
+
+    def test_requires_white_team(self):
+        self.client.get("/logout")
+        from tests.scoring_engine.conftest import _login
+
+        _login(self.client, "blueuser")
+        assert self.client.get("/api/admin/windows").status_code == 403
+        assert (
+            self.client.post(
+                "/api/admin/windows",
+                json={"start_time": "2026-07-27T09:00:00", "end_time": "2026-07-27T17:00:00"},
+            ).status_code
+            == 403
+        )
+        assert self.client.delete("/api/admin/windows/1").status_code == 403
+
+
+class TestWindowEndpointsAuth:
+    def test_requires_login(self, test_client):
+        assert test_client.get("/api/admin/windows").status_code == 302

--- a/tests/scoring_engine/test_consecutive_failures_cache.py
+++ b/tests/scoring_engine/test_consecutive_failures_cache.py
@@ -1,0 +1,137 @@
+"""Tests for the materialized SLA consecutive-failure cache.
+
+``Service.consecutive_failures_cache`` is maintained by the engine at round close
+via ``scores.apply_consecutive_failures`` (incremental, in memory) and repaired /
+backfilled via ``scores.recompute_consecutive_failures_cache`` (from checks). It
+must always equal ``sla.get_consecutive_failures`` (the check-scanning source of
+truth), or the batched penalty read (``team_penalties``) would score differently
+from the single-service path.
+
+These pin that invariant across round-by-round maintenance (pass resets, fail
+increments, a round with no check, multiple failing checks in one round), a full
+recompute, and a round rollback.
+"""
+
+from scoring_engine.db import db
+from scoring_engine.models.check import Check
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.team import Team
+from scoring_engine.scores import apply_consecutive_failures, recompute_consecutive_failures_cache
+from scoring_engine.sla import get_consecutive_failures
+
+
+def _cache(service_id):
+    return db.session.query(Service.consecutive_failures_cache).filter(Service.id == service_id).scalar()
+
+
+def _assert_cache_matches_scan(service_ids):
+    for sid in service_ids:
+        assert _cache(sid) == get_consecutive_failures(sid), f"service {sid}: cache {_cache(sid)} != scan"
+
+
+class TestConsecutiveFailuresCache:
+    def _setup_services(self, n=3):
+        team = Team(name="Blue", color="Blue")
+        db.session.add(team)
+        db.session.flush()
+        services = []
+        for i in range(n):
+            svc = Service(name=f"s{i}", check_name="ICMPCheck", host="127.0.0.1", team=team, points=100)
+            db.session.add(svc)
+            services.append(svc)
+        db.session.commit()
+        return services
+
+    def _run_round(self, number, results):
+        """Simulate the engine closing a round.
+
+        ``results`` maps a Service to its per-check results this round: True/False
+        for a single check, or a list for multiple checks (multi-environment).
+        A service absent from ``results`` is simply not checked this round.
+        """
+        rnd = Round(number=number)
+        db.session.add(rnd)
+        db.session.flush()
+        pass_ids = set()
+        fail_counts = {}
+        for svc, res in results.items():
+            outcomes = res if isinstance(res, list) else [res]
+            for outcome in outcomes:
+                db.session.add(Check(service=svc, round=rnd, result=outcome, completed=True, output=""))
+                if outcome:
+                    pass_ids.add(svc.id)
+                else:
+                    fail_counts[svc.id] = fail_counts.get(svc.id, 0) + 1
+        apply_consecutive_failures(db.session, pass_ids, fail_counts)
+        db.session.commit()
+        return rnd
+
+    def test_incremental_maintenance_matches_scan(self):
+        a, b, c = self._setup_services(3)
+        ids = [a.id, b.id, c.id]
+
+        self._run_round(1, {a: True, b: False, c: False})  # a=0 b=1 c=1
+        _assert_cache_matches_scan(ids)
+        assert (_cache(a.id), _cache(b.id), _cache(c.id)) == (0, 1, 1)
+
+        self._run_round(2, {a: False, b: False, c: True})  # a=1 b=2 c=0
+        _assert_cache_matches_scan(ids)
+        assert (_cache(a.id), _cache(b.id), _cache(c.id)) == (1, 2, 0)
+
+        self._run_round(3, {a: False, b: True})  # c not checked -> unchanged
+        _assert_cache_matches_scan(ids)
+        assert (_cache(a.id), _cache(b.id), _cache(c.id)) == (2, 0, 0)
+
+        # c fails twice in one round (two environments) -> streak jumps by 2.
+        self._run_round(4, {a: True, b: False, c: [False, False]})  # a=0 b=1 c=2
+        _assert_cache_matches_scan(ids)
+        assert (_cache(a.id), _cache(b.id), _cache(c.id)) == (0, 1, 2)
+
+    def test_recompute_matches_scan(self):
+        a, b, c = self._setup_services(3)
+        ids = [a.id, b.id, c.id]
+        # Build history directly (as if the cache had never been maintained).
+        for number, results in enumerate(
+            [{a: True, b: False, c: False}, {a: False, b: False, c: False}, {a: False, b: True, c: False}], start=1
+        ):
+            rnd = Round(number=number)
+            db.session.add(rnd)
+            db.session.flush()
+            for svc, res in results.items():
+                db.session.add(Check(service=svc, round=rnd, result=res, completed=True, output=""))
+        db.session.commit()
+
+        recompute_consecutive_failures_cache(db.session)
+        _assert_cache_matches_scan(ids)
+        # a failed rounds 2,3; b passed round 3; c failed all three.
+        assert (_cache(a.id), _cache(b.id), _cache(c.id)) == (2, 0, 3)
+
+    def test_recompute_subset_only_touches_given_services(self):
+        a, b = self._setup_services(2)
+        r = Round(number=1)
+        db.session.add(r)
+        db.session.flush()
+        db.session.add(Check(service=a, round=r, result=False, completed=True, output=""))
+        db.session.add(Check(service=b, round=r, result=False, completed=True, output=""))
+        db.session.commit()
+        recompute_consecutive_failures_cache(db.session, service_ids=[a.id])
+        assert _cache(a.id) == 1  # recomputed
+        assert _cache(b.id) == 0  # untouched (default), even though it has a failing check
+
+    def test_rollback_repairs_cache(self):
+        a, b, c = self._setup_services(3)
+        ids = [a.id, b.id, c.id]
+        self._run_round(1, {a: False, b: False, c: True})
+        r2 = self._run_round(2, {a: False, b: False, c: False})  # a=2 b=2 c=1
+        assert (_cache(a.id), _cache(b.id), _cache(c.id)) == (2, 2, 1)
+
+        # Delete round 2 (rollback) and repair the affected services.
+        affected = [row[0] for row in db.session.query(Check.service_id).filter(Check.round_id == r2.id).distinct()]
+        db.session.query(Check).filter(Check.round_id == r2.id).delete(synchronize_session=False)
+        db.session.query(Round).filter(Round.id == r2.id).delete(synchronize_session=False)
+        recompute_consecutive_failures_cache(db.session, service_ids=affected)
+
+        _assert_cache_matches_scan(ids)
+        # Back to the round-1 state: a=1 b=1 c=0.
+        assert (_cache(a.id), _cache(b.id), _cache(c.id)) == (1, 1, 0)

--- a/tests/scoring_engine/test_flag_scoring.py
+++ b/tests/scoring_engine/test_flag_scoring.py
@@ -1,0 +1,106 @@
+"""Tests for red-team flag scoring (wave 2, phase 4).
+
+A captured flag is a non-dummy Solve (a blue team's agent reported a red flag
+present on one of its hosts). Each is worth flag_points_user or flag_points_root
+by the flag's permission level; the total accrues to the red team, and a blue
+team's own score is unaffected ("add to red only").
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from scoring_engine.db import db
+from scoring_engine.models.flag import Flag, FlagTypeEnum, Perm, Platform, Solve
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.scores import flag_points_by_team, get_flag_point_values, red_team_flag_total
+
+
+def _flag(perm, dummy=False):
+    flag = Flag(
+        type=FlagTypeEnum.file,
+        platform=Platform.nix,
+        perm=perm,
+        data={"path": "/tmp/f", "content": "x"},
+        start_time=datetime.now(timezone.utc) - timedelta(minutes=5),
+        end_time=datetime.now(timezone.utc) + timedelta(hours=1),
+        dummy=dummy,
+    )
+    db.session.add(flag)
+    db.session.commit()
+    return flag
+
+
+def _solve(flag, team, host):
+    solve = Solve(host=host, team=team, flag=flag)
+    db.session.add(solve)
+    db.session.commit()
+    return solve
+
+
+class TestGetFlagPointValues:
+    def test_defaults_from_seeded_settings(self):
+        assert get_flag_point_values() == (100, 200)
+
+    def test_reads_overridden_settings(self):
+        for name, value in (("flag_points_user", "5"), ("flag_points_root", "50")):
+            setting = Setting.get_setting(name)
+            setting.value = value
+            db.session.commit()
+            Setting.clear_cache(name)
+        assert get_flag_point_values() == (5, 50)
+
+
+class TestFlagPointsByTeam:
+    def test_sums_by_permission_level(self):
+        team = Team(name="Blue 1", color="Blue")
+        db.session.add(team)
+        db.session.commit()
+        user_flag = _flag(Perm.user)
+        root_flag = _flag(Perm.root)
+        _solve(user_flag, team, "host-a")
+        _solve(user_flag, team, "host-b")  # same flag, different host -> another capture
+        _solve(root_flag, team, "host-a")
+
+        # 2 user captures * 100 + 1 root capture * 200 = 400
+        assert flag_points_by_team(db.session) == {team.id: 400}
+
+    def test_dummy_flags_excluded(self):
+        team = Team(name="Blue 1", color="Blue")
+        db.session.add(team)
+        db.session.commit()
+        _solve(_flag(Perm.user), team, "host-a")
+        _solve(_flag(Perm.root, dummy=True), team, "host-b")  # dummy: not scored
+        assert flag_points_by_team(db.session) == {team.id: 100}
+
+    def test_no_solves_is_empty(self):
+        team = Team(name="Blue 1", color="Blue")
+        db.session.add(team)
+        db.session.commit()
+        assert flag_points_by_team(db.session) == {}
+
+    def test_explicit_point_values_override_config(self):
+        team = Team(name="Blue 1", color="Blue")
+        db.session.add(team)
+        db.session.commit()
+        _solve(_flag(Perm.root), team, "host-a")
+        assert flag_points_by_team(db.session, user_points=1, root_points=7) == {team.id: 7}
+
+
+class TestRedTeamFlagTotal:
+    def test_total_is_sum_across_all_blue_teams(self):
+        blue1 = Team(name="Blue 1", color="Blue")
+        blue2 = Team(name="Blue 2", color="Blue")
+        db.session.add_all([blue1, blue2])
+        db.session.commit()
+        user_flag = _flag(Perm.user)
+        root_flag = _flag(Perm.root)
+        _solve(user_flag, blue1, "h1")  # 100
+        _solve(root_flag, blue1, "h1")  # 200
+        _solve(user_flag, blue2, "h1")  # 100
+
+        assert red_team_flag_total(db.session) == 400
+
+    def test_zero_when_nothing_captured(self):
+        db.session.add(Team(name="Blue 1", color="Blue"))
+        db.session.commit()
+        assert red_team_flag_total(db.session) == 0

--- a/tests/scoring_engine/test_freeze.py
+++ b/tests/scoring_engine/test_freeze.py
@@ -48,6 +48,36 @@ class TestGetFreezeTime:
         assert get_freeze_time() is None
 
 
+class TestGetFreezeTimeSchedule:
+    """get_freeze_time composes the manual freeze with the competition schedule."""
+
+    def _past_window(self):
+        # A window entirely in the past, so "now" is always after it and it
+        # deterministically implies a freeze at its close.
+        from scoring_engine.models.competition_window import CompetitionWindow
+
+        end = datetime(2020, 1, 1, 17, 0, 0)
+        db.session.add(
+            CompetitionWindow(name="past", start_time=datetime(2020, 1, 1, 9, 0, 0), end_time=end, enabled=True)
+        )
+        db.session.commit()
+        return end
+
+    def test_manual_freeze_overrides_schedule(self):
+        self._past_window()
+        _set_freeze("2026-01-01T10:30:00")
+        assert get_freeze_time() == FREEZE
+
+    def test_schedule_derived_when_no_manual_freeze(self):
+        end = self._past_window()
+        _set_freeze("")
+        assert get_freeze_time() == end
+
+    def test_no_manual_no_windows_is_not_frozen(self):
+        _set_freeze("")
+        assert get_freeze_time() is None
+
+
 class TestServiceScoreFreeze:
     def test_only_rounds_closed_before_freeze_count(self):
         team = make_team(color="Blue")

--- a/tests/scoring_engine/test_freeze.py
+++ b/tests/scoring_engine/test_freeze.py
@@ -1,0 +1,178 @@
+"""Tests for the wall-clock scoreboard freeze (wave 2, phase 6)."""
+
+from datetime import datetime
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.flag import Flag, FlagTypeEnum, Perm, Platform, Solve
+from scoring_engine.models.score_adjustment import ScoreAdjustment
+from scoring_engine.models.setting import Setting
+from scoring_engine.scores import (
+    all_team_service_scores,
+    flag_points_by_team,
+    get_freeze_time,
+    materialize_all_rounds,
+    team_adjustment_totals,
+)
+from tests.scoring_engine.factories import make_check, make_round, make_service, make_team
+
+# A fixed timeline: round 1 closes at T1, round 2 at T2; freeze falls between them.
+T1 = datetime(2026, 1, 1, 10, 0, 0)
+T2 = datetime(2026, 1, 1, 11, 0, 0)
+FREEZE = datetime(2026, 1, 1, 10, 30, 0)
+
+
+def _set_freeze(value):
+    setting = Setting.get_setting("scoreboard_freeze_time")
+    setting.value = value
+    db.session.commit()
+    Setting.clear_cache("scoreboard_freeze_time")
+
+
+class TestGetFreezeTime:
+    def test_empty_setting_is_not_frozen(self):
+        _set_freeze("")
+        assert get_freeze_time() is None
+
+    def test_iso_value_parses_to_naive_utc(self):
+        _set_freeze("2026-01-01T10:30:00")
+        assert get_freeze_time() == FREEZE
+
+    def test_tz_aware_value_normalized_to_utc(self):
+        _set_freeze("2026-01-01T05:30:00-05:00")  # == 10:30 UTC
+        assert get_freeze_time() == FREEZE
+
+    def test_garbage_value_is_not_frozen(self):
+        _set_freeze("not a date")
+        assert get_freeze_time() is None
+
+
+class TestServiceScoreFreeze:
+    def test_only_rounds_closed_before_freeze_count(self):
+        team = make_team(color="Blue")
+        svc = make_service(team=team)
+        svc.points = 100
+        db.session.commit()
+        r1 = make_round(number=1, round_end=T1)
+        r2 = make_round(number=2, round_end=T2)
+        make_check(service=svc, round_obj=r1, result=True)
+        make_check(service=svc, round_obj=r2, result=True)
+        materialize_all_rounds(db.session)
+
+        assert all_team_service_scores(db.session) == {team.id: 200}  # live
+        assert all_team_service_scores(db.session, freeze_time=FREEZE) == {team.id: 100}  # frozen
+
+    def test_round_still_open_is_excluded_by_freeze(self):
+        team = make_team(color="Blue")
+        svc = make_service(team=team)
+        svc.points = 100
+        db.session.commit()
+        r1 = make_round(number=1, round_end=T1)
+        r_open = make_round(number=2, round_end=None)  # in progress: no round_end
+        make_check(service=svc, round_obj=r1, result=True)
+        make_check(service=svc, round_obj=r_open, result=True)
+        materialize_all_rounds(db.session)
+
+        # Only the closed round counts under a freeze.
+        assert all_team_service_scores(db.session, freeze_time=FREEZE) == {team.id: 100}
+
+
+class TestAdjustmentFreeze:
+    def test_only_adjustments_before_freeze_count(self):
+        team = make_team(color="Blue")
+        db.session.commit()
+        db.session.add_all(
+            [
+                ScoreAdjustment(team_id=team.id, points=100, reason="early", created_at=T1),
+                ScoreAdjustment(team_id=team.id, points=50, reason="late", created_at=T2),
+            ]
+        )
+        db.session.commit()
+        assert team_adjustment_totals(db.session) == {team.id: 150}
+        assert team_adjustment_totals(db.session, freeze_time=FREEZE) == {team.id: 100}
+
+
+class TestFlagFreeze:
+    def test_only_solves_before_freeze_count(self):
+        team = make_team(color="Blue")
+        db.session.commit()
+        flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.nix,
+            perm=Perm.user,
+            data={"path": "/f", "content": "x"},
+            start_time=T1,
+            end_time=T2,
+            dummy=False,
+        )
+        db.session.add(flag)
+        db.session.commit()
+        db.session.add_all(
+            [
+                Solve(host="h1", team=team, flag=flag, created_at=T1),
+                Solve(host="h2", team=team, flag=flag, created_at=T2),
+            ]
+        )
+        db.session.commit()
+        assert flag_points_by_team(db.session) == {team.id: 200}  # both, 100 each
+        assert flag_points_by_team(db.session, freeze_time=FREEZE) == {team.id: 100}  # only the early one
+
+
+class TestFreezeEndpoints:
+    @pytest.fixture(autouse=True)
+    def setup(self, white_login):
+        self.client, self.teams = white_login
+
+    def test_status_not_frozen_by_default(self):
+        assert self.client.get("/api/scoreboard/freeze_status").json == {"frozen": False}
+
+    def test_admin_set_and_status(self):
+        resp = self.client.post("/api/admin/freeze", json={"freeze_time": "2026-01-01T10:30:00"})
+        assert resp.status_code == 200
+        status = self.client.get("/api/scoreboard/freeze_status").json
+        assert status["frozen"] is True
+        assert status["white_live"] is True  # setup logged in as white
+        assert "freeze_epoch" in status and "server_epoch" in status
+
+    def test_admin_clear(self):
+        self.client.post("/api/admin/freeze", json={"freeze_time": "2026-01-01T10:30:00"})
+        self.client.post("/api/admin/freeze", json={"freeze_time": ""})
+        assert self.client.get("/api/scoreboard/freeze_status").json == {"frozen": False}
+
+    def test_set_requires_white_team(self):
+        self.client.get("/logout")
+        from tests.scoring_engine.conftest import _login
+
+        _login(self.client, "blueuser")
+        resp = self.client.post("/api/admin/freeze", json={"freeze_time": "2026-01-01T10:30:00"})
+        assert resp.status_code == 403
+
+
+class TestScoreboardFreezeView:
+    def test_white_sees_live_others_see_frozen(self, test_client, three_teams):
+        blue = three_teams["blue_team"]
+        svc = make_service(team=blue)
+        svc.points = 100
+        db.session.commit()
+        r1 = make_round(number=1, round_end=T1)
+        r2 = make_round(number=2, round_end=T2)
+        make_check(service=svc, round_obj=r1, result=True)
+        make_check(service=svc, round_obj=r2, result=True)
+        materialize_all_rounds(db.session)
+        _set_freeze("2026-01-01T10:30:00")
+
+        from tests.scoring_engine.conftest import _login
+
+        # White: live (both rounds -> 200)
+        _login(test_client, "whiteuser")
+        white_data = test_client.get("/api/scoreboard/get_bar_data").json
+        wi = white_data["labels"].index("Blue Team")
+        assert white_data["service_scores"][wi] == "200"
+
+        # Blue (a competitor): frozen (only round 1 -> 100)
+        test_client.get("/logout")
+        _login(test_client, "blueuser")
+        blue_data = test_client.get("/api/scoreboard/get_bar_data").json
+        bi = blue_data["labels"].index("Blue Team")
+        assert blue_data["service_scores"][bi] == "100"

--- a/tests/scoring_engine/test_indexes.py
+++ b/tests/scoring_engine/test_indexes.py
@@ -72,8 +72,16 @@ class TestModelIndexDeclarations:
         assert actual_columns == expected_columns
 
     def test_no_undeclared_extra_indexes(self):
-        """Guard against a stray index landing in the models without a migration."""
-        declared = set(self._metadata_indexes())
+        """Guard against a stray index on a 003-managed table without a migration.
+
+        Scoped to the tables migration 003 owns. A later migration that adds a new
+        table with its own indexes (e.g. 005's round_score) is legitimate and must
+        not trip this guard -- it is validated by that migration's own test.
+        """
+        managed_tables = {table for table, _cols in EXPECTED_INDEXES.values()}
+        declared = {
+            name for name, (table, _cols) in self._metadata_indexes().items() if table in managed_tables
+        }
         assert declared == set(EXPECTED_INDEXES)
 
     def test_flag_solves_unique_constraint_still_present(self):

--- a/tests/scoring_engine/test_indexes.py
+++ b/tests/scoring_engine/test_indexes.py
@@ -31,6 +31,15 @@ EXPECTED_INDEXES = {
     "ix_kb_name_round_num": ("kb", ["name", "round_num"]),
 }
 
+# Indexes on 003-managed tables added by LATER migrations (each with its own
+# migration + migration test). Registered here so the "no undeclared index"
+# guard and the create_all check treat them as legitimate, without implying they
+# belong to the 003 migration set (test_migration_declares_same_indexes below
+# stays scoped to EXPECTED_INDEXES).
+POST_003_INDEXES = {
+    "ix_checks_sla_scan": ("checks", ["service_id", "completed", "result", "round_id"]),  # migration 009
+}
+
 _MIGRATION_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
     "alembic",
@@ -78,11 +87,18 @@ class TestModelIndexDeclarations:
         table with its own indexes (e.g. 005's round_score) is legitimate and must
         not trip this guard -- it is validated by that migration's own test.
         """
-        managed_tables = {table for table, _cols in EXPECTED_INDEXES.values()}
+        all_expected = {**EXPECTED_INDEXES, **POST_003_INDEXES}
+        managed_tables = {table for table, _cols in all_expected.values()}
         declared = {
             name for name, (table, _cols) in self._metadata_indexes().items() if table in managed_tables
         }
-        assert declared == set(EXPECTED_INDEXES)
+        assert declared == set(all_expected)
+
+    @pytest.mark.parametrize("index_name", sorted(POST_003_INDEXES))
+    def test_later_migration_index_declared_on_model(self, index_name):
+        declared = self._metadata_indexes()
+        assert index_name in declared, f"{index_name} is not declared in any model's __table_args__"
+        assert declared[index_name] == POST_003_INDEXES[index_name]
 
     def test_flag_solves_unique_constraint_still_present(self):
         """The new index is additive — the existing unique constraint stays."""
@@ -93,9 +109,9 @@ class TestModelIndexDeclarations:
 class TestIndexesExistInDatabase:
     """create_all() (used by bin/setup on fresh installs) must build them."""
 
-    @pytest.mark.parametrize("index_name", sorted(EXPECTED_INDEXES))
+    @pytest.mark.parametrize("index_name", sorted({**EXPECTED_INDEXES, **POST_003_INDEXES}))
     def test_index_created_by_create_all(self, index_name, db_session):
-        table_name, expected_columns = EXPECTED_INDEXES[index_name]
+        table_name, expected_columns = {**EXPECTED_INDEXES, **POST_003_INDEXES}[index_name]
         inspector = sa.inspect(db.engine)
         indexes = {i["name"]: i for i in inspector.get_indexes(table_name)}
         assert index_name in indexes, f"{index_name} missing from live {table_name} schema"

--- a/tests/scoring_engine/test_migration_005_round_score.py
+++ b/tests/scoring_engine/test_migration_005_round_score.py
@@ -1,0 +1,129 @@
+"""Tests for alembic migration 005 (round_score table + backfill).
+
+The migration must, against a database that predates it:
+  1. create the round_score table and its indexes, and
+  2. backfill it exactly from existing checks -- the reconstructed per-team,
+     per-round service_points must equal what scoring_engine.scores would compute
+     live, so a mid-competition upgrade does not change any team's score.
+"""
+
+import importlib.util
+import os
+
+import pytest
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+
+from scoring_engine.db import db
+
+_MIGRATION_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "alembic",
+    "versions",
+    "005_add_round_score.py",
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_005", _MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def migration():
+    return _load_migration()
+
+
+class TestMigration005:
+    @pytest.fixture()
+    def legacy_engine(self, tmp_path):
+        """Full current schema, then drop round_score to simulate a pre-005 DB."""
+        engine = sa.create_engine(f"sqlite:///{tmp_path}/legacy.db")
+        db.metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(sa.text("DROP TABLE round_score"))
+        yield engine
+        engine.dispose()
+
+    @staticmethod
+    def _seed_checks(conn):
+        """Insert two blue teams, services with distinct points, rounds, checks.
+
+        Team 1: svc worth 100 (up in rounds 1,2), svc worth 25 (up in round 1)
+                -> round 1 = 125, round 2 = 100, total 225
+        Team 2: svc worth 40 (down every round) -> no rows, total 0
+        """
+        conn.execute(sa.text("INSERT INTO teams (id, name, color) VALUES (1, 'B1', 'Blue'), (2, 'B2', 'Blue')"))
+        conn.execute(
+            sa.text(
+                "INSERT INTO services (id, name, check_name, team_id, points, host, port) VALUES "
+                "(1, 'A', 'ICMPCheck', 1, 100, 'h', 1), "
+                "(2, 'B', 'ICMPCheck', 1, 25, 'h', 1), "
+                "(3, 'C', 'ICMPCheck', 2, 40, 'h', 1)"
+            )
+        )
+        conn.execute(sa.text("INSERT INTO rounds (id, number) VALUES (1, 1), (2, 2)"))
+        conn.execute(
+            sa.text(
+                "INSERT INTO checks (id, round_id, service_id, result, completed) VALUES "
+                "(1, 1, 1, 1, 1), "  # team1 svc A up, round 1
+                "(2, 1, 2, 1, 1), "  # team1 svc B up, round 1
+                "(3, 2, 1, 1, 1), "  # team1 svc A up, round 2
+                "(4, 2, 2, 0, 1), "  # team1 svc B down, round 2
+                "(5, 1, 3, 0, 1), "  # team2 svc C down, round 1
+                "(6, 2, 3, 0, 1)"  # team2 svc C down, round 2
+            )
+        )
+
+    def test_upgrade_creates_table_and_backfills_exactly(self, legacy_engine, migration):
+        with legacy_engine.begin() as conn:
+            self._seed_checks(conn)
+            assert "round_score" not in sa.inspect(conn).get_table_names()
+
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()
+
+            assert "round_score" in sa.inspect(conn).get_table_names()
+            rows = conn.execute(
+                sa.text(
+                    "SELECT round_number, team_id, service_points, flag_points "
+                    "FROM round_score ORDER BY round_number, team_id"
+                )
+            ).fetchall()
+
+        # Only non-zero (team, round) rows; team 2 never passes so it is absent.
+        assert [tuple(r) for r in rows] == [
+            (1, 1, 125, 0),
+            (2, 1, 100, 0),
+        ]
+
+    def test_indexes_created(self, legacy_engine, migration):
+        with legacy_engine.begin() as conn:
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()
+            names = {i["name"] for i in sa.inspect(conn).get_indexes("round_score")}
+        assert "ix_round_score_team_round" in names
+        assert "ix_round_score_round_number" in names
+
+    def test_downgrade_drops_table(self, legacy_engine, migration):
+        with legacy_engine.begin() as conn:
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()
+                assert "round_score" in sa.inspect(conn).get_table_names()
+                migration.downgrade()
+            assert "round_score" not in sa.inspect(conn).get_table_names()
+
+    def test_upgrade_idempotent_when_table_exists(self, migration, tmp_path):
+        """A fresh install already has round_score (via create_all); upgrade is a no-op."""
+        engine = sa.create_engine(f"sqlite:///{tmp_path}/fresh.db")
+        db.metadata.create_all(engine)
+        try:
+            with engine.begin() as conn:
+                with Operations.context(MigrationContext.configure(conn)):
+                    migration.upgrade()  # must not raise "table already exists"
+                assert "round_score" in sa.inspect(conn).get_table_names()
+        finally:
+            engine.dispose()

--- a/tests/scoring_engine/test_migration_008_competition_window.py
+++ b/tests/scoring_engine/test_migration_008_competition_window.py
@@ -1,0 +1,77 @@
+"""Tests for alembic migration 008 (competition_window table).
+
+Against a database that predates it, the migration must create the
+competition_window table and its index; the downgrade must drop them. On a fresh
+install (table already present via create_all) upgrade is a no-op.
+"""
+
+import importlib.util
+import os
+
+import pytest
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+
+from scoring_engine.db import db
+
+_MIGRATION_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "alembic",
+    "versions",
+    "008_add_competition_window.py",
+)
+
+TABLE = "competition_window"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_008", _MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def migration():
+    return _load_migration()
+
+
+class TestMigration008:
+    @pytest.fixture()
+    def legacy_engine(self, tmp_path):
+        """Full current schema, then drop competition_window to simulate a pre-008 DB."""
+        engine = sa.create_engine(f"sqlite:///{tmp_path}/legacy.db")
+        db.metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(sa.text(f"DROP TABLE {TABLE}"))
+        yield engine
+        engine.dispose()
+
+    def test_upgrade_creates_table_and_index(self, legacy_engine, migration):
+        with legacy_engine.begin() as conn:
+            assert TABLE not in sa.inspect(conn).get_table_names()
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()
+            assert TABLE in sa.inspect(conn).get_table_names()
+            cols = {c["name"] for c in sa.inspect(conn).get_columns(TABLE)}
+            assert {"id", "name", "start_time", "end_time", "enabled"} <= cols
+            names = {i["name"] for i in sa.inspect(conn).get_indexes(TABLE)}
+            assert "ix_competition_window_start" in names
+
+    def test_upgrade_is_noop_when_table_exists(self, migration):
+        # Fresh install: table already present via create_all() on the test DB.
+        engine = db.session.get_bind()
+        with engine.connect() as conn:
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()  # must not raise
+            assert TABLE in sa.inspect(conn).get_table_names()
+
+    def test_downgrade_drops_table(self, legacy_engine, migration):
+        with legacy_engine.begin() as conn:
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()
+            assert TABLE in sa.inspect(conn).get_table_names()
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.downgrade()
+            assert TABLE not in sa.inspect(conn).get_table_names()

--- a/tests/scoring_engine/test_migration_009_checks_sla_scan.py
+++ b/tests/scoring_engine/test_migration_009_checks_sla_scan.py
@@ -1,0 +1,75 @@
+"""Tests for alembic migration 009 (ix_checks_sla_scan index).
+
+Against a database that predates it, the migration must create the composite
+index; the downgrade drops it. On a fresh install (index already present via
+create_all) upgrade is a no-op.
+"""
+
+import importlib.util
+import os
+
+import pytest
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+
+from scoring_engine.db import db
+
+_MIGRATION_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "alembic",
+    "versions",
+    "009_add_checks_sla_scan_index.py",
+)
+
+TABLE = "checks"
+INDEX = "ix_checks_sla_scan"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_009", _MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def migration():
+    return _load_migration()
+
+
+class TestMigration009:
+    @pytest.fixture()
+    def legacy_engine(self, tmp_path):
+        """Full current schema, then drop the index to simulate a pre-009 DB."""
+        engine = sa.create_engine(f"sqlite:///{tmp_path}/legacy.db")
+        db.metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(sa.text(f"DROP INDEX {INDEX}"))
+        yield engine
+        engine.dispose()
+
+    def test_upgrade_creates_index(self, legacy_engine, migration):
+        with legacy_engine.begin() as conn:
+            assert INDEX not in {i["name"] for i in sa.inspect(conn).get_indexes(TABLE)}
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()
+            idx = {i["name"]: i["column_names"] for i in sa.inspect(conn).get_indexes(TABLE)}
+            assert INDEX in idx
+            assert idx[INDEX] == ["service_id", "completed", "result", "round_id"]
+
+    def test_upgrade_is_noop_when_present(self, migration):
+        engine = db.session.get_bind()
+        with engine.connect() as conn:
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()  # must not raise
+            assert INDEX in {i["name"] for i in sa.inspect(conn).get_indexes(TABLE)}
+
+    def test_downgrade_drops_index(self, legacy_engine, migration):
+        with legacy_engine.begin() as conn:
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()
+            assert INDEX in {i["name"] for i in sa.inspect(conn).get_indexes(TABLE)}
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.downgrade()
+            assert INDEX not in {i["name"] for i in sa.inspect(conn).get_indexes(TABLE)}

--- a/tests/scoring_engine/test_migration_010_consecutive_failures_cache.py
+++ b/tests/scoring_engine/test_migration_010_consecutive_failures_cache.py
@@ -1,0 +1,102 @@
+"""Tests for alembic migration 010 (services.consecutive_failures_cache).
+
+The migration adds the column and backfills it from check history so an upgraded
+database is correct without waiting for the engine to run. The backfill must
+match scores._service_consecutive_failures: completed failing checks in rounds
+after the service's last passing round (all of them if it never passed).
+"""
+
+import importlib.util
+import os
+
+import pytest
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+
+from scoring_engine.db import db
+
+_MIGRATION_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "alembic",
+    "versions",
+    "010_add_service_consecutive_failures_cache.py",
+)
+
+TABLE = "services"
+COLUMN = "consecutive_failures_cache"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_010", _MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def migration():
+    return _load_migration()
+
+
+def _seed(conn):
+    """svc1 never passes (3 fails -> 3); svc2 fails,passes,fails (-> 1); svc3 all pass (-> 0)."""
+    conn.execute(sa.text("INSERT INTO teams (id, name, color) VALUES (1, 'B', 'Blue')"))
+    conn.execute(
+        sa.text(
+            "INSERT INTO services (id, name, check_name, team_id, points, host, port) VALUES "
+            "(1,'a','ICMPCheck',1,100,'h',1),(2,'b','ICMPCheck',1,100,'h',1),(3,'c','ICMPCheck',1,100,'h',1)"
+        )
+    )
+    conn.execute(sa.text("INSERT INTO rounds (id, number) VALUES (1,1),(2,2),(3,3)"))
+    conn.execute(
+        sa.text(
+            "INSERT INTO checks (id, round_id, service_id, result, completed) VALUES "
+            "(1,1,1,0,1),(2,2,1,0,1),(3,3,1,0,1),"  # svc1: fail,fail,fail
+            "(4,1,2,0,1),(5,2,2,1,1),(6,3,2,0,1),"  # svc2: fail,pass,fail
+            "(7,1,3,1,1),(8,2,3,1,1),(9,3,3,1,1)"  # svc3: pass,pass,pass
+        )
+    )
+
+
+class TestMigration010:
+    @pytest.fixture()
+    def legacy_engine(self, tmp_path):
+        """Full schema, then drop the column to simulate a pre-010 DB."""
+        engine = sa.create_engine(f"sqlite:///{tmp_path}/legacy.db")
+        db.metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(sa.text(f"ALTER TABLE {TABLE} DROP COLUMN {COLUMN}"))
+        yield engine
+        engine.dispose()
+
+    def test_upgrade_adds_column_and_backfills(self, legacy_engine, migration):
+        with legacy_engine.begin() as conn:
+            _seed(conn)
+            assert COLUMN not in {c["name"] for c in sa.inspect(conn).get_columns(TABLE)}
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()
+            assert COLUMN in {c["name"] for c in sa.inspect(conn).get_columns(TABLE)}
+            rows = conn.execute(sa.text(f"SELECT id, {COLUMN} FROM {TABLE} ORDER BY id")).fetchall()
+        assert [tuple(r) for r in rows] == [(1, 3), (2, 1), (3, 0)]
+
+    def test_backfill_runs_when_column_already_present(self, tmp_path, migration):
+        """Fresh-install shape: column exists (create_all), upgrade just backfills."""
+        engine = sa.create_engine(f"sqlite:///{tmp_path}/fresh.db")
+        db.metadata.create_all(engine)
+        with engine.begin() as conn:
+            _seed(conn)
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()  # column present -> add skipped, backfill runs
+            rows = conn.execute(sa.text(f"SELECT id, {COLUMN} FROM {TABLE} ORDER BY id")).fetchall()
+        engine.dispose()
+        assert [tuple(r) for r in rows] == [(1, 3), (2, 1), (3, 0)]
+
+    def test_downgrade_drops_column(self, legacy_engine, migration):
+        with legacy_engine.begin() as conn:
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.upgrade()
+            assert COLUMN in {c["name"] for c in sa.inspect(conn).get_columns(TABLE)}
+            with Operations.context(MigrationContext.configure(conn)):
+                migration.downgrade()
+            assert COLUMN not in {c["name"] for c in sa.inspect(conn).get_columns(TABLE)}

--- a/tests/scoring_engine/test_schedule.py
+++ b/tests/scoring_engine/test_schedule.py
@@ -1,0 +1,105 @@
+"""Tests for competition scheduling (scoring_engine.schedule).
+
+Windows gate the engine (engine_should_run) and imply a display freeze between
+windows (window_derived_freeze). With no windows the system behaves exactly as
+before: the engine always runs and the schedule implies no freeze.
+
+Redis is disabled in tests (cache_type=null), so get_windows queries the DB
+directly -- these tests exercise that path and never touch a cache.
+"""
+
+from datetime import datetime
+
+from scoring_engine.db import db
+from scoring_engine.models.competition_window import CompetitionWindow
+from scoring_engine.schedule import engine_should_run, get_windows, window_derived_freeze
+
+
+def _mk(start, end, enabled=True, name=None):
+    w = CompetitionWindow(name=name, start_time=start, end_time=end, enabled=enabled)
+    db.session.add(w)
+    db.session.commit()
+    return w
+
+
+# Day 1: 09:00-17:00, Day 2: 09:00-17:00 (naive UTC).
+D1_START = datetime(2026, 7, 27, 9, 0, 0)
+D1_END = datetime(2026, 7, 27, 17, 0, 0)
+D2_START = datetime(2026, 7, 28, 9, 0, 0)
+D2_END = datetime(2026, 7, 28, 17, 0, 0)
+
+
+class TestGetWindows:
+    def test_empty_when_none(self):
+        assert get_windows(session=db.session) == []
+
+    def test_excludes_disabled_and_sorts(self):
+        _mk(D2_START, D2_END, name="Day 2")
+        _mk(D1_START, D1_END, name="Day 1")
+        _mk(D1_START, D1_END, enabled=False, name="Parked")
+        windows = get_windows(session=db.session)
+        # Disabled excluded, remaining sorted by start.
+        assert [w["name"] for w in windows] == ["Day 1", "Day 2"]
+        assert windows[0]["start"] == D1_START
+        assert windows[0]["end"] == D1_END
+
+
+class TestEngineShouldRun:
+    def test_no_windows_always_runs(self):
+        assert engine_should_run(now=datetime(2026, 1, 1, 3, 0, 0), session=db.session) is True
+
+    def test_inside_window_runs(self):
+        _mk(D1_START, D1_END)
+        assert engine_should_run(now=datetime(2026, 7, 27, 12, 0, 0), session=db.session) is True
+
+    def test_before_first_window_pauses(self):
+        _mk(D1_START, D1_END)
+        assert engine_should_run(now=datetime(2026, 7, 27, 8, 0, 0), session=db.session) is False
+
+    def test_between_windows_pauses(self):
+        _mk(D1_START, D1_END)
+        _mk(D2_START, D2_END)
+        assert engine_should_run(now=datetime(2026, 7, 27, 20, 0, 0), session=db.session) is False
+
+    def test_end_is_exclusive(self):
+        _mk(D1_START, D1_END)
+        # Exactly at close: a round should not start.
+        assert engine_should_run(now=D1_END, session=db.session) is False
+        # Exactly at open: it should.
+        assert engine_should_run(now=D1_START, session=db.session) is True
+
+    def test_disabled_window_does_not_open(self):
+        # An enabled Day-2 window plus a disabled Day-1 window: during Day 1's
+        # interval the engine stays paused because the disabled window is ignored.
+        _mk(D2_START, D2_END, name="Day 2")
+        _mk(D1_START, D1_END, enabled=False, name="Day 1 parked")
+        assert engine_should_run(now=datetime(2026, 7, 27, 12, 0, 0), session=db.session) is False
+
+    def test_only_disabled_windows_means_no_schedule(self):
+        # If every window is parked, there is no active schedule -> always run.
+        _mk(D1_START, D1_END, enabled=False)
+        assert engine_should_run(now=datetime(2026, 7, 27, 12, 0, 0), session=db.session) is True
+
+
+class TestWindowDerivedFreeze:
+    def test_no_windows_no_freeze(self):
+        assert window_derived_freeze(now=datetime(2026, 7, 27, 20, 0, 0), session=db.session) is None
+
+    def test_inside_window_live(self):
+        _mk(D1_START, D1_END)
+        assert window_derived_freeze(now=datetime(2026, 7, 27, 12, 0, 0), session=db.session) is None
+
+    def test_before_first_window_no_freeze(self):
+        _mk(D1_START, D1_END)
+        assert window_derived_freeze(now=datetime(2026, 7, 27, 8, 0, 0), session=db.session) is None
+
+    def test_between_windows_freezes_to_last_close(self):
+        _mk(D1_START, D1_END)
+        _mk(D2_START, D2_END)
+        # Overnight gap after day 1: frozen to day 1's close.
+        assert window_derived_freeze(now=datetime(2026, 7, 27, 22, 0, 0), session=db.session) == D1_END
+
+    def test_after_all_windows_freezes_to_final_close(self):
+        _mk(D1_START, D1_END)
+        _mk(D2_START, D2_END)
+        assert window_derived_freeze(now=datetime(2026, 7, 29, 0, 0, 0), session=db.session) == D2_END

--- a/tests/scoring_engine/test_score_adjustments.py
+++ b/tests/scoring_engine/test_score_adjustments.py
@@ -1,0 +1,123 @@
+"""Tests for manual score adjustments (wave 2, phase 5)."""
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.score_adjustment import ScoreAdjustment
+from scoring_engine.models.team import Team
+from scoring_engine.scores import team_adjustment_total, team_adjustment_totals
+
+
+class TestScoreAdjustmentModel:
+    def test_create_and_read(self):
+        team = Team(name="Blue 1", color="Blue")
+        db.session.add(team)
+        db.session.commit()
+        adj = ScoreAdjustment(team_id=team.id, points=250, reason="Great IR report")
+        db.session.add(adj)
+        db.session.commit()
+        assert adj.id is not None
+        assert adj.created_at is not None
+        assert adj.team.name == "Blue 1"
+
+
+class TestAdjustmentTotals:
+    def test_net_sum_of_signed_points(self):
+        team = Team(name="Blue 1", color="Blue")
+        db.session.add(team)
+        db.session.commit()
+        db.session.add_all(
+            [
+                ScoreAdjustment(team_id=team.id, points=300, reason="bonus"),
+                ScoreAdjustment(team_id=team.id, points=-100, reason="penalty"),
+            ]
+        )
+        db.session.commit()
+        assert team_adjustment_total(db.session, team.id) == 200
+        assert team_adjustment_totals(db.session) == {team.id: 200}
+
+    def test_no_adjustments(self):
+        team = Team(name="Blue 1", color="Blue")
+        db.session.add(team)
+        db.session.commit()
+        assert team_adjustment_total(db.session, team.id) == 0
+        assert team_adjustment_totals(db.session) == {}
+
+
+class TestAdjustmentAdminAPI:
+    @pytest.fixture(autouse=True)
+    def setup(self, white_login):
+        self.client, self.teams = white_login
+        self.blue = self.teams["blue_team"]
+
+    def test_create_requires_white_team(self):
+        from tests.scoring_engine.conftest import _login
+
+        # setup logged us in as white; the login view ignores a re-login while
+        # authenticated, so log out before switching to a blue user.
+        self.client.get("/logout")
+        _login(self.client, "blueuser")
+        resp = self.client.post(
+            "/api/admin/adjustments",
+            json={"team_id": self.blue.id, "points": 100, "reason": "x"},
+        )
+        assert resp.status_code == 403
+
+    def test_create_and_list(self):
+        resp = self.client.post(
+            "/api/admin/adjustments",
+            json={"team_id": self.blue.id, "points": 250, "reason": "IR report bonus"},
+        )
+        assert resp.status_code == 201
+        assert resp.json["status"] == "success"
+
+        listing = self.client.get("/api/admin/adjustments").json["data"]
+        assert len(listing) == 1
+        row = listing[0]
+        assert row["team"] == "Blue Team"
+        assert row["points"] == 250
+        assert row["reason"] == "IR report bonus"
+        assert row["author"] == "whiteuser"
+
+    def test_negative_points_allowed(self):
+        resp = self.client.post(
+            "/api/admin/adjustments",
+            json={"team_id": self.blue.id, "points": -75, "reason": "late submission"},
+        )
+        assert resp.status_code == 201
+        assert team_adjustment_total(db.session, self.blue.id) == -75
+
+    def test_reason_is_required(self):
+        resp = self.client.post(
+            "/api/admin/adjustments",
+            json={"team_id": self.blue.id, "points": 100, "reason": "   "},
+        )
+        assert resp.status_code == 400
+
+    def test_nonexistent_team_rejected(self):
+        resp = self.client.post(
+            "/api/admin/adjustments",
+            json={"team_id": 99999, "points": 100, "reason": "x"},
+        )
+        assert resp.status_code == 404
+
+    def test_non_integer_points_rejected(self):
+        resp = self.client.post(
+            "/api/admin/adjustments",
+            json={"team_id": self.blue.id, "points": "abc", "reason": "x"},
+        )
+        assert resp.status_code == 400
+
+
+class TestAdjustmentInScoreboardTotal:
+    def test_adjustment_is_added_to_adjusted_score(self, white_login):
+        client, teams = white_login
+        blue = teams["blue_team"]
+        # No service/inject scores; a pure +500 adjustment should show as the total.
+        db.session.add(ScoreAdjustment(team_id=blue.id, points=500, reason="bonus"))
+        db.session.commit()
+
+        data = client.get("/api/scoreboard/get_bar_data").json
+        idx = data["labels"].index("Blue Team")
+        assert data["adjustments"][idx] == "500"
+        assert data["adjusted_scores"][idx] == "500"

--- a/tests/scoring_engine/test_scores.py
+++ b/tests/scoring_engine/test_scores.py
@@ -9,6 +9,7 @@ builds on.
 
 from scoring_engine.db import db
 from scoring_engine.models.round_score import RoundScore
+from scoring_engine.models.service import Service
 from scoring_engine.scores import compute_round_service_points, materialize_round
 from tests.scoring_engine.factories import make_check, make_round, make_service, make_team
 
@@ -124,14 +125,27 @@ class TestMaterializeRound:
         assert len(rows) == 1
         assert rows[0].service_points == 100
 
-    def test_golden_equivalence_with_current_score(self):
-        """SUM(round_score.service_points) per team == Team.current_score.
-
-        This is the invariant every later phase depends on. Build several teams,
-        services with different point values, and multiple rounds with a mix of
-        passing and failing checks, then prove the materialized totals match the
-        live computation exactly.
+    def test_golden_equivalence_with_full_history_oracle(self):
+        """SUM(round_score.service_points) per team == the checks-based full-history
+        sum. Team.current_score now READS round_score, so it can't be the oracle
+        (that would be circular); the oracle is an explicit checks query, exactly
+        the computation round_score replaces. This is the invariant every later
+        phase depends on: build several teams, services with distinct point values,
+        and rounds with mixed pass/fail, then prove the two agree.
         """
+        from scoring_engine.models.check import Check as _Check
+
+        def oracle(team_id):
+            return int(
+                db.session.query(db.func.coalesce(db.func.sum(Service.points), 0))
+                .select_from(Service)
+                .join(_Check)
+                .filter(Service.team_id == team_id)
+                .filter(_Check.result.is_(True))
+                .scalar()
+                or 0
+            )
+
         teams = [make_team(color="Blue") for _ in range(3)]
         # Give each team two services with distinct point values.
         services = {}
@@ -153,12 +167,15 @@ class TestMaterializeRound:
             materialize_round(db.session, rnd.id, rnd.number)
 
         for t in teams:
-            materialized = (
+            materialized = int(
                 db.session.query(db.func.coalesce(db.func.sum(RoundScore.service_points), 0))
                 .filter(RoundScore.team_id == t.id)
                 .scalar()
             )
-            assert materialized == t.current_score, f"team {t.id}: {materialized} != {t.current_score}"
+            expected = oracle(t.id)
+            assert materialized == expected, f"team {t.id}: round_score {materialized} != oracle {expected}"
+            # And the model property, now backed by round_score, agrees with both.
+            assert t.current_score == expected
 
     def test_rolling_back_a_round_leaves_no_ghost_scores(self):
         """Deleting rounds must delete their round_score rows (the rollback contract)."""

--- a/tests/scoring_engine/test_scores.py
+++ b/tests/scoring_engine/test_scores.py
@@ -1,0 +1,133 @@
+"""Tests for round_score materialization (wave 2, phase 1).
+
+The load-bearing assertion is the *golden equivalence* test: the sum of a team's
+materialized ``round_score.service_points`` must equal ``Team.current_score``, the
+live full-history computation it will replace. If those two ever diverge, the whole
+materialization is unsafe to read from -- so this is the guard the rest of wave 2
+builds on.
+"""
+
+from scoring_engine.db import db
+from scoring_engine.models.round_score import RoundScore
+from scoring_engine.scores import compute_round_service_points, materialize_round
+from tests.scoring_engine.factories import make_check, make_round, make_service, make_team
+
+
+class TestComputeRoundServicePoints:
+    def test_sums_only_passing_checks(self):
+        team = make_team(color="Blue")
+        svc_a = make_service(team=team, name="A")
+        svc_b = make_service(team=team, name="B")
+        svc_a.points = 100
+        svc_b.points = 50
+        db.session.commit()
+        rnd = make_round(number=1)
+        make_check(service=svc_a, round_obj=rnd, result=True)
+        make_check(service=svc_b, round_obj=rnd, result=False)  # down: excluded
+
+        result = compute_round_service_points(db.session, rnd.id)
+        assert result == {team.id: 100}
+
+    def test_absent_team_when_nothing_passes(self):
+        team = make_team(color="Blue")
+        svc = make_service(team=team)
+        db.session.commit()
+        rnd = make_round(number=1)
+        make_check(service=svc, round_obj=rnd, result=False)
+        # No passing checks -> team simply absent (reads coalesce to zero).
+        assert compute_round_service_points(db.session, rnd.id) == {}
+
+
+class TestMaterializeRound:
+    def test_writes_one_row_per_scoring_team(self):
+        blue1 = make_team(color="Blue")
+        blue2 = make_team(color="Blue")
+        s1 = make_service(team=blue1)
+        s2 = make_service(team=blue2)
+        s1.points = 100
+        s2.points = 100
+        db.session.commit()
+        rnd = make_round(number=1)
+        make_check(service=s1, round_obj=rnd, result=True)
+        make_check(service=s2, round_obj=rnd, result=True)
+
+        written = materialize_round(db.session, rnd)
+        assert written == 2
+        rows = db.session.query(RoundScore).filter(RoundScore.round_id == rnd.id).all()
+        assert {r.team_id: r.service_points for r in rows} == {blue1.id: 100, blue2.id: 100}
+        # round_number is denormalized onto every row.
+        assert all(r.round_number == 1 for r in rows)
+        # flag_points is 0 at this phase.
+        assert all(r.flag_points == 0 for r in rows)
+
+    def test_is_idempotent_under_retry(self):
+        team = make_team(color="Blue")
+        svc = make_service(team=team)
+        svc.points = 100
+        db.session.commit()
+        rnd = make_round(number=1)
+        make_check(service=svc, round_obj=rnd, result=True)
+
+        materialize_round(db.session, rnd)
+        materialize_round(db.session, rnd)  # retry: must not double-count
+        rows = db.session.query(RoundScore).filter(RoundScore.round_id == rnd.id).all()
+        assert len(rows) == 1
+        assert rows[0].service_points == 100
+
+    def test_golden_equivalence_with_current_score(self):
+        """SUM(round_score.service_points) per team == Team.current_score.
+
+        This is the invariant every later phase depends on. Build several teams,
+        services with different point values, and multiple rounds with a mix of
+        passing and failing checks, then prove the materialized totals match the
+        live computation exactly.
+        """
+        teams = [make_team(color="Blue") for _ in range(3)]
+        # Give each team two services with distinct point values.
+        services = {}
+        for t in teams:
+            a = make_service(team=t, name=f"A-{t.id}")
+            b = make_service(team=t, name=f"B-{t.id}")
+            a.points = 100
+            b.points = 25
+            services[t.id] = (a, b)
+        db.session.commit()
+
+        rounds = [make_round(number=n) for n in range(1, 6)]
+        # Deterministic pass/fail pattern so the test is not flaky.
+        for i, rnd in enumerate(rounds):
+            for t in teams:
+                a, b = services[t.id]
+                make_check(service=a, round_obj=rnd, result=(i % 2 == 0))
+                make_check(service=b, round_obj=rnd, result=(t.id % 2 == 0))
+            materialize_round(db.session, rnd)
+
+        for t in teams:
+            materialized = (
+                db.session.query(db.func.coalesce(db.func.sum(RoundScore.service_points), 0))
+                .filter(RoundScore.team_id == t.id)
+                .scalar()
+            )
+            assert materialized == t.current_score, f"team {t.id}: {materialized} != {t.current_score}"
+
+    def test_rolling_back_a_round_leaves_no_ghost_scores(self):
+        """Deleting rounds must delete their round_score rows (the rollback contract)."""
+        team = make_team(color="Blue")
+        svc = make_service(team=team)
+        svc.points = 100
+        db.session.commit()
+        r1 = make_round(number=1)
+        r2 = make_round(number=2)
+        make_check(service=svc, round_obj=r1, result=True)
+        make_check(service=svc, round_obj=r2, result=True)
+        materialize_round(db.session, r1)
+        materialize_round(db.session, r2)
+        assert db.session.query(RoundScore).count() == 2
+
+        # Simulate the rollback deletion contract (admin_rollback / _cleanup_failed_round).
+        db.session.query(RoundScore).filter(RoundScore.round_number >= 2).delete(synchronize_session=False)
+        db.session.commit()
+
+        remaining = db.session.query(RoundScore).all()
+        assert len(remaining) == 1
+        assert remaining[0].round_number == 1

--- a/tests/scoring_engine/test_scores.py
+++ b/tests/scoring_engine/test_scores.py
@@ -51,7 +51,7 @@ class TestMaterializeRound:
         make_check(service=s1, round_obj=rnd, result=True)
         make_check(service=s2, round_obj=rnd, result=True)
 
-        written = materialize_round(db.session, rnd)
+        written = materialize_round(db.session, rnd.id, rnd.number)
         assert written == 2
         rows = db.session.query(RoundScore).filter(RoundScore.round_id == rnd.id).all()
         assert {r.team_id: r.service_points for r in rows} == {blue1.id: 100, blue2.id: 100}
@@ -59,6 +59,56 @@ class TestMaterializeRound:
         assert all(r.round_number == 1 for r in rows)
         # flag_points is 0 at this phase.
         assert all(r.flag_points == 0 for r in rows)
+
+    def test_commit_false_defers_persistence(self):
+        """The engine calls materialize_round(commit=False) so the rows land in the
+        SAME commit as the round. Prove the rows are staged but not committed, so a
+        rollback (the failed-round path) discards them cleanly."""
+        team = make_team(color="Blue")
+        svc = make_service(team=team)
+        svc.points = 100
+        db.session.commit()
+        rnd = make_round(number=1)
+        make_check(service=svc, round_obj=rnd, result=True)
+
+        written = materialize_round(db.session, rnd.id, rnd.number, commit=False)
+        assert written == 1
+        # Visible within the uncommitted transaction...
+        assert db.session.query(RoundScore).filter(RoundScore.round_id == rnd.id).count() == 1
+        # ...but a rollback (failed-round cleanup) throws them away with the round.
+        db.session.rollback()
+        assert db.session.query(RoundScore).filter(RoundScore.round_id == rnd.id).count() == 0
+
+    def test_precomputed_points_match_the_queried_path(self):
+        """The engine passes points it accumulated in-memory instead of querying.
+        Both paths must write identical rows, or the fast engine path would drift
+        from the golden-equivalence guarantee."""
+        team_a = make_team(color="Blue")
+        team_b = make_team(color="Blue")
+        sa1 = make_service(team=team_a)
+        sa1.points = 100
+        sb1 = make_service(team=team_b)
+        sb1.points = 30
+        db.session.commit()
+        rnd = make_round(number=1)
+        make_check(service=sa1, round_obj=rnd, result=True)
+        make_check(service=sb1, round_obj=rnd, result=True)
+
+        queried = compute_round_service_points(db.session, rnd.id)
+        # Engine path: same sums, supplied directly, no query, no clear.
+        materialize_round(db.session, rnd.id, rnd.number, points_by_team=queried, clear_existing=False)
+        rows = {r.team_id: r.service_points for r in db.session.query(RoundScore).filter(RoundScore.round_id == rnd.id)}
+        assert rows == {team_a.id: 100, team_b.id: 30}
+        assert rows == queried
+
+    def test_zero_points_team_gets_no_row(self):
+        """A precomputed 0 (or missing) team must not create a row."""
+        team = make_team(color="Blue")
+        db.session.commit()
+        rnd = make_round(number=1)
+        written = materialize_round(db.session, rnd.id, rnd.number, points_by_team={team.id: 0}, clear_existing=False)
+        assert written == 0
+        assert db.session.query(RoundScore).filter(RoundScore.round_id == rnd.id).count() == 0
 
     def test_is_idempotent_under_retry(self):
         team = make_team(color="Blue")
@@ -68,8 +118,8 @@ class TestMaterializeRound:
         rnd = make_round(number=1)
         make_check(service=svc, round_obj=rnd, result=True)
 
-        materialize_round(db.session, rnd)
-        materialize_round(db.session, rnd)  # retry: must not double-count
+        materialize_round(db.session, rnd.id, rnd.number)
+        materialize_round(db.session, rnd.id, rnd.number)  # retry: must not double-count
         rows = db.session.query(RoundScore).filter(RoundScore.round_id == rnd.id).all()
         assert len(rows) == 1
         assert rows[0].service_points == 100
@@ -100,7 +150,7 @@ class TestMaterializeRound:
                 a, b = services[t.id]
                 make_check(service=a, round_obj=rnd, result=(i % 2 == 0))
                 make_check(service=b, round_obj=rnd, result=(t.id % 2 == 0))
-            materialize_round(db.session, rnd)
+            materialize_round(db.session, rnd.id, rnd.number)
 
         for t in teams:
             materialized = (
@@ -120,8 +170,8 @@ class TestMaterializeRound:
         r2 = make_round(number=2)
         make_check(service=svc, round_obj=r1, result=True)
         make_check(service=svc, round_obj=r2, result=True)
-        materialize_round(db.session, r1)
-        materialize_round(db.session, r2)
+        materialize_round(db.session, r1.id, r1.number)
+        materialize_round(db.session, r2.id, r2.number)
         assert db.session.query(RoundScore).count() == 2
 
         # Simulate the rollback deletion contract (admin_rollback / _cleanup_failed_round).

--- a/tests/scoring_engine/test_sla.py
+++ b/tests/scoring_engine/test_sla.py
@@ -10,6 +10,7 @@ from scoring_engine.models.round import Round
 from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
+from scoring_engine.scores import materialize_all_rounds
 from scoring_engine.sla import (
     SLAConfig,
     apply_dynamic_scoring_to_round,
@@ -869,6 +870,9 @@ class TestMultipleTeams:
                 db.session.add(check)
 
         db.session.commit()
+        # Materialize round_score, as the engine does at round close, so the
+        # score reads (now backed by round_score) reflect these checks.
+        materialize_all_rounds(db.session)
         return teams
 
     def test_different_penalties_per_team(self):
@@ -1069,6 +1073,7 @@ class TestCombinedDynamicScoringAndPenalties:
             db.session.add(check)
 
         db.session.commit()
+        materialize_all_rounds(db.session)
         return team, service
 
     def test_early_rounds_with_sla_penalty(self):
@@ -1092,6 +1097,7 @@ class TestCombinedDynamicScoringAndPenalties:
         # Penalty = 1000 * 10% = 100 points (penalty based on dynamic score)
         # Adjusted = 1000 - 100 = 900
 
+        materialize_all_rounds(db.session)
         base_score = calculate_team_base_score_with_dynamic(team, config)
         assert base_score == 1000, f"Expected 1000 base with 2x early multiplier, got {base_score}"
 
@@ -1144,6 +1150,7 @@ class TestCombinedDynamicScoringAndPenalties:
         # Penalty = 200 * 30% = 60 points (penalty based on dynamic score)
         # Adjusted = 200 - 60 = 140
 
+        materialize_all_rounds(db.session)
         base_score = calculate_team_base_score_with_dynamic(team, config)
         assert base_score == 200, f"Expected 200 base with 0.5x late multiplier, got {base_score}"
 
@@ -1219,6 +1226,7 @@ class TestCombinedDynamicScoringAndPenalties:
         # Penalty points = 3150 * 40% = 1260 (based on dynamic score)
         # Adjusted = 3150 - 1260 = 1890
 
+        materialize_all_rounds(db.session)
         base_score = calculate_team_base_score_with_dynamic(team, config)
         assert base_score == 3150, f"Expected 3150 base with mixed multipliers, got {base_score}"
 
@@ -1277,6 +1285,7 @@ class TestCombinedDynamicScoringAndPenalties:
             db.session.add(check3)
 
         db.session.commit()
+        materialize_all_rounds(db.session)
 
         # Team 1: 10 * 100 * 2.0 = 2000 dynamic, no penalty
         score1 = calculate_team_adjusted_score(team1, config)
@@ -1343,6 +1352,7 @@ class TestCombinedDynamicScoringAndPenalties:
 
         config = self._create_combined_config()
 
+        materialize_all_rounds(db.session)
         base_score = calculate_team_base_score_with_dynamic(team, config)
         assert base_score == 50, f"Expected 50 dynamic base score, got {base_score}"
 
@@ -1395,6 +1405,7 @@ class TestCombinedDynamicScoringAndPenalties:
 
         db.session.commit()
 
+        materialize_all_rounds(db.session)
         base_score = calculate_team_base_score_with_dynamic(team, config)
         assert base_score == 100, f"Expected 100 dynamic base score, got {base_score}"
 
@@ -1417,6 +1428,7 @@ class TestCombinedDynamicScoringAndPenalties:
         check_results = [False] * 10  # 10 failures
         team, service = self._create_team_with_rounds(check_results, points=100)
 
+        materialize_all_rounds(db.session)
         base_score = calculate_team_base_score_with_dynamic(team, config)
         assert base_score == 0, "All failures should result in 0 base score"
 

--- a/tests/scoring_engine/test_team_penalties.py
+++ b/tests/scoring_engine/test_team_penalties.py
@@ -73,8 +73,14 @@ class TestTeamPenaltiesEquivalence:
     def _assert_equiv(self, **settings):
         for name, value in settings.items():
             _set(name, value)
-        from scoring_engine.scores import team_penalties
+        from scoring_engine.scores import recompute_consecutive_failures_cache, team_penalties
         from scoring_engine.sla import calculate_team_total_penalties, get_sla_config
+
+        # team_penalties reads the materialized cache; populate it from the checks
+        # these tests built directly (the engine would maintain it in production).
+        # The oracle (calculate_team_total_penalties) still scans checks, so the
+        # two remain independent.
+        recompute_consecutive_failures_cache(db.session)
 
         cfg = get_sla_config()
         batched = team_penalties(db.session, cfg)

--- a/tests/scoring_engine/test_team_penalties.py
+++ b/tests/scoring_engine/test_team_penalties.py
@@ -1,0 +1,115 @@
+"""Equivalence test for the batched SLA penalty path (scores.team_penalties).
+
+team_penalties replaces the per-service calculate_team_total_penalties loop with
+a handful of grouped queries. It must produce byte-identical penalties, or a
+mid-competition deploy would silently change every team's score. This test pins
+that: for a fixed dataset and a matrix of SLA configurations, the batched result
+equals the per-service oracle for every team.
+"""
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.check import Check
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+
+NUM_ROUNDS = 60  # early=1..10, mid=11..49, late=50..60 under the default dynamic config
+
+# service pattern -> list of per-round results (True=pass) across the 60 rounds
+PATTERNS = {
+    "allpass": [True] * NUM_ROUNDS,
+    "allfail": [False] * NUM_ROUNDS,
+    "fail_tail_8": [True] * 52 + [False] * 8,  # 8 consecutive failures (over threshold)
+    "fail_tail_3": [True] * 57 + [False] * 3,  # 3 consecutive (below default threshold 5)
+    "flap": [i % 2 == 0 for i in range(NUM_ROUNDS)],  # ends on a fail (round 60 -> index 59 odd)
+    "late_only": [False] * 49 + [True] * 6 + [False] * 5,  # passes only in late rounds, then fails
+}
+# points chosen so dynamic multipliers produce fractional products (truncation matters)
+POINTS = {"allpass": 100, "allfail": 100, "fail_tail_8": 25, "fail_tail_3": 100, "flap": 75, "late_only": 25}
+
+
+def _set(name, value):
+    setting = Setting.get_setting(name)
+    setting.value = value
+    db.session.commit()
+    Setting.clear_cache(name)
+
+
+def _build_team(name):
+    team = Team(name=name, color="Blue")
+    db.session.add(team)
+    db.session.flush()
+    for pname, pattern in PATTERNS.items():
+        svc = Service(
+            name=f"{name}-{pname}",
+            check_name="ICMPCheck",
+            host="127.0.0.1",
+            team=team,
+            points=POINTS[pname],
+        )
+        db.session.add(svc)
+        db.session.flush()
+        for rnd, result in zip(_build_team.rounds, pattern):
+            db.session.add(Check(service=svc, round=rnd, result=result, completed=True, output=""))
+    db.session.commit()
+    return team
+
+
+class TestTeamPenaltiesEquivalence:
+    @pytest.fixture(autouse=True)
+    def setup(self, db_session):
+        _build_team.rounds = []
+        for n in range(1, NUM_ROUNDS + 1):
+            r = Round(number=n)
+            db.session.add(r)
+            _build_team.rounds.append(r)
+        db.session.commit()
+        # Two teams so the per-team grouping is exercised, not just per-service math.
+        self.teams = [_build_team("Alpha"), _build_team("Bravo")]
+
+    def _assert_equiv(self, **settings):
+        for name, value in settings.items():
+            _set(name, value)
+        from scoring_engine.scores import team_penalties
+        from scoring_engine.sla import calculate_team_total_penalties, get_sla_config
+
+        cfg = get_sla_config()
+        batched = team_penalties(db.session, cfg)
+        for team in self.teams:
+            oracle = calculate_team_total_penalties(team, cfg)
+            got = batched.get(team.id, 0)
+            assert got == oracle, f"team {team.name} settings={settings}: batched {got} != oracle {oracle}"
+            assert oracle > 0, f"team {team.name} settings={settings}: oracle penalty was 0 (not exercised)"
+
+    def test_disabled_returns_empty(self):
+        _set("sla_enabled", False)
+        from scoring_engine.scores import team_penalties
+        from scoring_engine.sla import get_sla_config
+
+        assert team_penalties(db.session, get_sla_config()) == {}
+
+    def test_additive_static(self):
+        self._assert_equiv(sla_enabled=True, dynamic_scoring_enabled=False, sla_penalty_mode="additive")
+
+    def test_additive_dynamic(self):
+        self._assert_equiv(sla_enabled=True, dynamic_scoring_enabled=True, sla_penalty_mode="additive")
+
+    def test_flat_dynamic(self):
+        self._assert_equiv(sla_enabled=True, dynamic_scoring_enabled=True, sla_penalty_mode="flat")
+
+    def test_exponential_dynamic(self):
+        self._assert_equiv(sla_enabled=True, dynamic_scoring_enabled=True, sla_penalty_mode="exponential")
+
+    def test_allow_negative_uncapped(self):
+        self._assert_equiv(
+            sla_enabled=True,
+            dynamic_scoring_enabled=True,
+            sla_penalty_mode="exponential",
+            sla_allow_negative=True,
+        )
+
+    def test_lower_threshold(self):
+        self._assert_equiv(sla_enabled=True, dynamic_scoring_enabled=True, sla_penalty_threshold="2")

--- a/tests/scoring_engine/web/views/api/test_flags_api.py
+++ b/tests/scoring_engine/web/views/api/test_flags_api.py
@@ -683,9 +683,7 @@ class TestFlagsAPI:
         db.session.add_all(flags)
         db.session.flush()
 
-        solves = [
-            Solve(host=solves_data[i], team_id=self.blue_team1.id, flag_id=flags[i].id) for i in range(4)
-        ]
+        solves = [Solve(host=solves_data[i], team_id=self.blue_team1.id, flag_id=flags[i].id) for i in range(4)]
         db.session.add_all(solves)
         db.session.commit()
 
@@ -737,3 +735,51 @@ class TestFlagsAPI:
         team1_entry = next(e for e in data if e["team"] == "Blue Team 1")
         assert team1_entry["nix_score"] == 4.0
         assert team1_entry["total_score"] == 4.0
+
+    # /api/flags/score (red-team flag score) --------------------------------
+
+    def _capture(self, team, perm, host):
+        flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.nix,
+            perm=perm,
+            data={"path": "/tmp/f", "content": "x"},
+            start_time=datetime.now(timezone.utc) - timedelta(minutes=5),
+            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
+            dummy=False,
+        )
+        db.session.add(flag)
+        db.session.commit()
+        db.session.add(Solve(host=host, team=team, flag=flag))
+        db.session.commit()
+
+    def test_api_flags_score_requires_auth(self):
+        resp = self.client.get("/api/flags/score")
+        assert resp.status_code == 302  # redirected to login
+
+    def test_api_flags_score_blue_team_unauthorized(self):
+        self.login("blueuser1")
+        resp = self.client.get("/api/flags/score")
+        assert resp.status_code == 403
+
+    def test_api_flags_score_red_team_authorized(self):
+        self.login("reduser")
+        resp = self.client.get("/api/flags/score")
+        assert resp.status_code == 200
+
+    def test_api_flags_score_white_team_authorized(self):
+        self.login("whiteuser")
+        resp = self.client.get("/api/flags/score")
+        assert resp.status_code == 200
+
+    def test_api_flags_score_values(self):
+        self._capture(self.blue_team1, Perm.user, "h1")
+        self._capture(self.blue_team1, Perm.root, "h1")
+        self._capture(self.blue_team2, Perm.user, "h1")
+        self.login("whiteuser")
+        data = self.client.get("/api/flags/score").json
+        assert data["red_total"] == 400  # 100 + 200 + 100
+        assert data["points"] == {"user": 100, "root": 200}
+        by_team = {row["team"]: row["points"] for row in data["by_team"]}
+        assert by_team["Blue Team 1"] == 300
+        assert by_team["Blue Team 2"] == 100

--- a/tests/scoring_engine/web/views/api/test_overview_api.py
+++ b/tests/scoring_engine/web/views/api/test_overview_api.py
@@ -236,7 +236,8 @@ class TestOverviewAPI:
         assert len(rows) >= 3
         assert rows[0][0] == "Current Score"
         assert rows[1][0] == "Current Place"
-        assert rows[2][0] == "Up/Down Ratio"
+        assert rows[2][0] == "Services Up"
+        assert rows[3][0] == "Services Down"
 
     def test_get_data_with_checks_and_scores(self):
         svc1 = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", port=22, team=self.blue_team, points=100)
@@ -262,11 +263,15 @@ class TestOverviewAPI:
         assert places_row[0] == "Current Place"
         assert places_row[1] == "1"
 
-        # Up/Down Ratio row - structured counts, no markup
-        ratio_row = rows[2]
-        assert ratio_row[0] == "Up/Down Ratio"
-        assert ratio_row[1] == {"up": 1, "down": 0}
-        assert ratio_row[2] == {"up": 0, "down": 1}
+        # Services Up / Services Down rows - plain integer counts, no markup
+        up_row = rows[2]
+        assert up_row[0] == "Services Up"
+        assert up_row[1] == 1
+        assert up_row[2] == 0
+        down_row = rows[3]
+        assert down_row[0] == "Services Down"
+        assert down_row[1] == 0
+        assert down_row[2] == 1
 
         # Service row (SSH)
         assert any(row[0] == "SSH" for row in rows)
@@ -294,7 +299,8 @@ class TestOverviewAPI:
         assert "Current Score" in row_labels
         assert "Current Place" in row_labels
         assert "SLA Penalties" in row_labels
-        assert "Up/Down Ratio" in row_labels
+        assert "Services Up" in row_labels
+        assert "Services Down" in row_labels
 
     def test_get_data_with_sla_penalties_shown(self):
         """Test that SLA penalties appear when a team exceeds the failure threshold."""
@@ -485,17 +491,18 @@ class TestOverviewAPI:
         assert "service_ids" in resp.json
         assert len(resp.json["service_ids"]) == 2
 
-    def test_get_data_up_down_ratio_is_structured(self):
-        """Up/Down Ratio cells are {"up": int, "down": int} objects."""
+    def test_get_data_up_down_are_separate_integer_rows(self):
+        """Services Up / Services Down are separate rows of plain integer counts."""
         self._setup_penalty_scenario()
 
         resp = self.client.get("/api/overview/get_data")
         rows = resp.json["data"]
-        ratio_row = next(row for row in rows if row[0] == "Up/Down Ratio")
+        up_row = next(row for row in rows if row[0] == "Services Up")
+        down_row = next(row for row in rows if row[0] == "Services Down")
 
         # blue_team: HTTP up, SSH down. blue_team2: SSH up, nothing down.
-        assert ratio_row[1] == {"up": 1, "down": 1}
-        assert ratio_row[2] == {"up": 1, "down": 0}
+        assert up_row[1] == 1 and down_row[1] == 1
+        assert up_row[2] == 1 and down_row[2] == 0
 
     def test_get_data_sla_penalties_are_numeric(self):
         """SLA Penalties cells are plain numbers (magnitude), not formatted strings."""

--- a/tests/scoring_engine/web/views/api/test_overview_api.py
+++ b/tests/scoring_engine/web/views/api/test_overview_api.py
@@ -71,9 +71,12 @@ class TestOverviewAPI:
             check = Check(service=svc, round=round_obj, result=result, output="", completed=True)
             db.session.add(check)
         db.session.commit()
-        from scoring_engine.scores import materialize_round
+        from scoring_engine.scores import materialize_round, recompute_consecutive_failures_cache
 
         materialize_round(db.session, round_obj.id, round_number)
+        # team_penalties reads the materialized SLA cache; the engine maintains it
+        # in production, so populate it here from the checks these tests built.
+        recompute_consecutive_failures_cache(db.session)
         return round_obj
 
     # --- get_anonymize_mode (via /api/overview/get_columns endpoint) ---

--- a/tests/scoring_engine/web/views/api/test_overview_api.py
+++ b/tests/scoring_engine/web/views/api/test_overview_api.py
@@ -71,6 +71,9 @@ class TestOverviewAPI:
             check = Check(service=svc, round=round_obj, result=result, output="", completed=True)
             db.session.add(check)
         db.session.commit()
+        from scoring_engine.scores import materialize_round
+
+        materialize_round(db.session, round_obj.id, round_number)
         return round_obj
 
     # --- get_anonymize_mode (via /api/overview/get_columns endpoint) ---

--- a/tests/scoring_engine/web/views/api/test_scoreboard_api.py
+++ b/tests/scoring_engine/web/views/api/test_scoreboard_api.py
@@ -249,14 +249,15 @@ class TestScoreboardAPI:
         assert team1_data is not None
         assert team2_data is not None
 
-        # Scores are cumulative over rounds with passing checks
-        # Blue Team: passed round 1 (100) and round 2 (100)
-        # Cumulative: [0, 100, 200]
-        assert team1_data["scores"] == [0, 100, 200]
+        # Scores are cumulative per round; a round with no points carries the
+        # previous total forward so the series aligns to the rounds axis.
+        # Blue Team: pass r1 (100), pass r2 (100), fail r3 (carry 200)
+        # Cumulative by round 0,1,2,3: [0, 100, 200, 200]
+        assert team1_data["scores"] == [0, 100, 200, 200]
 
-        # Blue Team 2: passed round 1 (50) and round 3 (50)
-        # Cumulative: [0, 50, 100]
-        assert team2_data["scores"] == [0, 50, 100]
+        # Blue Team 2: pass r1 (50), fail r2 (carry 50), pass r3 (100)
+        # Cumulative by round 0,1,2,3: [0, 50, 50, 100]
+        assert team2_data["scores"] == [0, 50, 50, 100]
 
         assert "color" in team1_data
         assert "color" in team2_data
@@ -277,6 +278,32 @@ class TestScoreboardAPI:
         team_data = data["team"][0]
         # Cumulative: [0, 200, 400]
         assert team_data["scores"] == [0, 200, 400]
+
+    def test_get_line_data_downsamples_when_over_cap(self, monkeypatch):
+        """A long competition is downsampled to a bounded number of x-points,
+        keeping the endpoints and the final cumulative total, with every team's
+        series aligned to the (downsampled) rounds axis."""
+        import scoring_engine.web.views.api.scoreboard as sb
+
+        monkeypatch.setattr(sb, "LINE_CHART_MAX_POINTS", 5)
+
+        svc = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", team=self.blue_team, points=10)
+        db.session.add(svc)
+        db.session.commit()
+        for r in range(1, 13):  # 12 rounds -> 13 x-points (0..12), over the cap of 5
+            self._create_round_with_checks(r, [svc], [True])
+
+        resp = self.client.get("/api/scoreboard/get_line_data")
+        assert resp.status_code == 200
+        data = resp.json
+
+        assert len(data["rounds"]) <= 5
+        assert data["rounds"][0] == "Round 0"
+        assert data["rounds"][-1] == "Round 12"
+        for t in data["team"]:
+            assert len(t["scores"]) == len(data["rounds"])  # aligned
+        team = next(t for t in data["team"] if t["name"] == "Blue Team")
+        assert team["scores"][-1] == 120  # 12 rounds * 10, full total preserved
 
     # -----------------------------------------------------------------------
     # Anonymize mode tests
@@ -360,3 +387,30 @@ class TestScoreboardAPI:
         data = resp.json
         assert "Blue Team" in data["labels"]
         assert "Blue Team 2" in data["labels"]
+
+
+class TestDownsampleIndices:
+    """Unit tests for the line-chart x-axis downsampler."""
+
+    def _fn(self):
+        from scoring_engine.web.views.api.scoreboard import _downsample_indices
+
+        return _downsample_indices
+
+    def test_returns_all_when_at_or_under_cap(self):
+        f = self._fn()
+        assert f(5, 10) == [0, 1, 2, 3, 4]
+        assert f(10, 10) == list(range(10))
+
+    def test_caps_and_keeps_endpoints(self):
+        f = self._fn()
+        idx = f(100, 10)
+        assert len(idx) <= 10
+        assert idx[0] == 0
+        assert idx[-1] == 99  # last index always included
+        assert idx == sorted(idx)
+        assert len(set(idx)) == len(idx)  # unique
+
+    def test_evenly_spaced(self):
+        f = self._fn()
+        assert f(11, 6) == [0, 2, 4, 6, 8, 10]

--- a/tests/scoring_engine/web/views/api/test_scoreboard_api.py
+++ b/tests/scoring_engine/web/views/api/test_scoreboard_api.py
@@ -55,6 +55,9 @@ class TestScoreboardAPI:
             check = Check(service=svc, round=round_obj, result=result, output="")
             db.session.add(check)
         db.session.commit()
+        from scoring_engine.scores import materialize_round
+
+        materialize_round(db.session, round_obj.id, round_number)
         return round_obj
 
     # -----------------------------------------------------------------------

--- a/tests/scoring_engine/web/views/api/test_weighted_scoring.py
+++ b/tests/scoring_engine/web/views/api/test_weighted_scoring.py
@@ -1,0 +1,223 @@
+"""Tests for weighted scoring (wave 2, phase 3).
+
+Weighted scoring rebalances how service uptime, injects, and flag captures
+combine into the scoreboard total. Each weight is a multiplier applied at the
+point the categories combine:
+
+- the blue teams' combined total on the scoreboard (service + inject), and
+- the red team's flag total on the flags API.
+
+Manual adjustments are never weighted. With the feature disabled every total is
+identical to the un-weighted behaviour.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scoring_engine.db import db
+from scoring_engine.models.check import Check
+from scoring_engine.models.round import Round
+from scoring_engine.models.service import Service
+from scoring_engine.models.setting import Setting
+from scoring_engine.models.team import Team
+from scoring_engine.models.user import User
+
+
+def _set(name, value):
+    setting = Setting.get_setting(name)
+    setting.value = value
+    db.session.commit()
+    Setting.clear_cache(name)
+
+
+def _enable_weights(service=1.0, inject=1.0, flag=1.0):
+    _set("weighted_scoring_enabled", True)
+    _set("service_weight", str(service))
+    _set("inject_weight", str(inject))
+    _set("flag_weight", str(flag))
+
+
+class TestSlaConfigWeights:
+    def test_defaults_when_seeded(self):
+        from scoring_engine.sla import get_sla_config
+
+        cfg = get_sla_config()
+        assert cfg.weighted_scoring_enabled is False
+        assert cfg.service_weight == 1.0
+        assert cfg.inject_weight == 1.0
+        assert cfg.flag_weight == 1.0
+
+    def test_reads_overrides(self):
+        from scoring_engine.sla import get_sla_config
+
+        _enable_weights(service=2.0, inject=0.5, flag=3.0)
+        cfg = get_sla_config()
+        assert cfg.weighted_scoring_enabled is True
+        assert cfg.service_weight == 2.0
+        assert cfg.inject_weight == 0.5
+        assert cfg.flag_weight == 3.0
+
+
+class TestWeightedBarData:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, db_session):
+        self.client = test_client
+        self.white = Team(name="White Team", color="White")
+        self.blue = Team(name="Blue Team", color="Blue")
+        db.session.add_all([self.white, self.blue])
+        db.session.flush()
+        self.white_user = User(username="whiteuser", password="testpass", team=self.white)
+        db.session.add(self.white_user)
+        self.svc = Service(name="SSH", check_name="SSHCheck", host="10.0.0.1", team=self.blue, points=100)
+        db.session.add(self.svc)
+        db.session.commit()
+        # Two passing rounds -> raw service score = 200.
+        self._round(1, True)
+        self._round(2, True)
+
+    def _round(self, number, result):
+        now = datetime.now(timezone.utc)
+        r = Round(number=number, round_start=now - timedelta(seconds=60), round_end=now)
+        db.session.add(r)
+        db.session.flush()
+        db.session.add(Check(service=self.svc, round=r, result=result, output=""))
+        db.session.commit()
+        from scoring_engine.scores import materialize_round
+
+        materialize_round(db.session, r.id, number)
+
+    def _bar(self):
+        return self.client.get("/api/scoreboard/get_bar_data").json
+
+    def test_disabled_is_unweighted(self):
+        data = self._bar()
+        assert data["service_scores"] == ["200"]
+        assert data["adjusted_scores"] == ["200"]
+        assert data["weighted_scoring_enabled"] is False
+        assert "weights" not in data
+
+    def test_service_weight_scales_total(self):
+        _enable_weights(service=1.5)
+        data = self._bar()
+        # 200 service * 1.5 = 300
+        assert data["service_scores"] == ["300"]
+        assert data["adjusted_scores"] == ["300"]
+        assert data["weighted_scoring_enabled"] is True
+        assert data["weights"]["service"] == 1.5
+        # Raw (pre-weight) value is preserved for the breakdown.
+        assert data["raw_service_scores"] == ["200"]
+
+    def test_inject_weight_scales_injects(self):
+        from scoring_engine.models.inject import Inject, InjectRubricScore, RubricItem, Template
+
+        _set("inject_scores_visible", True)
+        template = Template(
+            title="T",
+            scenario="s",
+            deliverable="d",
+            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        db.session.add(template)
+        db.session.flush()
+        rubric = RubricItem(title="r", points=100, template=template)
+        db.session.add(rubric)
+        db.session.flush()
+        inject = Inject(team=self.blue, template=template)
+        inject.status = "Graded"
+        db.session.add(inject)
+        db.session.flush()
+        db.session.add(InjectRubricScore(score=100, inject=inject, rubric_item=rubric, grader=self.white_user))
+        db.session.commit()
+
+        _enable_weights(service=1.0, inject=2.0)
+        data = self._bar()
+        # service 200*1.0 + inject 100*2.0 = 400
+        assert data["inject_scores"] == ["200"]
+        assert data["adjusted_scores"] == ["400"]
+
+    def test_adjustments_are_not_weighted(self):
+        from scoring_engine.models.score_adjustment import ScoreAdjustment
+
+        db.session.add(ScoreAdjustment(team_id=self.blue.id, points=100, reason="bonus"))
+        db.session.commit()
+
+        _enable_weights(service=2.0)
+        data = self._bar()
+        # service 200*2.0 = 400, plus un-weighted adjustment 100 = 500
+        assert data["adjustments"] == ["100"]
+        assert data["adjusted_scores"] == ["500"]
+
+
+class TestWeightedFlagTotal:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, db_session):
+        self.client = test_client
+
+    def test_flag_weight_scales_red_total(self, three_teams):
+        from scoring_engine.models.flag import Flag, FlagTypeEnum, Perm, Platform, Solve
+
+        blue = three_teams["blue_team"]
+        flag = Flag(
+            type=FlagTypeEnum.file,
+            platform=Platform.nix,
+            perm=Perm.user,
+            data={"path": "/f", "content": "x"},
+            start_time=datetime.now(timezone.utc) - timedelta(hours=1),
+            end_time=datetime.now(timezone.utc) + timedelta(hours=1),
+            dummy=False,
+        )
+        db.session.add(flag)
+        db.session.commit()
+        db.session.add(Solve(host="h", team=blue, flag=flag))
+        db.session.commit()
+
+        from tests.scoring_engine.conftest import _login
+
+        _login(self.client, "whiteuser")
+
+        # Unweighted: one user flag = 100.
+        assert self.client.get("/api/flags/score").json["red_total"] == 100
+
+        # flag_weight 2.5 -> 250.
+        _enable_weights(flag=2.5)
+        assert self.client.get("/api/flags/score").json["red_total"] == 250
+
+
+class TestWeightedScoringAdminAPI:
+    @pytest.fixture(autouse=True)
+    def setup(self, white_login):
+        self.client, self.teams = white_login
+
+    def test_get_defaults(self):
+        data = self.client.get("/api/admin/weighted_scoring").json
+        assert data == {"enabled": False, "service_weight": 1.0, "inject_weight": 1.0, "flag_weight": 1.0}
+
+    def test_set_and_read_back(self):
+        resp = self.client.post(
+            "/api/admin/weighted_scoring",
+            json={"enabled": True, "service_weight": 1.5, "inject_weight": 0.5, "flag_weight": 2.0},
+        )
+        assert resp.status_code == 200
+        data = self.client.get("/api/admin/weighted_scoring").json
+        assert data["enabled"] is True
+        assert data["service_weight"] == 1.5
+        assert data["inject_weight"] == 0.5
+        assert data["flag_weight"] == 2.0
+
+    def test_rejects_negative_weight(self):
+        resp = self.client.post("/api/admin/weighted_scoring", json={"service_weight": -1})
+        assert resp.status_code == 400
+
+    def test_rejects_non_numeric_weight(self):
+        resp = self.client.post("/api/admin/weighted_scoring", json={"inject_weight": "abc"})
+        assert resp.status_code == 400
+
+    def test_requires_white_team(self):
+        self.client.get("/logout")
+        from tests.scoring_engine.conftest import _login
+
+        _login(self.client, "blueuser")
+        assert self.client.get("/api/admin/weighted_scoring").status_code == 403
+        assert self.client.post("/api/admin/weighted_scoring", json={"enabled": True}).status_code == 403

--- a/tests/scoring_engine/web/views/test_api.py
+++ b/tests/scoring_engine/web/views/test_api.py
@@ -1464,22 +1464,24 @@ class TestAPI:
         assert resp.status_code == 200
         data = resp.json
 
-        # Find Up/Down Ratio row
-        ratio_row = None
+        # Find the Services Up / Services Down rows
+        up_row = None
+        down_row = None
         for row in data["data"]:
-            if row[0] == "Up/Down Ratio":
-                ratio_row = row
-                break
+            if row[0] == "Services Up":
+                up_row = row
+            elif row[0] == "Services Down":
+                down_row = row
 
-        assert ratio_row is not None, "Up/Down Ratio row not found"
+        assert up_row is not None, "Services Up row not found"
+        assert down_row is not None, "Services Down row not found"
 
         # Find team 2's index (teams ordered by id)
         team2_idx = 2 if team1.id < team2.id else 1
 
-        # The ratio cell should show 2 up / 1 down for team 2 in round 3
-        # Format: {"up": 2, "down": 1}
-        team_ratio = ratio_row[team2_idx]
-        assert team_ratio == {"up": 2, "down": 1}, f"Expected 2 up / 1 down for team 2, got: {team_ratio}"
+        # Team 2 in round 3 should show 2 up, 1 down
+        assert up_row[team2_idx] == 2, f"Expected 2 up for team 2, got: {up_row[team2_idx]}"
+        assert down_row[team2_idx] == 1, f"Expected 1 down for team 2, got: {down_row[team2_idx]}"
 
     def test_overview_get_data_multiple_teams_all_services_correct(self):
         """Comprehensive test: multiple teams, multiple services, ID divergence.

--- a/tests/scoring_engine/web/views/test_api.py
+++ b/tests/scoring_engine/web/views/test_api.py
@@ -13,7 +13,7 @@ from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
 from scoring_engine.models.user import User
-from scoring_engine.scores import materialize_all_rounds
+from scoring_engine.scores import materialize_all_rounds, recompute_consecutive_failures_cache
 from scoring_engine.web.views.api.service import is_valid_user_input
 
 
@@ -440,6 +440,8 @@ class TestAPI:
         db.session.commit()
 
         materialize_all_rounds(db.session)
+
+        recompute_consecutive_failures_cache(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json
@@ -521,6 +523,7 @@ class TestAPI:
             )
             db.session.add_all([check1, check2, check3])
         db.session.commit()
+        recompute_consecutive_failures_cache(db.session)
 
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
@@ -751,6 +754,8 @@ class TestAPI:
         db.session.commit()
 
         materialize_all_rounds(db.session)
+
+        recompute_consecutive_failures_cache(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json
@@ -799,6 +804,8 @@ class TestAPI:
         db.session.commit()
 
         materialize_all_rounds(db.session)
+
+        recompute_consecutive_failures_cache(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json
@@ -839,6 +846,8 @@ class TestAPI:
         db.session.commit()
 
         materialize_all_rounds(db.session)
+
+        recompute_consecutive_failures_cache(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json
@@ -884,6 +893,8 @@ class TestAPI:
         db.session.commit()
 
         materialize_all_rounds(db.session)
+
+        recompute_consecutive_failures_cache(db.session)
         resp = self.client.get("/api/overview/get_data")
         assert resp.status_code == 200
         data = resp.json
@@ -1108,6 +1119,8 @@ class TestAPI:
         db.session.commit()
 
         materialize_all_rounds(db.session)
+
+        recompute_consecutive_failures_cache(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json
@@ -1186,6 +1199,8 @@ class TestAPI:
         db.session.commit()
 
         materialize_all_rounds(db.session)
+
+        recompute_consecutive_failures_cache(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json

--- a/tests/scoring_engine/web/views/test_api.py
+++ b/tests/scoring_engine/web/views/test_api.py
@@ -13,6 +13,7 @@ from scoring_engine.models.service import Service
 from scoring_engine.models.setting import Setting
 from scoring_engine.models.team import Team
 from scoring_engine.models.user import User
+from scoring_engine.scores import materialize_all_rounds
 from scoring_engine.web.views.api.service import is_valid_user_input
 
 
@@ -438,6 +439,7 @@ class TestAPI:
             db.session.add(check)
         db.session.commit()
 
+        materialize_all_rounds(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json
@@ -748,6 +750,7 @@ class TestAPI:
             db.session.add(check)
         db.session.commit()
 
+        materialize_all_rounds(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json
@@ -795,6 +798,7 @@ class TestAPI:
             db.session.add(check)
         db.session.commit()
 
+        materialize_all_rounds(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json
@@ -834,6 +838,7 @@ class TestAPI:
             db.session.add(check)
         db.session.commit()
 
+        materialize_all_rounds(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json
@@ -878,6 +883,7 @@ class TestAPI:
             db.session.add(check)
         db.session.commit()
 
+        materialize_all_rounds(db.session)
         resp = self.client.get("/api/overview/get_data")
         assert resp.status_code == 200
         data = resp.json
@@ -1101,6 +1107,7 @@ class TestAPI:
             db.session.add(check)
         db.session.commit()
 
+        materialize_all_rounds(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json
@@ -1178,6 +1185,7 @@ class TestAPI:
             db.session.add(check)
         db.session.commit()
 
+        materialize_all_rounds(db.session)
         resp = self.client.get("/api/scoreboard/get_bar_data")
         assert resp.status_code == 200
         data = resp.json


### PR DESCRIPTION
## Why this PR exists

Wave 2 was merged in #1211 — but into `feature/wave-1-hardening`, **not** master. Because #1212 (`feature/wave-1-hardening → master`) merged ~1 minute *before* #1211 landed, master took a **wave-1-only** snapshot. So both PRs show "merged," yet none of wave-2's code ever reached master. This PR propagates it.

Verified before this PR: master had alembic only through `004`, and no `scores.py` / `round_score.py` / `competition_window.py` / weighted-scoring / SLA cache.

## What lands

- **`round_score` materialized table** + `scores.py` read path (per-team/per-round scoring without full-history re-sums)
- **Competition windows + scheduling** (`schedule.py`, `CompetitionWindow`): engine idles outside configured windows; window-derived scoreboard freeze
- **Weighted scoring**: service/inject/flag weight multipliers
- **SLA perf**: batched `team_penalties`, `ix_checks_sla_scan` covering index, and a materialized `Service.consecutive_failures_cache` maintained at round close
- **Overview matrix UI** (scrollable/sticky, Up/Down split) and **line-chart downsampling** (bounded payload regardless of round count)
- `bin/generate-perf-data` perf/debug tooling
- Alembic migrations **005–010** (linear chain, single head `010`)

## Versioning

- Version stays **2.2.0** (already tagged for the wave-1 release); `coverage`/`pytz` keep master's newer pins. Merge had no code conflicts.
- Wave-2 ships in the **next tag (2.3.0)** once this is on master.

## Testing

- Full wave-2 unit + migration suite passes locally (103 passed).
- The internal `WAVE_2_DESIGN.md` planning doc was dropped from the merge (not landed on master).
