### PR TITLE
Fix 500 in ungraded-inject endpoints on orphaned submissions

### DIFF
--- a/scoring_engine/web/views/api/admin.py
+++ b/scoring_engine/web/views/api/admin.py
@@ -1102,16 +1102,22 @@ def admin_get_ungraded_injects():
         .filter(Inject.status.in_(("Submitted", "Resubmitted")))
         .all()
     )
-    data = [
-        {
-            "inject_id": inject.id,
-            "team": inject.team.name,
-            "title": inject.template.title,
-            "status": inject.status,
-            "file_count": len(inject.files),
-        }
-        for inject in injects
-    ]
+    data = []
+    for inject in injects:
+        # Skip orphaned submissions with no team/template: they can't be attributed
+        # or graded, and dereferencing the missing relation would 500 the whole
+        # list (the scores endpoints guard the same way -- see `if inject.team`).
+        if inject.team is None or inject.template is None:
+            continue
+        data.append(
+            {
+                "inject_id": inject.id,
+                "team": inject.team.name,
+                "title": inject.template.title,
+                "status": inject.status,
+                "file_count": len(inject.files),
+            }
+        )
     data.sort(key=lambda d: (d["team"].lower(), d["title"].lower()))
     return jsonify(data=data)
 
@@ -1140,6 +1146,10 @@ def admin_download_ungraded_injects():
     files_added = 0
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
         for inject in injects:
+            # Orphaned submissions (no team/template) can't be laid out in the
+            # archive and aren't gradeable; skip them rather than 500.
+            if inject.team is None or inject.template is None:
+                continue
             team_dir = secure_filename(inject.team.name) or f"team_{inject.team_id}"
             inject_dir = secure_filename(inject.template.title) or f"inject_{inject.id}"
             for f in inject.files:

--- a/tests/scoring_engine/web/views/api/test_injects_api.py
+++ b/tests/scoring_engine/web/views/api/test_injects_api.py
@@ -122,6 +122,34 @@ class TestInjectsAPI:
         assert zf.namelist() == ["Blue_Team_1/Recon_Report/report.pdf"]
         assert zf.read("Blue_Team_1/Recon_Report/report.pdf") == b"PDF-CONTENT"
 
+    def test_admin_ungraded_skips_orphaned_injects(self):
+        # A submission whose team no longer exists (team is None) must be skipped,
+        # not 500 the whole list.
+        self._inject_with_status(self.blue_team1, "Real", "Submitted")
+        orphan = self._inject_with_status(self.blue_team1, "Orphan", "Submitted")
+        orphan.team = None
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/injects/ungraded")
+        assert resp.status_code == 200
+        assert [d["title"] for d in resp.get_json()["data"]] == ["Real"]
+
+    def test_admin_download_ungraded_skips_orphaned_injects(self, tmp_path, monkeypatch):
+        from scoring_engine.web.views.api import admin as admin_module
+
+        monkeypatch.setattr(admin_module.config, "upload_folder", str(tmp_path))
+
+        orphan = self._inject_with_status(self.blue_team1, "Orphan", "Submitted")
+        db.session.add(InjectFile("stored.pdf", self.blue_user1, orphan, original_filename="o.pdf"))
+        orphan.team = None
+        db.session.commit()
+
+        self.login("whiteuser")
+        resp = self.client.get("/api/admin/injects/download_ungraded")
+        # The only submission is orphaned and skipped, so nothing to bundle -> 404, not 500.
+        assert resp.status_code == 404
+
     # Authorization Tests
     def test_api_injects_requires_auth(self):
         """Test that /api/injects requires authentication"""


### PR DESCRIPTION
## Bug
`/api/admin/injects/ungraded` and `/api/admin/injects/download_ungraded` (added in #1218) dereference `inject.team.name` / `inject.template.title` unconditionally. A submission whose team no longer exists (`inject.team is None`) raises `AttributeError` → **HTTP 500 for the entire list**, so the admin Grading Queue card fails to load.

Found while manually testing #1218 against a 100-team stack that had 12 orphaned submissions (dangling `team_id`).

## Fix
Skip orphaned injects (no team/template) in both endpoints — they can't be attributed or graded. This matches how the existing scores endpoints already guard (`if inject.team`, admin.py:503/646).

## Tests
- `test_admin_ungraded_skips_orphaned_injects` — orphan excluded, list returns 200 not 500
- `test_admin_download_ungraded_skips_orphaned_injects` — orphan skipped, endpoint 404s (nothing to bundle) instead of 500

Verified live: on the affected stack the endpoint now returns 3 valid rows and skips 12 orphans.