### PR TITLE
Add /api/admin/get_hosts endpoint (salvaged from #1082)

### DIFF
--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1097,6 +1097,23 @@ def admin_get_teams():
         return {"status": "Unauthorized"}, 403
 
 
+@mod.route("/api/admin/get_hosts")
+@login_required
+def admin_get_hosts():
+    """Distinct service hosts across all teams, sorted ascending. White team only.
+
+    Gives organizers an inventory of every host in the competition (one row per
+    unique host, deduplicated across teams) without exposing per-team scoring
+    detail. Read-only, so it is not cached the same way the scoreboard is -- the
+    host list changes only when services are added/edited.
+    """
+    if current_user.is_white_team:
+        hosts = db.session.query(Service.host).distinct().order_by(Service.host).all()
+        return jsonify(data=[{"host": host} for (host,) in hosts])
+    else:
+        return {"status": "Unauthorized"}, 403
+
+
 @mod.route("/api/admin/update_password", methods=["POST"])
 @login_required
 def admin_update_password():

--- a/tests/scoring_engine/web/views/api/test_admin_api.py
+++ b/tests/scoring_engine/web/views/api/test_admin_api.py
@@ -23,6 +23,7 @@ ADMIN_API_AUTH_PATHS = [
     pytest.param("get", "/api/admin/get_teams", id="get_teams"),
     pytest.param("post", "/api/admin/toggle_engine", id="toggle_engine"),
     pytest.param("get", "/api/admin/get_engine_paused", id="get_engine_paused"),
+    pytest.param("get", "/api/admin/get_hosts", id="get_hosts"),
 ]
 
 
@@ -56,6 +57,28 @@ class TestAdminAPI:
         resp = getattr(self.client, method)(path)
         assert resp.status_code == 302
         assert "/login?" in resp.location
+
+    def test_admin_get_hosts_requires_white_team(self):
+        """Only the white team may list hosts; blue/red get 403."""
+        self.login("blueuser")
+        resp = self.client.get("/api/admin/get_hosts")
+        assert resp.status_code == 403
+        assert resp.get_json() == {"status": "Unauthorized"}
+
+    def test_admin_get_hosts_returns_distinct_sorted_hosts(self):
+        """Hosts are deduplicated across teams and sorted ascending."""
+        db.session.add_all(
+            [
+                Service(name="Web", check_name="HTTPCheck", host="host-b", port=80, team=self.blue_team),
+                Service(name="DNS", check_name="DNSCheck", host="host-a", port=53, team=self.blue_team),
+                Service(name="SSH", check_name="SSHCheck", host="host-a", port=22, team=self.red_team),
+            ]
+        )
+        db.session.commit()
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/get_hosts")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"data": [{"host": "host-a"}, {"host": "host-b"}]}
 
     def test_admin_update_environment_requires_white_team(self):
         """Test that only white team can update environment"""


### PR DESCRIPTION
Salvages the sound, useful part of **#1082** (by @CWiendl): a white-team endpoint listing every unique service host in the competition.

## What it adds
`GET /api/admin/get_hosts` → `{"data": [{"host": ...}, ...]}` — distinct `Service.host` across all teams, sorted ascending, white-team only (`login_required` + `is_white_team`, `403` otherwise). Follows the existing `/api/admin/get_teams` convention; read-only, so uncached like the other admin GET endpoints.

## Why not the rest of #1082
#1082 also added a `Machine` model + `/api/status` + `/api/team/<id>/hosts`, but the `Machine` model was orphaned (nothing populates it), had no Alembic migration, and its `set_*` helpers called a method that doesn't exist. This PR takes only the piece that is correct and immediately useful — hosts derived from existing services.

## Tests
- `get_hosts` added to the admin auth-paths matrix (unauthenticated → 302 login)
- White-team gating (blue → 403)
- Distinct + sorted behavior across teams

Credit: original idea and implementation by @CWiendl in #1082.
