### PR TITLE
Add ungraded-inject grading queue + bulk ZIP download (from #1157)

### DIFF
--- a/scoring_engine/web/templates/admin/injects.html
+++ b/scoring_engine/web/templates/admin/injects.html
@@ -31,6 +31,22 @@
   </div>
 </div>
 
+<h3 class="section-header">Grading Queue</h3>
+<div class="chart-card" style="padding:0; overflow:hidden;">
+  <div class="d-flex justify-content-between align-items-center p-2">
+    <span class="text-muted" id="ungraded-count">Loading&hellip;</span>
+    <button id="download-ungraded" class="btn btn-sm btn-primary" type="button" disabled>
+      <i class="bi bi-download"></i> Download all as ZIP
+    </button>
+  </div>
+  <table class="table table-sm overview-matrix mb-0" id="ungradedTable" width="100%">
+    <thead>
+      <tr><th>Team</th><th>Inject</th><th>Status</th><th>Files</th><th></th></tr>
+    </thead>
+    <tbody id="ungradedBody"></tbody>
+  </table>
+</div>
+
 <h3 class="section-header">Inject Scores</h3>
 <div class="chart-card">
   <div id="teamBar" style="width: 100%; height:300px;"></div>
@@ -245,6 +261,57 @@
       ]
     });
   });
+  });
+</script>
+<script>
+  // Grading queue: a flat, cross-team list of submissions awaiting grading,
+  // plus a one-click bulk download of every ungraded file for offline grading.
+  $(document).ready(function () {
+    function esc(s) { return $('<div>').text(s == null ? '' : s).html(); }
+
+    function loadUngraded() {
+      $.getJSON('/api/admin/injects/ungraded', function (result) {
+        var rows = (result && result.data) || [];
+        $('#ungraded-count').text(
+          rows.length === 0 ? 'Nothing awaiting grading.' : rows.length + ' submission(s) awaiting grading'
+        );
+        $('#ungradedBody').html(rows.map(function (r) {
+          return '<tr>'
+            + '<td>' + esc(r.team) + '</td>'
+            + '<td>' + esc(r.title) + '</td>'
+            + '<td><span class="badge bg-warning text-dark">' + esc(r.status) + '</span></td>'
+            + '<td>' + esc(r.file_count) + '</td>'
+            + '<td><a class="btn btn-sm btn-outline-secondary" href="/admin/injects/' + encodeURIComponent(r.inject_id) + '">Grade</a></td>'
+            + '</tr>';
+        }).join(''));
+        $('#download-ungraded').prop('disabled', rows.length === 0);
+      });
+    }
+
+    loadUngraded();
+    if (window.ScoringEngineSSE) {
+      ScoringEngineSSE.on('inject_update', loadUngraded);
+    }
+
+    $('#download-ungraded').on('click', function () {
+      fetch('/api/admin/injects/download_ungraded')
+        .then(function (resp) {
+          if (resp.status === 404) { return null; }
+          if (!resp.ok) { throw new Error('Download failed'); }
+          return resp.blob();
+        })
+        .then(function (blob) {
+          if (!blob) { return; }
+          var url = URL.createObjectURL(blob);
+          var a = document.createElement('a');
+          a.href = url;
+          a.download = 'ungraded_submissions.zip';
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          URL.revokeObjectURL(url);
+        });
+    });
   });
 </script>
 {% endblock %}

--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1,17 +1,20 @@
 import html
+import io
 import json
 import os
 import re
 import time
+import zipfile
 from datetime import datetime, timezone
 
 import pytz
 from dateutil.parser import parse
