### PR TITLE
a11y: skip-to-content link + labelled main/nav landmarks (from #1149/#1159)

### DIFF
--- a/scoring_engine/web/templates/base.html
+++ b/scoring_engine/web/templates/base.html
@@ -72,6 +72,7 @@
 {% else %}
 <body class="bg-body d-flex flex-column min-vh-100{% if current_user.is_authenticated %} {% if current_user.is_white_team %}team-white{% elif current_user.is_blue_team %}team-blue{% elif current_user.is_red_team %}team-red{% endif %}{% endif %}">
 {% endif %}
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
     <script>
       // Announcements badge - global scope for child templates
       var _lastBadgeCount = -1;
@@ -167,7 +168,7 @@
     </div>
     {% endfor %}
 
-    <nav class="navbar navbar-expand-md navbar-dark">
+    <nav class="navbar navbar-expand-md navbar-dark" aria-label="Main navigation">
       <div class="container">
         <a class="navbar-brand" href="/"><span class="brand-icon">SE</span> Scoring Engine</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -270,7 +271,7 @@
         </div>
         <!--/.container-fluid -->
       </nav>
-      <main class="flex-grow-1">
+      <main id="main-content" tabindex="-1" class="flex-grow-1">
       {% block content %}
       {% endblock %}
       </main>

--- a/tests/scoring_engine/web/test_accessibility.py
+++ b/tests/scoring_engine/web/test_accessibility.py
@@ -1,0 +1,34 @@
+"""Accessibility landmarks every page inherits from base.html.
+
+A skip-to-content link and a labelled ``<main>`` landmark are keyboard and
+screen-reader essentials. They live in base.html, so a single guard here covers
+every page and stops a future base.html rewrite from silently dropping them.
+"""
+
+import pytest
+
+
+class TestAccessibilityLandmarks:
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client, db_session):
+        self.client = test_client
+
+    def _body(self, path="/scoreboard"):
+        resp = self.client.get(path)
+        assert resp.status_code == 200
+        return resp.data.decode()
+
+    def test_skip_link_targets_main_content(self):
+        body = self._body()
+        # A keyboard user's first Tab should reveal a jump to the content.
+        assert 'href="#main-content"' in body
+        assert "visually-hidden-focusable" in body
+
+    def test_main_landmark_has_the_matching_id(self):
+        body = self._body()
+        assert 'id="main-content"' in body
+
+    def test_primary_nav_is_labelled(self):
+        # Distinguishes the navigation landmark for assistive tech.
+        body = self._body()
+        assert 'aria-label="Main navigation"' in body


### PR DESCRIPTION
Re-authors the accessibility intent of **#1149 / #1159** (by @pbayona9554) for the current Bootstrap 5 templates. The original diffs were Bootstrap-3-era (`sr-only`, glyphicons) and no longer apply to master; this delivers the highest-value, lowest-risk pieces cleanly.

## What it adds (all in base.html, so every page inherits it)
- A **"Skip to main content" link** as the first focusable element (`visually-hidden-focusable`, revealed on Tab).
- **`id="main-content"` + `tabindex="-1"`** on `<main>` as the skip target.
- **`aria-label="Main navigation"`** on the primary `<nav>` landmark.

Uses Bootstrap 5's built-in `.visually-hidden-focusable` — **no CSS changes**, so none of the dark-theme regressions the original PR's global `a { color }` rule would have caused. A guard test asserts all three survive future base.html edits.

## Scope
Deliberately focused on the base-template landmarks rather than sweeping every template (where the original PRs mixed in obsolete markup and a non-a11y feature). Table `scope`/caption semantics and chart fallback tables are good follow-ups.

Credit: accessibility work originated by @pbayona9554 in #1149/#1159.
