### PR TITLE
bin/setup: idempotent runs + fix SCORINGENGINE_OVERWRITE_DB case-sensitivity (rebase of #1151)

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import optparse
 import os
+import sys
 from datetime import datetime, timedelta
 from random import choice, randint, sample
 
@@ -36,18 +37,12 @@ parser.add_option(
 
 options, arguments = parser.parse_args()
 
-# In order to handle docker-compose usability
-# we have a check to see if the SCORINGENGINE_EXAMPLE environment
-# variable is true. If it is, we want to populate
-# the db with example data
-if "SCORINGENGINE_EXAMPLE" in os.environ and os.environ["SCORINGENGINE_EXAMPLE"].lower() == "true":
+if os.environ.get("SCORINGENGINE_EXAMPLE", "").lower() == "true":
     options.overwrite_db = True
     options.example = True
 
-# If the SCORINGENGINE_OVERWRITE_DB environment variable is set
-# we want to delete any previous data in the db
-if "SCORINGENGINE_OVERWRITE_DB" in os.environ and os.environ["SCORINGENGINE_OVERWRITE_DB"].lower() == "true":
-    options.overwrite_db = os.environ["SCORINGENGINE_OVERWRITE_DB"] == "true"
+if os.environ.get("SCORINGENGINE_OVERWRITE_DB", "").lower() == "true":
+    options.overwrite_db = True
 
 logger.info("Starting Setup v.{0}".format(version))
 
@@ -73,20 +68,23 @@ if not secret_key_is_configured():
 app = create_app()
 
 with app.app_context():
-    if not options.overwrite_db:
-        if verify_db_ready():
-            logger.error("Exiting script and not overwriting db...must use --overwrite-db to overwrite data.")
-            exit()
-        else:
-            # Database doesn't exist, so continuing on to setup script
-            logger.debug("Database doesn't exist yet...")
+    db_ready = verify_db_ready()
+
+    if db_ready and not options.overwrite_db:
+        logger.info("Database already initialized; skipping setup. (use --overwrite-db to reset)")
+        sys.exit(0)
 
     logger.info("Setting up DB")
-    delete_db()
+
+    if options.overwrite_db and db_ready:
+        logger.warning("Overwriting existing DB (--overwrite-db enabled)")
+        delete_db()
+
     init_db()
 
     competition_config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "competition.yaml")
-    sample_competition_str = open(competition_config_file, "r").read()
+    with open(competition_config_file, "r") as f:
+        sample_competition_str = f.read()
     competition = Competition.parse_yaml_str(sample_competition_str)
     competition.save()
 


### PR DESCRIPTION
Rebases **#1151** (by @pbayona9554) onto current `master`.

The original targets the `student-contributions` branch, which is fully merged into master and ~235 commits stale, so it can't merge as-is. This cherry-picks the author's commit onto master (authorship preserved) and resolves the one conflict (master reordered `bin/setup`'s imports since the original was written).

## What it does
- Fixes a real bug: `SCORINGENGINE_OVERWRITE_DB` was parsed case-sensitively (`os.environ[...] == "true"`), so `=True`/`=TRUE` silently set `overwrite_db` back to `False` even after the outer `.lower()` check passed. Now `os.environ.get(...).lower() == "true"` → `True`.
- Makes `bin/setup` idempotent: if the DB is already initialized and `--overwrite-db` is not set, it logs and `sys.exit(0)` instead of erroring — friendlier for docker-compose re-runs.
- Only calls `delete_db()` when actually overwriting an existing DB (no needless call on a fresh DB).
- Uses a `with open(...)` context manager for the competition YAML.

Behavior is equivalent to the old flow in every case, plus the bug fix and a clean exit-0 skip. The wave-2 `materialize_all_rounds` / `recompute_consecutive_failures_cache` calls at the end of setup are untouched. `bin/setup` compiles.

Closes #1151.