-from flask import flash, jsonify, redirect, request, url_for
+from flask import flash, jsonify, redirect, request, send_file, url_for
 from flask_login import current_user, login_required
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func
+from werkzeug.utils import secure_filename
 
 from scoring_engine.cache_helper import (
     update_all_cache,
@@ -1079,6 +1082,92 @@ def admin_update_template():
                     return jsonify({"status": "Updated Property Information"})
             return jsonify({"error": "Template Not Found"})
     return jsonify({"error": "Incorrect permissions"})
+
+
+@mod.route("/api/admin/injects/ungraded")
+@login_required
+def admin_get_ungraded_injects():
+    """Flat, cross-team list of inject submissions awaiting grading. White team only.
+
+    "Awaiting grading" means status Submitted or Resubmitted (the per-template
+    submissions endpoint only shows one template at a time). Sorted by team then
+    title for a stable grading order.
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    injects = (
+        db.session.query(Inject)
+        .options(joinedload(Inject.template), joinedload(Inject.team), joinedload(Inject.files))
+        .filter(Inject.status.in_(("Submitted", "Resubmitted")))
+        .all()
+    )
+    data = [
+        {
+            "inject_id": inject.id,
+            "team": inject.team.name,
+            "title": inject.template.title,
+            "status": inject.status,
+            "file_count": len(inject.files),
+        }
+        for inject in injects
+    ]
+    data.sort(key=lambda d: (d["team"].lower(), d["title"].lower()))
+    return jsonify(data=data)
+
+
+@mod.route("/api/admin/injects/download_ungraded")
+@login_required
+def admin_download_ungraded_injects():
+    """Bundle every ungraded submission's files into one ZIP for offline grading.
+
+    Files are laid out as ``<team>/<inject title>/<original name>`` so a grader can
+    tell submissions apart at a glance; collisions inside a folder get a numeric
+    suffix. White team only. 404 when nothing is awaiting grading (empty ZIP is
+    not useful and would look like a success).
+    """
+    if not current_user.is_white_team:
+        return {"status": "Unauthorized"}, 403
+
+    injects = (
+        db.session.query(Inject)
+        .options(joinedload(Inject.template), joinedload(Inject.team), joinedload(Inject.files))
+        .filter(Inject.status.in_(("Submitted", "Resubmitted")))
+        .all()
+    )
+
+    zip_buffer = io.BytesIO()
+    files_added = 0
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        for inject in injects:
+            team_dir = secure_filename(inject.team.name) or f"team_{inject.team_id}"
+            inject_dir = secure_filename(inject.template.title) or f"inject_{inject.id}"
+            for f in inject.files:
+                # Files are stored under upload_folder/<inject id>/<team name>/<stored name>;
+                # see api_injects_file_upload.
+                src = os.path.join(config.upload_folder, str(inject.id), inject.team.name, f.filename)
+                if not os.path.exists(src):
+                    continue
+                display = secure_filename(f.original_filename or f.filename) or f.filename
+                arcname = f"{team_dir}/{inject_dir}/{display}"
+                candidate, counter = arcname, 1
+                while candidate in zip_file.namelist():
+                    root, ext = os.path.splitext(arcname)
+                    candidate = f"{root}_{counter}{ext}"
+                    counter += 1
+                zip_file.write(src, candidate)
+                files_added += 1
+
+    if files_added == 0:
+        return jsonify({"error": "No ungraded submission files found"}), 404
+
+    zip_buffer.seek(0)
+    return send_file(
+        zip_buffer,
+        mimetype="application/zip",
+        as_attachment=True,
+        download_name="ungraded_submissions.zip",
+    )
 
 
 @mod.route("/api/admin/get_teams")

--- a/tests/scoring_engine/web/views/api/test_injects_api.py
+++ b/tests/scoring_engine/web/views/api/test_injects_api.py
@@ -53,6 +53,75 @@ class TestInjectsAPI:
         defaults.update(kwargs)
         return Template(**defaults)
 
+    # --- Admin ungraded-submissions endpoints (#1157) -----------------------
+    def _inject_with_status(self, team, title, status):
+        template = self._make_template(title=title)
+        inject = Inject(team=team, template=template)
+        inject.status = status
+        db.session.add_all([template, inject])
+        db.session.commit()
+        return inject
+
+    def test_admin_ungraded_requires_white_team(self):
+        self.login("blueuser1")
+        resp = self.client.get("/api/admin/injects/ungraded")
+        assert resp.status_code == 403
+        assert resp.get_json() == {"status": "Unauthorized"}
+
+    def test_admin_ungraded_lists_only_submitted_and_resubmitted_sorted(self):
+        self._inject_with_status(self.blue_team1, "Bravo", "Submitted")
+        self._inject_with_status(self.blue_team2, "Alpha", "Resubmitted")
+        # Graded / Draft submissions must not appear.
+        self._inject_with_status(self.blue_team1, "Already graded", "Graded")
+        self._inject_with_status(self.blue_team1, "Still a draft", "Draft")
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/injects/ungraded")
+        assert resp.status_code == 200
+        rows = [(d["team"], d["title"], d["status"]) for d in resp.get_json()["data"]]
+        # Sorted by team then title; only the two awaiting grading.
+        assert rows == [
+            ("Blue Team 1", "Bravo", "Submitted"),
+            ("Blue Team 2", "Alpha", "Resubmitted"),
+        ]
+
+    def test_admin_download_ungraded_requires_white_team(self):
+        self.login("blueuser1")
+        resp = self.client.get("/api/admin/injects/download_ungraded")
+        assert resp.status_code == 403
+        assert resp.get_json() == {"status": "Unauthorized"}
+
+    def test_admin_download_ungraded_404_when_nothing_pending(self):
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/injects/download_ungraded")
+        assert resp.status_code == 404
+
+    def test_admin_download_ungraded_returns_zip(self, tmp_path, monkeypatch):
+        import zipfile
+
+        from scoring_engine.web.views.api import admin as admin_module
+
+        monkeypatch.setattr(admin_module.config, "upload_folder", str(tmp_path))
+
+        inject = self._inject_with_status(self.blue_team1, "Recon Report", "Submitted")
+        stored = f"Inject{inject.id}_blue_abcd1234_report.pdf"
+        db.session.add(InjectFile(stored, self.blue_user1, inject, original_filename="report.pdf"))
+        db.session.commit()
+
+        # Write the actual file where the endpoint expects it: <folder>/<inject id>/<team name>/<stored>.
+        dest = tmp_path / str(inject.id) / self.blue_team1.name
+        dest.mkdir(parents=True)
+        (dest / stored).write_bytes(b"PDF-CONTENT")
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/injects/download_ungraded")
+        assert resp.status_code == 200
+        assert resp.mimetype == "application/zip"
+
+        zf = zipfile.ZipFile(io.BytesIO(resp.data))
+        assert zf.namelist() == ["Blue_Team_1/Recon_Report/report.pdf"]
+        assert zf.read("Blue_Team_1/Recon_Report/report.pdf") == b"PDF-CONTENT"
+
     # Authorization Tests
     def test_api_injects_requires_auth(self):
         """Test that /api/injects requires authentication"""


### PR DESCRIPTION
Re-implements the novel parts of **#1157** (by @pbayona9554) on the current injects API.

## What it adds
- **`GET /api/admin/injects/ungraded`** — a flat, cross-team list of every submission awaiting grading (status `Submitted`/`Resubmitted`): team, title, status, file count; sorted by team then title. The existing per-template submissions endpoint only shows one template at a time.
- **`GET /api/admin/injects/download_ungraded`** — bundles all ungraded submission files into one ZIP for offline bulk grading, laid out as `<team>/<inject title>/<original filename>` (collisions get a numeric suffix). `404` when nothing is pending.
- **A "Grading Queue" card** on the admin injects page (Bootstrap 5, matching the existing DataTables/ECharts styling): the queue list with per-inject **Grade** links and a **Download all as ZIP** button. Team/title/status are HTML-escaped client-side.

Both endpoints are white-team gated (`login_required` + `is_white_team`, `403` otherwise).

## Why only these parts
#1157 also reworked the resubmit / request-revision flow, but that already exists on master (richer than the PR's version), so taking it would regress the current state-machine. This PR takes only what's genuinely new and useful: the ungraded queue view + bulk download.

## Tests
- Auth gating on both endpoints (blue → 403)
- `ungraded` returns only Submitted/Resubmitted, correctly sorted (Graded/Draft excluded)
- `download_ungraded` → real ZIP with the expected layout + content; 404 when nothing pending
- Admin injects page renders with the new card

Credit: original idea and implementation by @pbayona9554 in #1157.
