### PR TITLE
ci: integration-test timeout + docker debug logs on failure (rebase of #1153)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,4 +46,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run integration tests
+        timeout-minutes: 25
         run: ./tests/integration/run.sh
+
+      - name: Debug docker state (on failure)
+        if: failure()
+        run: |
+          echo "=== docker ps ==="
+          docker ps -a
+          echo "=== docker compose logs (tail) ==="
+          docker compose -f docker-compose.yml -f docker/testbed/docker-compose.yml -f tests/integration/docker-compose.yml -p scoringengine logs --no-color --tail=300 || true


### PR DESCRIPTION
Rebases **#1153** (by @pbayona9554) onto current `master`.

The original targets the dead `student-contributions` branch. This cherry-picks the author's commit onto master (authorship preserved); it applied cleanly — master's integration-tests step is unchanged from the original's base.

## What it does
- Adds `timeout-minutes: 25` to the "Run integration tests" step so a hung integration run fails fast instead of burning the full job budget.
- Adds an `if: failure()` debug step that dumps `docker ps -a` and the compose logs. The compose command matches `tests/integration/run.sh` exactly (`-f docker-compose.yml -f docker/testbed/docker-compose.yml -f tests/integration/docker-compose.yml -p scoringengine`), so the logs are the right project's.

CI-only change; no product code touched.

Closes #1153.
