### PR TITLE
Fix: mark ungraded-download fetch() as csrf-safe (unbreaks master)

### DIFF
--- a/scoring_engine/web/templates/admin/injects.html
+++ b/scoring_engine/web/templates/admin/injects.html
@@ -294,7 +294,9 @@
     }
 
     $('#download-ungraded').on('click', function () {
-      fetch('/api/admin/injects/download_ungraded')
+      // csrf-safe: read-only GET download (the jQuery $(document).ajaxSend CSRF
+      // hook does not cover native fetch(), and a GET needs no token anyway).
+      fetch('/api/admin/injects/download_ungraded', { method: 'GET' })
         .then(function (resp) {
           if (resp.status === 404) { return null; }
           if (!resp.ok) { throw new Error('Download failed'); }


### PR DESCRIPTION
#1218 added a `fetch()` for the ungraded-submissions ZIP download. The CSRF template guard (`test_csrf.py::TestTemplatesCarryTokens::test_no_template_uses_a_request_path_the_jquery_hook_misses`) flags any `fetch()`/XHR that isn't covered by the jQuery `ajaxSend` CSRF hook or marked safe — so master's `unit-tests` job is currently failing.

This is a read-only GET (no state change, no token needed). Adds the `method: 'GET'` / `csrf-safe` marker the scanner recognizes. No behavior change — GET is fetch's default.

Verified: `TestTemplatesCarryTokens` 18/18 pass locally.